### PR TITLE
feat: build Z-Wave controller firmware

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,11 @@ on:
       - Dockerfile
       - .github/workflows/build.yaml
       - .github/workflows/silabs-firmware-build.yaml
+      - .github/workflows/silabs-firmware-build-zwave.yaml
       - EmberZNet/**
       - OpenThreadRCP/**
       - RCPMultiPAN/**
+      - ZWave/**
     branches:
       - main
     tags:
@@ -142,3 +144,53 @@ jobs:
       metadata_fw_type: "ot-rcp"
       baudrate: 460800
       metadata_extra: "{ \"ot_rcp_version\": \"SL-OPENTHREAD/2.3.2.0_GitHub-e6df00dd6\" }"
+
+  zwave-firmware-build:
+    name: Z-Wave Serial API Controller
+    needs: build-container
+    strategy:
+      matrix:
+        include:
+          # Silicon Labs UZB-7 (SLUSB001A), +14 dBm, with SAW filters
+          # (???) Aeotec Z-Stick 7 / Z-Pi 7
+          - target: BRD4201A
+            device: EFR32ZG14P231F256GM32
+            components: brd4201a
+            compression: lz4
+            sign_key: /gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_sign.key
+            enc_key: /gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_encrypt.key
+
+          # Silicon Labs UZB-7 (SLUSB001A), +14 dBm, Z-Wave Long Range
+          - target: BRD4206A
+            device: EFR32ZG14P231F256GM32
+            components: brd4206a
+            compression: lz4
+            sign_key: /gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_sign.key
+            enc_key: /gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_encrypt.key
+
+          - target: BRD4207A
+            device: ZGM130S037HGN
+            components: brd4207a
+            compression: lz4
+            sign_key: /gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_sign.key
+            enc_key: /gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_encrypt.key
+
+    uses: ./.github/workflows/silabs-firmware-build-zwave.yaml
+    with:
+      image_name: ${{ needs.build-container.outputs.image_name }}
+      firmware_name: zwave_serial_api_controller_${{ needs.build-container.outputs.sdk_version }}_${{ matrix.target }}
+      project_file: "/gecko_sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/zwave_ncp_serial_api_controller.slcp"
+      project_name: "zwave_ncp_serial_api_controller"
+      device: ${{ matrix.device }}
+      components: ${{ matrix.components }}
+      # Fix known issue 1171840 in Z-Wave SDK
+      configuration: "ZAF_CONFIG_GENERIC_TYPE:0,ZAF_CONFIG_SPECIFIC_TYPE:0"
+      # patchpath: ${{ matrix.patchpath }}
+      sdk_version: ${{ needs.build-container.outputs.sdk_version }}
+      metadata_fw_type: "zwave"
+      # There are two "series" of chips:
+      # * Series 1 devices (EFR32xG1x, ZG[M]13) require lz4 compression
+      # * Series 2 devices (EFR32xG2x) require lzma compression
+      gbl_compression: lz4
+      gbl_sign_key: "/gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_sign.key"
+      gbl_enc_key: "/gecko_sdk/protocol/z-wave/platform/SiliconLabs/PAL/BootLoader/controller-keys/controller_encrypt.key"

--- a/.github/workflows/silabs-firmware-build-zwave.yaml
+++ b/.github/workflows/silabs-firmware-build-zwave.yaml
@@ -1,0 +1,144 @@
+name: Single firmware build
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: false
+        type: string
+        default: "ghcr.io/${{ github.repository_owner }}/silabs-firmware-builder:${{ inputs.sdk_version }}"
+      firmware_name:
+        required: true
+        type: string
+      project_file:
+        required: true
+        type: string
+      project_name:
+        required: true
+        type: string
+      device:
+        required: true
+        type: string
+      components:
+        required: false
+        type: string
+      configuration:
+        required: false
+        type: string
+      patchpath:
+        required: false
+        type: string
+      sdkpatchpath:
+        required: false
+        type: string
+      extra_c_defs:
+        required: false
+        type: string
+      sdk_version:
+        required: true
+        type: string
+      metadata_fw_type:
+        required: true
+        type: string
+      metadata_extra:
+        required: false
+        default: "null"
+        type: string
+      gbl_compression:
+        required: true
+        type: string
+      gbl_sign_key:
+        required: false
+        type: string
+      gbl_enc_key:
+        required: false
+        type: string
+      
+jobs:
+  firmware-build:
+    name: Build firmware
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.image_name }}
+      options: --user root
+    defaults:
+      run:
+        shell: su --shell=/bin/bash builder {0}
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Adjust permission
+        shell: bash
+        run: chown builder .
+      - name: Generate Firmware Project
+        run: |
+          slc generate \
+              --with="${{ inputs.device }},${{ inputs.components }}" \
+              --project-file="${{ inputs.project_file }}" \
+              --output-type="makefile" \
+              --export-destination="$PWD/${{ inputs.firmware_name }}" \
+              --copy-proj-sources --copy-sdk-sources --new-project --force \
+              --configuration="${{ inputs.configuration }}"
+
+      - name: Patch Firmware
+        if: "${{ inputs.patchpath != '' }}"
+        run: |
+          cd ${{ inputs.firmware_name }}
+          for patch in "../${{ inputs.patchpath }}"/*.patch
+          do
+              echo "Applying ${patch}"
+              patch -p1 < $patch
+          done
+
+      - name: Patch SDK
+        if: "${{ inputs.sdkpatchpath != '' }}"
+        run: |
+          cd ${{ inputs.firmware_name }}/gecko_sdk_${{ inputs.sdk_version }}
+          for patch in "../../${{ inputs.sdkpatchpath }}"/*.patch
+          do
+              echo "Applying ${patch}"
+              patch -p1 < $patch
+          done
+
+      - name: Patch Makefile
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          cd ${{ inputs.firmware_name }}
+          echo "POST_BUILD_EXE = $PWD/${{ inputs.firmware_name }}/postbuild.sh"
+          sed -i "s/^C_DEFS\s*=.*$/C_DEFS = ${{ inputs.extra_c_defs }}/" \
+            "${{ inputs.project_name }}.Makefile"
+          sed -i 's#^POST_BUILD_EXE_LINUX = .*$#POST_BUILD_EXE_LINUX = true#' \
+            "${{ inputs.project_name }}.Makefile"
+
+      - name: Build Firmware
+        run: |
+          cd ${{ inputs.firmware_name }}
+          make -f ${{ inputs.project_name }}.Makefile release
+      - name: Add Firmware Metadata
+        run: |
+          cd ${{ inputs.firmware_name }}
+          jq --null-input \
+             '{
+                "metadata_version": 1,
+                "sdk_version": "${{ inputs.sdk_version }}",
+                "fw_type": "${{ inputs.metadata_fw_type }}"
+              } + ${{ inputs.metadata_extra }}' >  version.json
+
+      - name: Generate gbl Firmware
+        run: |
+          cd ${{ inputs.firmware_name }}
+          if [ -n "${{ inputs.gbl_sign_key }}" ] ; then
+            SIGN_KEY="--sign ${{ inputs.gbl_sign_key }}"
+          fi
+          if [ -n "${{ inputs.gbl_enc_key }}" ] ; then
+            ENC_KEY="--encrypt ${{ inputs.gbl_enc_key }}"
+          fi
+          commander gbl create build/release/${{ inputs.firmware_name }}.gbl \
+                    --app build/release/${{ inputs.project_name }}.hex \
+                    $SIGN_KEY $ENC_KEY \
+                    --compress ${{ inputs.gbl_compression }}
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: ${{ inputs.firmware_name }}
+          path: ${{ inputs.firmware_name }}/build/release/${{ inputs.firmware_name }}.gbl


### PR DESCRIPTION
Adds support for building Z-Wave controller firmware. I tested that BRD4201A and BRD4206A both work on my Aeotec Z-Stick 7 with unlocked bootloader, and I tested that the BRD4201A works on my UZB-7 that still checks encryption/signature.

This may be interesting if we decide to build custom firmware in the future, but for the short term to get around this known issue:
![grafik](https://github.com/NabuCasa/silabs-firmware-builder/assets/17641229/a31ec844-b272-4199-9978-b44f6f8c9bdb)
