### PR TITLE
Reproducible build

### DIFF
--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Patch Makefile
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          meta_datetime=$(git log -1 --format="%cd" --date=format:"%b %-d %Y %H:%M:%S")
+          LC_TIME=C meta_datetime=$(git log -1 --format="%cd" --date=format:"%b %-d %Y %H:%M:%S")
           cd ${{ inputs.firmware_name }}
           sed -i "s/^C_DEFS\s*=.*$/C_DEFS = '-DOPENTHREAD_BUILD_DATETIME=\"$meta_datetime\"' ${{ inputs.extra_c_defs }}/" \
             "${{ inputs.project_name }}.Makefile"

--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -94,10 +94,17 @@ jobs:
               patch -p1 < $patch
           done
 
+      - name: Patch Makefile
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          meta_datetime=$(git log -1 --format="%cd" --date=format:"%b %-d %Y %H:%M:%S")
+          cd ${{ inputs.firmware_name }}
+          sed -i "s/^C_DEFS\s*=.*$/C_DEFS = '-DOPENTHREAD_BUILD_DATETIME=\"$meta_datetime\"' ${{ inputs.extra_c_defs }}/" \
+            "${{ inputs.project_name }}.Makefile"
+
       - name: Build Firmware
         run: |
           cd ${{ inputs.firmware_name }}
-          sed -i "s/^C_DEFS\s*=.*$/C_DEFS = ${{ inputs.extra_c_defs }}/" "${{ inputs.project_name }}.Makefile"
           make -f ${{ inputs.project_name }}.Makefile release
       - name: Add Firmware Metadata
         run: |


### PR DESCRIPTION
RCP Builds (both MultiPan and Openthread), have a timestamp in a build version string, that causes the output binary to change each time its built even if there are no other changes to the build.

```
$ strings ot-rcp.gbl | grep EFR
SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455; EFR32; Mar 25 2023 18:24:06
```

This PR drops the timestamp from the string output.