### PR TITLE
Add the `zigbee_token_interface` component to NCP firmware

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,10 +60,11 @@ jobs:
         include:
           - target: yellow
             device: MGM210PA32JIA
-            components: simple_led:board_activity
+            components: simple_led:board_activity,zigbee_token_interface
             patchpath: "EmberZNet/Yellow"
           - target: skyconnect
             device: EFR32MG21A020F512IM32
+            components: zigbee_token_interface
             patchpath: "EmberZNet/SkyConnect"
     uses: ./.github/workflows/silabs-firmware-build.yaml
     with:


### PR DESCRIPTION
The token interface allows for the EUI64 to be written to rewriteable NV3 storage as opposed to one-time writable USERDATA.

See: https://github.com/zigpy/bellows/pull/565