### PR TITLE
Support act for local building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1
       - name: Build and Push
-        uses: docker/build-push-action@v3.3.0
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -139,4 +139,4 @@ jobs:
         if: success() || failure()
         with:
           name: ${{ inputs.firmware_name }}
-          path: ${{ inputs.firmware_name }}
+          path: ${{ inputs.firmware_name }}/build/release/*.*

--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -128,6 +128,13 @@ jobs:
                     --app build/release/${{ inputs.project_name }}.out \
                     --device ${{ inputs.device }} --metadata version.json
 
+      - name: Install node within container (act)
+        if: ${{ env.ACT }}
+        shell: bash
+        run: |
+            curl -fsSL https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s 20
+            apt-get install -y nodejs
+
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:


### PR DESCRIPTION
These are some minor changes to get the builder working locally with [act](https://github.com/nektos/act). I'm using it to build multi-PAN firmwares and it creates the firmware builder image, uploads it (if it's not cached), compiles, and creates artifacts in a local folder.

I've also stripped down the released artifacts to just the output binaries, as we currently include the whole build tree.

```console
$ mkdir artifacts
$ act --job rcp-multi-pan-firmware-build -s GITHUB_TOKEN=ghp_tokentokentokentokentokentokentoken --artifact-server-path artifacts
...
$ gunzip -S .gz__ -r artifacts
$ find artifacts -type f
artifacts/1/rcp-uart-802154-yellow/rcp-uart-802154.out
artifacts/1/rcp-uart-802154-yellow/rcp-uart-802154.s37
artifacts/1/rcp-uart-802154-yellow/rcp-uart-802154.map
artifacts/1/rcp-uart-802154-yellow/rcp-uart-802154.hex
artifacts/1/rcp-uart-802154-yellow/rcp-uart-802154.bin
artifacts/1/rcp-uart-802154-yellow/rcp-uart-802154.gbl
artifacts/1/rcp-uart-802154-skyconnect/rcp-uart-802154.out
artifacts/1/rcp-uart-802154-skyconnect/rcp-uart-802154.s37
artifacts/1/rcp-uart-802154-skyconnect/rcp-uart-802154.map
artifacts/1/rcp-uart-802154-skyconnect/rcp-uart-802154.hex
artifacts/1/rcp-uart-802154-skyconnect/rcp-uart-802154.gbl
artifacts/1/rcp-uart-802154-skyconnect/rcp-uart-802154.bin
```