### PR TITLE
Fix Git repo permissions during CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,10 +104,11 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
-          limit-access-to-actor: true 
+          limit-access-to-actor: true
 
       - name: Build firmware
         run: |
+          # Make a small change so that it re-runs CI?
           # Pass all SDKs as consecutive `--sdk ...` arguments
           sdk_args=""
           for sdk_dir in /gecko_sdk*; do

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
-          limit-access-to-actor: true
+          limit-access-to-actor: true 
 
       - name: Build firmware
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,14 +2,6 @@ name: Build firmwares
 
 on:
   push:
-    paths:
-      - Dockerfile
-      - .github/workflows/build.yaml
-      - manifests/**/*.yaml
-    branches:
-      - main
-    tags:
-      - '*'
 
 jobs:
   build-container:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,6 +101,11 @@ jobs:
             done
           done
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+
       - name: Build firmware
         run: |
           # Pass all SDKs as consecutive `--sdk ...` arguments

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,14 +96,11 @@ jobs:
             done
           done
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
-
       - name: Build firmware
         run: |
-          # Make a small change so that it re-runs CI?
+          # Fix `fatal: detected dubious ownership in repository at`
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
           # Pass all SDKs as consecutive `--sdk ...` arguments
           sdk_args=""
           for sdk_dir in /gecko_sdk*; do

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ name: Build firmwares
 on:
   push:
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   build-container:
     name: Create build container image
@@ -15,7 +18,7 @@ jobs:
         id: create-container-name
         run: |
           repository_owner=$(echo $GITHUB_REPOSITORY_OWNER | tr [:upper:] [:lower:])
-          image_name="ghcr.io/$repository_owner/silabs-firmware-builder"
+          image_name="${{ env.REGISTRY }}/$repository_owner/silabs-firmware-builder"
           tag_name="${{ hashFiles('Dockerfile') }}"
 
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
@@ -24,7 +27,7 @@ jobs:
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v2.1.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4.1
+      - uses: actions/checkout@v4.1.4
       - name: Create container name
         id: create-container-name
         run: |
@@ -48,7 +48,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4.1
+      - uses: actions/checkout@v4.1.4
       - id: set-matrix
         run: |
           echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4.1
+      - uses: actions/checkout@v4.1.4
 
       - name: Parse firmware manifest
         id: read_manifest_yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4.1
+      - uses: actions/checkout@v3.3.0
       - name: Create container name
         id: create-container-name
         run: |
@@ -51,7 +51,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4.1
+      - uses: actions/checkout@v3.3.0
       - id: set-matrix
         run: |
           echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -67,7 +67,7 @@ jobs:
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4.1
+      - uses: actions/checkout@v3.3.0
 
       - name: Parse firmware manifest
         id: read_manifest_yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1
       - name: Create container name
         id: create-container-name
         run: |
@@ -48,7 +48,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1
       - id: set-matrix
         run: |
           echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1
 
       - name: Parse firmware manifest
         id: read_manifest_yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1
       - name: Create container name
         id: create-container-name
         run: |
@@ -51,7 +51,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1
       - id: set-matrix
         run: |
           echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -67,7 +67,7 @@ jobs:
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1
 
       - name: Parse firmware manifest
         id: read_manifest_yaml


### PR DESCRIPTION
#41 does not run without `git config --global --add safe.directory "$GITHUB_WORKSPACE"`.

Tested in my fork, all artifacts are generated properly: https://github.com/puddly/silabs-firmware-builder/actions/runs/8902112353#artifacts