### PR TITLE
Fix channel switching patch paths to work inside builder

### DIFF
--- a/RCPMultiPAN/SkyConnect/0003-disable-fast-channel-switching.patch
+++ b/RCPMultiPAN/SkyConnect/0003-disable-fast-channel-switching.patch
@@ -4,14 +4,14 @@ Date: Fri, 8 Dec 2023 19:14:32 -0500
 Subject: [PATCH] Disable fast channel switching
 
 ---
- .../sl_rail_util_ieee802154_fast_channel_switching_config.h     | 2 +-
- protocol/openthread/platform-abstraction/efr32/radio.c          | 2 +-
+ config/sl_rail_util_ieee802154_fast_channel_switching_config.h  | 2 +-
+ .../protocol/openthread/platform-abstraction/efr32/radio.c      | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h b/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
-index a44700695..36373d7fc 100644
---- a/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
-+++ b/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
+diff --git a/config/sl_rail_util_ieee802154_fast_channel_switching_config.h b/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
+index a447006..36373d7 100644
+--- a/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
++++ b/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
 @@ -43,7 +43,7 @@
  // <h> IEEE802.15.4 Fast Channel Switching Configuration
  // <q SL_RAIL_UTIL_IEEE802154_FAST_CHANNEL_SWITCHING_ENABLED> Enable fast channel switching
@@ -21,10 +21,10 @@ index a44700695..36373d7fc 100644
  // </h>
  // <<< end of configuration section >>>
  #endif //SL_RAIL_UITL_IEEE802154_FAST_CHANNEL_SWITCHING_CONFIG_H
-diff --git a/protocol/openthread/platform-abstraction/efr32/radio.c b/protocol/openthread/platform-abstraction/efr32/radio.c
-index 04ecef2ae..a2b899d91 100644
---- a/protocol/openthread/platform-abstraction/efr32/radio.c
-+++ b/protocol/openthread/platform-abstraction/efr32/radio.c
+diff --git a/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c b/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c
+index 04ecef2..a2b899d 100644
+--- a/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c
++++ b/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c
 @@ -321,7 +321,7 @@ static bool isMultiChannel(void)
              {
                  firstChannel = sChannelSwitchingCfg.channels[i];
@@ -34,6 +34,5 @@ index 04ecef2ae..a2b899d91 100644
              {
                  return true;
              }
--- 
-2.43.0
-
+--
+2.39.2

--- a/RCPMultiPAN/Yellow/0003-disable-fast-channel-switching.patch
+++ b/RCPMultiPAN/Yellow/0003-disable-fast-channel-switching.patch
@@ -4,14 +4,14 @@ Date: Fri, 8 Dec 2023 19:14:32 -0500
 Subject: [PATCH] Disable fast channel switching
 
 ---
- .../sl_rail_util_ieee802154_fast_channel_switching_config.h     | 2 +-
- protocol/openthread/platform-abstraction/efr32/radio.c          | 2 +-
+ config/sl_rail_util_ieee802154_fast_channel_switching_config.h  | 2 +-
+ .../protocol/openthread/platform-abstraction/efr32/radio.c      | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h b/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
-index a44700695..36373d7fc 100644
---- a/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
-+++ b/platform/radio/rail_lib/plugin/rail_util_ieee802154/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
+diff --git a/config/sl_rail_util_ieee802154_fast_channel_switching_config.h b/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
+index a447006..36373d7 100644
+--- a/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
++++ b/config/sl_rail_util_ieee802154_fast_channel_switching_config.h
 @@ -43,7 +43,7 @@
  // <h> IEEE802.15.4 Fast Channel Switching Configuration
  // <q SL_RAIL_UTIL_IEEE802154_FAST_CHANNEL_SWITCHING_ENABLED> Enable fast channel switching
@@ -21,10 +21,10 @@ index a44700695..36373d7fc 100644
  // </h>
  // <<< end of configuration section >>>
  #endif //SL_RAIL_UITL_IEEE802154_FAST_CHANNEL_SWITCHING_CONFIG_H
-diff --git a/protocol/openthread/platform-abstraction/efr32/radio.c b/protocol/openthread/platform-abstraction/efr32/radio.c
-index 04ecef2ae..a2b899d91 100644
---- a/protocol/openthread/platform-abstraction/efr32/radio.c
-+++ b/protocol/openthread/platform-abstraction/efr32/radio.c
+diff --git a/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c b/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c
+index 04ecef2..a2b899d 100644
+--- a/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c
++++ b/gecko_sdk_4.3.2/protocol/openthread/platform-abstraction/efr32/radio.c
 @@ -321,7 +321,7 @@ static bool isMultiChannel(void)
              {
                  firstChannel = sChannelSwitchingCfg.channels[i];
@@ -34,6 +34,5 @@ index 04ecef2ae..a2b899d91 100644
              {
                  return true;
              }
--- 
-2.43.0
-
+--
+2.39.2


### PR DESCRIPTION
#36 does not actually build, as the SDK and config paths differ inside the builder.