### PR TITLE
Bump all CI action versions to remove deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.4
       - name: Create container name
         id: create-container-name
         run: |
@@ -25,15 +25,15 @@ jobs:
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
           echo "container_name=$image_name:$tag_name" >> $GITHUB_OUTPUT
       - name: Log in to the GitHub container registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Build and Push
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.3.0
         with:
           context: .
           file: Dockerfile
@@ -51,7 +51,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.4
       - id: set-matrix
         run: |
           echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -67,7 +67,7 @@ jobs:
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.4
 
       - name: Parse firmware manifest
         id: read_manifest_yaml
@@ -134,7 +134,9 @@ jobs:
           apt-get install -y nodejs
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: ${{ steps.read_manifest_yaml.outputs['manifest_base'] }}
           path: outputs/*
+          compression-level: 9
+          if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,14 @@ name: Build firmwares
 
 on:
   push:
+    paths:
+      - Dockerfile
+      - .github/workflows/build.yaml
+      - manifests/**/*.yaml
+    branches:
+      - main
+    tags:
+      - '*'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
As before, tested in my fork: https://github.com/puddly/silabs-firmware-builder/actions/runs/8909074864