### PR TITLE
Import `typing` to `tools/build_project.py` to fix CI

### DIFF
--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -10,6 +10,7 @@ import sys
 import copy
 import json
 import shutil
+import typing
 import hashlib
 import logging
 import pathlib


### PR DESCRIPTION
#60 added pre-commit but did not merge `main`, which included #55.