### PR TITLE
Allow PRs to build images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
             head_image=$(echo ${{ github.repository }} | awk '{print tolower($0)}')
           fi
 
-          tag_name="${{ hashFiles('Dockerfile') }}"
+          tag_name=$(echo "${{ hashFiles('Dockerfile') }}" | cut -c-16)
 
           # Default to building a new container under the original repo
           image_name=$head_image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,35 +8,8 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  get-build-container-names:
-    name: Get the possible build containers
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.4
-      - name: Create container name
-        id: create-container-name
-        run: |
-          current_user=$(echo $GITHUB_REPOSITORY_OWNER | tr [:upper:] [:lower:])
-          current_repo=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])
-          current_image_name="${{ env.REGISTRY }}/$current_user/$current_repo"
-
-          tag_name="${{ hashFiles('Dockerfile') }}"
-
-          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-          echo "image_name=$current_image_name" >> $GITHUB_OUTPUT
-    outputs:
-      tag_name: ${{ steps.create-container-name.outputs.tag_name }}
-      image_name: ${{ steps.create-container-name.outputs.image_name }}
-      container_name: ${{ steps.create-container-name.outputs.image_name }}:${{ steps.create-container-name.outputs.tag_name }}
-
-  maybe-build-container:
+  build-container:
     name: Create build container image
-    needs: [get-build-container-names]
-    if: >-
-      (github.event_name != 'pull_request') ||
-      (github.event.pull_request.author_association == 'COLLABORATOR') ||
-      (github.event.pull_request.author_association == 'MEMBER') ||
-      (github.event.pull_request.author_association == 'OWNER')
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -48,28 +21,51 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create container name
+        id: create-container-info
+        run: |
+          base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | tr [:upper:] [:lower:])
+          head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | tr [:upper:] [:lower:])
+          tag_name="${{ hashFiles('Dockerfile') }}"
+
+          # Default to building a new container under the original repo
+          image_name=$head_image
+          build=true
+
+          # Check if we can use the base image (Nabu Casa)
+          if docker manifest inspect ${{ env.REGISTRY }}/$base_image:$tag_name; then
+            image_name=$base_image
+            build=false
+          fi
+
+          # Check if we can use the head image (PR)
+          if docker manifest inspect ${{ env.REGISTRY }}/$head_image:$tag_name; then
+            image_name=$head_image
+            build=false
+          fi
+
+          echo "build=$build" >> $GITHUB_OUTPUT
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
+          echo "container_name=$image_name:$tag_name" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
+        if: steps.create-container-info.outputs.build == 'true'
       - name: Build and Push
         uses: docker/build-push-action@v5.3.0
+        if: steps.create-container-info.outputs.build == 'true'
         with:
           context: .
           file: Dockerfile
-          tags: ${{ needs.get-build-container-names.outputs.container_name }}
-          cache-from: ${{ needs.get-build-container-names.outputs.image_name }}:cache-${{ needs.get-build-container-names.outputs.tag_name }}
-          cache-to: ${{ needs.get-build-container-names.outputs.image_name }}:cache-${{ needs.get-build-container-names.outputs.tag_name }}
-          push: ${{ github.event_name == 'push' }}
-
-  get-build-container:
-    name: Get the image name of the build container to use
-    needs: [maybe-build-container, get-build-container-names]
-    if: always()  # If `maybe-build-container` runs, we should run after it
-    runs-on: ubuntu-latest
-    steps:
-      - id: noop
-        run: echo "noop"
+          tags: ${{ steps.create-container-info.outputs.tag_name }}
+          cache-from: ${{ steps.create-container-info.outputs.image_name }}:cache-${{ steps.create-container-info.outputs.tag_name }}
+          cache-to: ${{ steps.create-container-info.outputs.image_name }}:cache-${{ steps.create-container-info.outputs.tag_name }}
+          push: true
     outputs:
-      container_name: ${{ needs.get-build-container-names.outputs.container_name }}
+      tag_name: ${{ steps.create-container-info.outputs.tag_name }}
+      image_name: ${{ steps.create-container-info.outputs.image_name }}
+      container_name: ${{ steps.create-container-info.outputs.container_name }}
+
 
   list-manifests:
     name: List firmware manifests
@@ -84,10 +80,10 @@ jobs:
 
   build-firmwares:
     name: Firmware builder
-    needs: [list-manifests, get-build-container]
+    needs: [list-manifests, build-container]
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.get-build-container.outputs.container_name }}
+      image: ${{ env.REGISTRY }}/${{ needs.build-container.outputs.container_name }}
       options: --user root
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,61 +28,31 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create container name
         id: create-container-info
-        shell: python -u {0}
         run: |
-          import os
-          import json
-          import pathlib
-          import subprocess
-          import urllib.request
+          base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | tr [:upper:] [:lower:])
+          head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | tr [:upper:] [:lower:])
+          tag_name="${{ hashFiles('Dockerfile') }}"
 
-          GITHUB_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
-          TAG_NAME = "${{ hashFiles('Dockerfile') }}"
+          # Default to building a new container under the original repo
+          image_name=$head_image
+          build=true
 
+          # Check if we can use the base image (Nabu Casa)
+          if docker manifest inspect ${{ env.REGISTRY }}/$base_image:$tag_name; then
+            image_name=$base_image
+            build=false
+          fi
 
-          req = urllib.request.Request(
-              url=f"https://api.github.com/repos/{os.environ['REPOSITORY']}",
-              headers={
-                  "Authorization": "token ${{ secrets.GITHUB_TOKEN }}",
-                  "Accept": "application/vnd.github.v3+json",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              }
-          )
+          # Check if we can use the head image (PR)
+          if docker manifest inspect ${{ env.REGISTRY }}/$head_image:$tag_name; then
+            image_name=$head_image
+            build=false
+          fi
 
-          with urllib.request.urlopen(req) as response:
-              assert response.status == 200
-              data = json.loads(response.read().decode())
-
-          head_image = data["full_name"].lower()
-
-          if data["parent"]:
-              base_image = data["parent"]["full_name"].lower()
-          else:
-              base_image = head_image
-
-          image_name = head_image
-          build = True
-
-          for image in {base_image, head_image}:
-              try:
-                  subprocess.run([
-                      "docker", "manifest", "inspect",
-                      f"{os.environ['REGISTRY']}/{image}:{TAG_NAME}"
-                  ], check=True)
-              except subprocess.CalledProcessError:
-                  continue
-              else:
-                  image_name = image
-                  build = False
-                  break
-
-          with GITHUB_OUTPUT.open("a") as f:
-              f.writelines([
-                  f"build={build}\n",
-                  f"tag_name={TAG_NAME}\n",
-                  f"image_name={image_name}\n",
-                  f"container_name={os.environ['REGISTRY']}/{image_name}:{TAG_NAME}\n",
-              ])
+          echo "build=$build" >> $GITHUB_OUTPUT
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
+          echo "container_name=${{ env.REGISTRY }}/$image_name:$tag_name" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
         if: steps.create-container-info.outputs.build == 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.3.0
         if: steps.read-repo-info.outputs.build_image == 'true'
       - name: Build and Push
-        uses: docker/build_image-push-action@v5.3.0
+        uses: docker/build-push-action@v5.3.0
         if: steps.read-repo-info.outputs.build_image == 'true'
         with:
           context: .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       packages: write
     steps:
+      - uses: actions/checkout@v4.1.4
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v3.1.0
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,8 +29,8 @@ jobs:
         id: read-repo-info-pr
         if: steps.get-current-pr.outputs.pr_found == 'true'
         run: |
-          base_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).base.repo.full_name }} | tr [:upper:] [:lower:]))
-          head_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).head.repo.full_name }} | tr [:upper:] [:lower:]))
+          base_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).base.repo.full_name }} | tr [:upper:] [:lower:])
+          head_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).head.repo.full_name }} | tr [:upper:] [:lower:])
           echo "base_image=$base_image" >> $GITHUB_OUTPUT
           echo "head_image=$base_image" >> $GITHUB_OUTPUT
       - name: Read repository information (no PR)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,12 +26,27 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create container name
-        id: create-container-info
+      - name: Read repository information (push)
+        id: read-repo-info
+        if: github.event_name != 'pull_request'
+        run: |
+          base_image=$(echo ${{ github.repository }} | tr [:upper:] [:lower:])
+          echo "base_image=$base_image" >> $GITHUB_OUTPUT
+          echo "head_image=$base_image" >> $GITHUB_OUTPUT
+      - name: Read repository information (pull request)
+        id: read-repo-info-pr
+        if: github.event_name == 'pull_request'
         run: |
           base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | tr [:upper:] [:lower:])
           head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | tr [:upper:] [:lower:])
-          tag_name="${{ hashFiles('Dockerfile') }}"
+
+          echo "base_image=$base_image" >> $GITHUB_OUTPUT
+          echo "head_image=$head_image" >> $GITHUB_OUTPUT
+      - name: Create container info
+        id: create-container-info
+        run: |
+          base_image=${{ steps.read-repo-info.outputs.base_image || steps.read-repo-info-pr.outputs.base_image }}
+          head_image=${{ steps.read-repo-info.outputs.head_image || steps.read-repo-info-pr.outputs.head_image }}
 
           # Default to building a new container under the original repo
           image_name=$head_image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,11 @@ jobs:
             fi
           fi
 
+          if [[ $build_image == "true" && $GITHUB_EVENT_NAME == "pull_request" ]]; then
+            echo "Cannot build a new container within a PR. Please re-run this action after $head_image:$tag_name is built."
+            exit 1
+          fi
+
           echo "build_image=$build_image" >> $GITHUB_OUTPUT
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
           echo "image_name=$image_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,6 @@
 name: Build firmwares
 
 on:
-  pull_request:
-    paths-ignore:
-      - '.gitignore'
-      - 'README.md'
   push:
     paths-ignore:
       - '.gitignore'
@@ -26,22 +22,24 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Read repository information (push)
+      - name: Get current PR
+        id: get-current-pr
+        uses: 8BitJonny/gh-get-current-pr@3.0.0
+      - name: Read repository information (PR)
+        id: read-repo-info-pr
+        if: steps.get-current-pr.outputs.pr_found == 'true'
+        run: |
+          base_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).base.repo.full_name }} | tr [:upper:] [:lower:]))
+          head_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).head.repo.full_name }} | tr [:upper:] [:lower:]))
+          echo "base_image=$base_image" >> $GITHUB_OUTPUT
+          echo "head_image=$base_image" >> $GITHUB_OUTPUT
+      - name: Read repository information (no PR)
         id: read-repo-info
-        if: github.event_name != 'pull_request'
+        if: steps.get-current-pr.outputs.pr_found == 'false'
         run: |
           base_image=$(echo ${{ github.repository }} | tr [:upper:] [:lower:])
           echo "base_image=$base_image" >> $GITHUB_OUTPUT
           echo "head_image=$base_image" >> $GITHUB_OUTPUT
-      - name: Read repository information (pull request)
-        id: read-repo-info-pr
-        if: github.event_name == 'pull_request'
-        run: |
-          base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | tr [:upper:] [:lower:])
-          head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | tr [:upper:] [:lower:])
-
-          echo "base_image=$base_image" >> $GITHUB_OUTPUT
-          echo "head_image=$head_image" >> $GITHUB_OUTPUT
       - name: Create container info
         id: create-container-info
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,9 @@ jobs:
     needs: [maybe-build-container, get-build-container-names]
     if: always()  # If `maybe-build-container` runs, we should run after it
     runs-on: ubuntu-latest
+    steps:
+      - id: noop
+        run: echo "noop"
     outputs:
       container_name: ${{ needs.get-build-container-names.outputs.container_name }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,10 @@
 name: Build firmwares
 
 on:
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'README.md'
   push:
     paths-ignore:
       - '.gitignore'
@@ -22,29 +26,17 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get current PR
-        id: get-current-pr
-        uses: 8BitJonny/gh-get-current-pr@3.0.0
-      - name: Read repository information (PR)
-        id: read-repo-info-pr
-        if: steps.get-current-pr.outputs.pr_found == 'true'
-        run: |
-          base_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).base.repo.full_name }} | tr [:upper:] [:lower:])
-          head_image=$(echo ${{ fromJSON(steps.get-current-pr.outputs.pr).head.repo.full_name }} | tr [:upper:] [:lower:])
-          echo "base_image=$base_image" >> $GITHUB_OUTPUT
-          echo "head_image=$base_image" >> $GITHUB_OUTPUT
-      - name: Read repository information (no PR)
+      - name: Read repository information
         id: read-repo-info
-        if: steps.get-current-pr.outputs.pr_found == 'false'
         run: |
-          base_image=$(echo ${{ github.repository }} | tr [:upper:] [:lower:])
-          echo "base_image=$base_image" >> $GITHUB_OUTPUT
-          echo "head_image=$base_image" >> $GITHUB_OUTPUT
-      - name: Create container info
-        id: create-container-info
-        run: |
-          base_image="${{ steps.read-repo-info.outputs.base_image || steps.read-repo-info-pr.outputs.base_image }}"
-          head_image="${{ steps.read-repo-info.outputs.head_image || steps.read-repo-info-pr.outputs.head_image }}"
+          if $GITHUB_EVENT_NAME == 'pull_request'; then
+            base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | awk '{print tolower($0)}')
+            head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | awk '{print tolower($0)}')
+          else
+            base_image=$(echo ${{ github.repository }} | awk '{print tolower($0)}')
+            head_image=$(echo ${{ github.repository }} | awk '{print tolower($0)}')
+          fi
+
           tag_name="${{ hashFiles('Dockerfile') }}"
 
           # Default to building a new container under the original repo
@@ -57,10 +49,12 @@ jobs:
             build=false
           fi
 
-          # Check if we can use the head image (PR)
-          if docker manifest inspect ${{ env.REGISTRY }}/$head_image:$tag_name; then
-            image_name=$head_image
-            build=false
+          # Check if we can use the head image (if this is a PR)
+          if [[ $base_image != $head_image ]]; then
+            if docker manifest inspect ${{ env.REGISTRY }}/$head_image:$tag_name; then
+              image_name=$head_image
+              build=false
+            fi
           fi
 
           echo "build=$build" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,8 +26,8 @@ jobs:
           echo "image_name=$current_image_name" >> $GITHUB_OUTPUT
     outputs:
       tag_name: ${{ steps.create-container-name.outputs.tag_name }}
-      image_name: ${{ steps.create-container-name.outputs.current_image_name }}
-      container_name: ${{ steps.create-container-name.outputs.current_image_name }}:${{ steps.create-container-name.outputs.tag_name }}
+      image_name: ${{ steps.create-container-name.outputs.image_name }}
+      container_name: ${{ steps.create-container-name.outputs.image_name }}:${{ steps.create-container-name.outputs.tag_name }}
 
   maybe-build-container:
     name: Create build container image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,14 +3,6 @@ name: Build firmwares
 on:
   pull_request:
   push:
-    paths:
-      - Dockerfile
-      - .github/workflows/build.yaml
-      - manifests/**/*.yaml
-    branches:
-      - main
-    tags:
-      - '*'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
           tags: ${{ needs.get-build-container-names.outputs.container_name }}
           cache-from: ${{ needs.get-build-container-names.outputs.image_name }}:cache-${{ needs.get-build-container-names.outputs.tag_name }}
           cache-to: ${{ needs.get-build-container-names.outputs.image_name }}:cache-${{ needs.get-build-container-names.outputs.tag_name }}
-          push: true
+          push: ${{ github.event_name == 'push' }}
 
   get-build-container:
     name: Get the image name of the build container to use

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
 
           req = urllib.request.Request(
-              url=f"https://api.github.com/repos/{os.environ['REPOSITORY']}",
+              url=f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}",
               headers={
                   "Authorization": "token ${{ secrets.GITHUB_TOKEN }}",
                   "Accept": "application/vnd.github.v3+json",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,31 +28,61 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create container name
         id: create-container-info
+        shell: python -u {0}
         run: |
-          base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | tr [:upper:] [:lower:])
-          head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | tr [:upper:] [:lower:])
-          tag_name="${{ hashFiles('Dockerfile') }}"
+          import os
+          import json
+          import pathlib
+          import subprocess
+          import urllib.request
 
-          # Default to building a new container under the original repo
-          image_name=$head_image
-          build=true
+          GITHUB_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          TAG_NAME = "${{ hashFiles('Dockerfile') }}"
 
-          # Check if we can use the base image (Nabu Casa)
-          if docker manifest inspect ${{ env.REGISTRY }}/$base_image:$tag_name; then
-            image_name=$base_image
-            build=false
-          fi
 
-          # Check if we can use the head image (PR)
-          if docker manifest inspect ${{ env.REGISTRY }}/$head_image:$tag_name; then
-            image_name=$head_image
-            build=false
-          fi
+          req = urllib.request.Request(
+              url=f"https://api.github.com/repos/{os.environ['REPOSITORY']}",
+              headers={
+                  "Authorization": "token ${{ secrets.GITHUB_TOKEN }}",
+                  "Accept": "application/vnd.github.v3+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              }
+          )
 
-          echo "build=$build" >> $GITHUB_OUTPUT
-          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-          echo "image_name=$image_name" >> $GITHUB_OUTPUT
-          echo "container_name=${{ env.REGISTRY }}/$image_name:$tag_name" >> $GITHUB_OUTPUT
+          with urllib.request.urlopen(req) as response:
+              assert response.status == 200
+              data = json.loads(response.read().decode())
+
+          head_image = data["full_name"].lower()
+
+          if data["parent"]:
+              base_image = data["parent"]["full_name"].lower()
+          else:
+              base_image = head_image
+
+          image_name = head_image
+          build = True
+
+          for image in {base_image, head_image}:
+              try:
+                  subprocess.run([
+                      "docker", "manifest", "inspect",
+                      f"{os.environ['REGISTRY']}/{image}:{TAG_NAME}"
+                  ], check=True)
+              except subprocess.CalledProcessError:
+                  continue
+              else:
+                  image_name = image
+                  build = False
+                  break
+
+          with GITHUB_OUTPUT.open("a") as f:
+              f.writelines([
+                  f"build={build}\n",
+                  f"tag_name={TAG_NAME}\n",
+                  f"image_name={image_name}\n",
+                  f"container_name={os.environ['REGISTRY']}/{image_name}:{TAG_NAME}\n",
+              ])
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
         if: steps.create-container-info.outputs.build == 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,8 +45,9 @@ jobs:
       - name: Create container info
         id: create-container-info
         run: |
-          base_image=${{ steps.read-repo-info.outputs.base_image || steps.read-repo-info-pr.outputs.base_image }}
-          head_image=${{ steps.read-repo-info.outputs.head_image || steps.read-repo-info-pr.outputs.head_image }}
+          base_image="${{ steps.read-repo-info.outputs.base_image || steps.read-repo-info-pr.outputs.base_image }}"
+          head_image="${{ steps.read-repo-info.outputs.head_image || steps.read-repo-info-pr.outputs.head_image }}"
+          tag_name="${{ hashFiles('Dockerfile') }}"
 
           # Default to building a new container under the original repo
           image_name=$head_image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4.1.4
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v3.1.0
         with:
@@ -70,9 +69,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: ${{ steps.read-repo-info.outputs.tag_name }}
-          cache-from: ${{ steps.read-repo-info.outputs.image_name }}:cache-${{ steps.read-repo-info.outputs.tag_name }}
-          cache-to: ${{ steps.read-repo-info.outputs.image_name }}:cache-${{ steps.read-repo-info.outputs.tag_name }}
+          tags: ${{ env.REGISTRY }}/${{ steps.read-repo-info.outputs.image_name }}:${{ steps.read-repo-info.outputs.tag_name }}
+          cache-from: ${{ env.REGISTRY }}/${{ steps.read-repo-info.outputs.image_name }}:cache-${{ steps.read-repo-info.outputs.tag_name }}
+          cache-to: ${{ env.REGISTRY }}/${{ steps.read-repo-info.outputs.image_name }}:cache-${{ steps.read-repo-info.outputs.tag_name }}
           push: true
     outputs:
       tag_name: ${{ steps.read-repo-info.outputs.tag_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Read repository information
         id: read-repo-info
         run: |
-          if $GITHUB_EVENT_NAME == 'pull_request'; then
+          if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
             base_image=$(echo ${{ github.event.pull_request.base.repo.full_name }} | awk '{print tolower($0)}')
             head_image=$(echo ${{ github.event.pull_request.head.repo.full_name }} | awk '{print tolower($0)}')
           else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
 
           req = urllib.request.Request(
-              url=f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}",
+              url=f"https://api.github.com/repos/{os.environ['REPOSITORY']}",
               headers={
                   "Authorization": "token ${{ secrets.GITHUB_TOKEN }}",
                   "Accept": "application/vnd.github.v3+json",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,43 +41,43 @@ jobs:
 
           # Default to building a new container under the original repo
           image_name=$head_image
-          build=true
+          build_image=true
 
           # Check if we can use the base image (Nabu Casa)
           if docker manifest inspect ${{ env.REGISTRY }}/$base_image:$tag_name; then
             image_name=$base_image
-            build=false
+            build_image=false
           fi
 
           # Check if we can use the head image (if this is a PR)
           if [[ $base_image != $head_image ]]; then
             if docker manifest inspect ${{ env.REGISTRY }}/$head_image:$tag_name; then
               image_name=$head_image
-              build=false
+              build_image=false
             fi
           fi
 
-          echo "build=$build" >> $GITHUB_OUTPUT
+          echo "build_image=$build_image" >> $GITHUB_OUTPUT
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "container_name=${{ env.REGISTRY }}/$image_name:$tag_name" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
-        if: steps.create-container-info.outputs.build == 'true'
+        if: steps.read-repo-info.outputs.build_image == 'true'
       - name: Build and Push
-        uses: docker/build-push-action@v5.3.0
-        if: steps.create-container-info.outputs.build == 'true'
+        uses: docker/build_image-push-action@v5.3.0
+        if: steps.read-repo-info.outputs.build_image == 'true'
         with:
           context: .
           file: Dockerfile
-          tags: ${{ steps.create-container-info.outputs.tag_name }}
-          cache-from: ${{ steps.create-container-info.outputs.image_name }}:cache-${{ steps.create-container-info.outputs.tag_name }}
-          cache-to: ${{ steps.create-container-info.outputs.image_name }}:cache-${{ steps.create-container-info.outputs.tag_name }}
+          tags: ${{ steps.read-repo-info.outputs.tag_name }}
+          cache-from: ${{ steps.read-repo-info.outputs.image_name }}:cache-${{ steps.read-repo-info.outputs.tag_name }}
+          cache-to: ${{ steps.read-repo-info.outputs.image_name }}:cache-${{ steps.read-repo-info.outputs.tag_name }}
           push: true
     outputs:
-      tag_name: ${{ steps.create-container-info.outputs.tag_name }}
-      image_name: ${{ steps.create-container-info.outputs.image_name }}
-      container_name: ${{ steps.create-container-info.outputs.container_name }}
+      tag_name: ${{ steps.read-repo-info.outputs.tag_name }}
+      image_name: ${{ steps.read-repo-info.outputs.image_name }}
+      container_name: ${{ steps.read-repo-info.outputs.container_name }}
 
 
   list-manifests:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "build=$build" >> $GITHUB_OUTPUT
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
-          echo "container_name=$image_name:$tag_name" >> $GITHUB_OUTPUT
+          echo "container_name=${{ env.REGISTRY }}/$image_name:$tag_name" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
         if: steps.create-container-info.outputs.build == 'true'
@@ -83,7 +83,7 @@ jobs:
     needs: [list-manifests, build-container]
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.REGISTRY }}/${{ needs.build-container.outputs.container_name }}
+      image: ${{ needs.build-container.outputs.container_name }}
       options: --user root
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,7 @@ env:
 jobs:
   get-build-container-names:
     name: Get the possible build containers
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.4
       - name: Create container name

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Build firmwares
 
 on:
+  pull_request:
   push:
     paths:
       - Dockerfile
@@ -15,23 +16,39 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-container:
-    name: Create build container image
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
+  get-build-container-names:
+    name: Get the possible build containers
     steps:
       - uses: actions/checkout@v4.1.4
       - name: Create container name
         id: create-container-name
         run: |
-          repository_owner=$(echo $GITHUB_REPOSITORY_OWNER | tr [:upper:] [:lower:])
-          image_name="${{ env.REGISTRY }}/$repository_owner/silabs-firmware-builder"
+          current_user=$(echo $GITHUB_REPOSITORY_OWNER | tr [:upper:] [:lower:])
+          current_repo=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])
+          current_image_name="${{ env.REGISTRY }}/$current_user/$current_repo"
+
           tag_name="${{ hashFiles('Dockerfile') }}"
 
-          echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-          echo "container_name=$image_name:$tag_name" >> $GITHUB_OUTPUT
+          echo "image_name=$current_image_name" >> $GITHUB_OUTPUT
+    outputs:
+      tag_name: ${{ steps.create-container-name.outputs.tag_name }}
+      image_name: ${{ steps.create-container-name.outputs.current_image_name }}
+      container_name: ${{ steps.create-container-name.outputs.current_image_name }}:${{ steps.create-container-name.outputs.tag_name }}
+
+  maybe-build-container:
+    name: Create build container image
+    needs: [get-build-container-names]
+    if: >-
+      (github.event_name != 'pull_request') ||
+      (github.event.pull_request.author_association == 'COLLABORATOR') ||
+      (github.event.pull_request.author_association == 'MEMBER') ||
+      (github.event.pull_request.author_association == 'OWNER')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4.1.4
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v3.1.0
         with:
@@ -45,16 +62,21 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: ${{ steps.create-container-name.outputs.container_name }}
-          cache-from: ${{ steps.create-container-name.outputs.image_name }}:cache-${{ steps.create-container-name.outputs.tag_name }}
-          cache-to: ${{ steps.create-container-name.outputs.image_name }}:cache-${{ steps.create-container-name.outputs.tag_name }}
+          tags: ${{ needs.get-build-container-names.outputs.container_name }}
+          cache-from: ${{ needs.get-build-container-names.outputs.image_name }}:cache-${{ needs.get-build-container-names.outputs.tag_name }}
+          cache-to: ${{ needs.get-build-container-names.outputs.image_name }}:cache-${{ needs.get-build-container-names.outputs.tag_name }}
           push: true
+
+  get-build-container:
+    name: Get the image name of the build container to use
+    needs: [maybe-build-container, get-build-container-names]
+    if: always()  # If `maybe-build-container` runs, we should run after it
+    runs-on: ubuntu-latest
     outputs:
-      container_name: ${{ steps.create-container-name.outputs.container_name }}
+      container_name: ${{ needs.get-build-container-names.outputs.container_name }}
 
   list-manifests:
     name: List firmware manifests
-    needs: build-container
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -66,10 +88,10 @@ jobs:
 
   build-firmwares:
     name: Firmware builder
-    needs: [list-manifests, build-container]
+    needs: [list-manifests, get-build-container]
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.build-container.outputs.container_name }}
+      image: ${{ needs.get-build-container.outputs.container_name }}
       options: --user root
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,13 @@ name: Build firmwares
 
 on:
   pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'README.md'
   push:
-
+    paths-ignore:
+      - '.gitignore'
+      - 'README.md'
 env:
   REGISTRY: ghcr.io
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,15 @@ RUN \
 
 # Gecko SDK 4.4.0
 RUN \
-    git clone --depth 1 -b v4.4.0 https://github.com/SiliconLabs/gecko_sdk.git gecko_sdk_4.4.0 \
-    && rm -rf gecko_sdk_4.4.0/.git
+    curl -o gecko_sdk_4.4.0.zip -L https://github.com/SiliconLabs/gecko_sdk/releases/download/v4.4.0/gecko-sdk.zip \
+    && unzip -d gecko_sdk_4.4.0 gecko_sdk_4.4.0.zip \
+    && rm gecko_sdk_4.4.0.zip
 
 # Gecko SDK 4.3.1
 RUN \
-    git clone --depth 1 -b v4.3.1 https://github.com/SiliconLabs/gecko_sdk.git gecko_sdk_4.3.1 \
-    && rm -rf gecko_sdk_4.3.1/.git
+    curl -o gecko_sdk_4.3.1.zip -L https://github.com/SiliconLabs/gecko_sdk/releases/download/v4.3.1/gecko-sdk.zip \
+    && unzip -d gecko_sdk_4.3.1 gecko_sdk_4.3.1.zip \
+    && rm gecko_sdk_4.3.1.zip
 
 ARG USERNAME=builder
 ARG USER_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 # is known to be working with Commander_linux_x86_64_1v15p0b1306.tar.bz).
 RUN \
     curl -O https://www.silabs.com/documents/login/software/SimplicityCommander-Linux.zip \
-    && unzip SimplicityCommander-Linux.zip \
+    && unzip -q SimplicityCommander-Linux.zip \
     && tar -C /opt -xjf SimplicityCommander-Linux/Commander_linux_x86_64_*.tar.bz \
     && rm -r SimplicityCommander-Linux \
     && rm SimplicityCommander-Linux.zip
@@ -34,7 +34,7 @@ ENV PATH="$PATH:/opt/commander"
 # Install Silicon Labs Configurator (slc)
 RUN \
     curl -O https://www.silabs.com/documents/login/software/slc_cli_linux.zip \
-    && unzip -d /opt slc_cli_linux.zip \
+    && unzip -q -d /opt slc_cli_linux.zip \
     && rm slc_cli_linux.zip
 
 ENV PATH="$PATH:/opt/slc_cli"
@@ -54,13 +54,13 @@ RUN \
 # Gecko SDK 4.4.0
 RUN \
     curl -o gecko_sdk_4.4.0.zip -L https://github.com/SiliconLabs/gecko_sdk/releases/download/v4.4.0/gecko-sdk.zip \
-    && unzip -d gecko_sdk_4.4.0 gecko_sdk_4.4.0.zip \
+    && unzip -q -d gecko_sdk_4.4.0 gecko_sdk_4.4.0.zip \
     && rm gecko_sdk_4.4.0.zip
 
 # Gecko SDK 4.3.1
 RUN \
     curl -o gecko_sdk_4.3.1.zip -L https://github.com/SiliconLabs/gecko_sdk/releases/download/v4.3.1/gecko-sdk.zip \
-    && unzip -d gecko_sdk_4.3.1 gecko_sdk_4.3.1.zip \
+    && unzip -q -d gecko_sdk_4.3.1 gecko_sdk_4.3.1.zip \
     && rm gecko_sdk_4.3.1.zip
 
 ARG USERNAME=builder


### PR DESCRIPTION
This PR makes the container building step optional, allowing PRs that modify both to be done in two stages:

1. Make a PR that updates `Dockerfile`
2. Once merged, a new container will be built and pushed. This can then be used by subsequent PRs.

Since no write access is granted to the container for non-members, it can be used by normal PRs within CI (after approval).