### PR TITLE
Disable ZGP on multi-PAN

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,6 +97,7 @@ jobs:
           - target: yellow
             device: MGM210PA32JIA
             components: simple_led:board_activity,cpc_security_secondary_none,zigbee_mfglib
+            without_components: ot_rcp_gp_interface
             patchpath: "RCPMultiPAN/Yellow"
             slcp_yaml_changes: >
               . += {"sdk_extension": [{"id": "nc_efr32_watchdog", version: "1.0.0"}]}
@@ -104,6 +105,7 @@ jobs:
           - target: skyconnect
             device: EFR32MG21A020F512IM32
             components: cpc_security_secondary_none,zigbee_mfglib
+            without_components: ot_rcp_gp_interface
             patchpath: "RCPMultiPAN/SkyConnect"
             slcp_yaml_changes: >
               . += {"sdk_extension": [{"id": "nc_efr32_watchdog", version: "1.0.0"}]}
@@ -116,6 +118,7 @@ jobs:
       project_name: "rcp-uart-802154"
       device: ${{ matrix.device }}
       components: ${{ matrix.components }}
+      without_components: ${{ matrix.without_components }}
       patchpath: ${{ matrix.patchpath }}
       slcp_yaml_changes: ${{ matrix.slcp_yaml_changes }}
       sdk_version: ${{ needs.build-container.outputs.sdk_version }}

--- a/.github/workflows/silabs-firmware-build.yaml
+++ b/.github/workflows/silabs-firmware-build.yaml
@@ -25,6 +25,9 @@ on:
       components:
         required: false
         type: string
+      without_components:
+        required: false
+        type: string
       configuration:
         required: false
         type: string
@@ -83,6 +86,7 @@ jobs:
         run: |
           slc generate \
               --with="${{ inputs.device }},${{ inputs.components }}" \
+              --without="${{ inputs.without_components }}" \
               --project-file="${{ inputs.project_file }}" \
               --export-destination="$PWD/${{ inputs.firmware_name }}" \
               --copy-proj-sources --copy-sdk-sources --new-project --force \


### PR DESCRIPTION
All known multi-PAN crashes are currently due to the ZGP patchset for OpenThread. With increased Thread traffic, these crashes occur nearly hourly.

Silicon Labs is investigating this issue and will probably fix it in the next GSDK release. Until then, we should disable Zigbee Green Power.