### PR TITLE
Run CI on PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Silicon Labs firmware build
 
 on:
+  pull_request: ~
   push:
     paths:
       - Dockerfile


### PR DESCRIPTION
This ensures PRs actually build before being merged and allows for testing firmwares generated as artifacts.