### PR TITLE
Include a `baudrate` key in the firmware GBL metadata JSON

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
       extra_c_defs: "'-DEMBER_ADDRESS_TABLE_SIZE=16' '-DEMBER_MULTICAST_TABLE_SIZE=16'"
       sdk_version: 4.2.2
       metadata_fw_type: "ncp-uart-hw"
-      metadata_extra: "{ \"ezsp_version\": \"7.2.2.0\" }"
+      metadata_extra: "{ \"ezsp_version\": \"7.2.2.0\", \"baudrate\": 115200 }"
 
   rcp-multi-pan-firmware-build:
     name: RCP Multi-PAN
@@ -98,6 +98,7 @@ jobs:
       patchpath: ${{ matrix.patchpath }}
       sdk_version: 4.2.2
       metadata_fw_type: "rcp-uart-802154"
+      metadata_extra: "{ \"baudrate\": 460800 }"
 
   ot-rcp-firmware-build:
     name: OpenThread RCP
@@ -125,4 +126,4 @@ jobs:
       extra_c_defs: "'-DOPENTHREAD_CONFIG_NCP_REBOOT_BOOTLOADER_ENABLE=1'"
       sdk_version: 4.2.2
       metadata_fw_type: "ot-rcp"
-      metadata_extra: "{ \"ot_rcp_version\": \"SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455\" }"
+      metadata_extra: "{ \"ot_rcp_version\": \"SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455\", \"baudrate\": 460800 }"


### PR DESCRIPTION
This allows for the flasher's entry point to probe with both the expected firmware type and the expected baudrate before trying other combinations, speeding up startup.