### PR TITLE
Use absolute paths for `slc generate` to work around SLC bug

### DIFF
--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -68,7 +68,7 @@ jobs:
           slc generate \
               --with="${{ inputs.device }},${{ inputs.components }}" \
               --project-file="${{ inputs.project_file }}" \
-              --export-destination=${{ inputs.firmware_name }} \
+              --export-destination="$PWD/${{ inputs.firmware_name }}" \
               --copy-proj-sources --copy-sdk-sources --new-project --force \
               --configuration="${{ inputs.configuration }}"
 


### PR DESCRIPTION
Fixes #27.

(Currently untested)