### PR TITLE
Upload artifacts on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,7 +180,27 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.3
         with:
-          name: ${{ steps.build-firmware.outputs.output_basename }}
+          name: firmware-build-${{ steps.build-firmware.outputs.output_basename }}
           path: outputs/*
           compression-level: 9
           if-no-files-found: error
+
+  release-assets:
+    name: Upload release assets
+    needs: [build-firmwares]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all workflow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+          pattern: firmware-build-*
+
+      - name: Upload artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/*.gbl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - '.gitignore'
       - 'README.md'
+  release:
+    types:
+      - published
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Let's try #62 again 😅.

This one has been tested on my fork: https://github.com/puddly/silabs-firmware-builder/releases/tag/v1.0.1

---

Only difference is that only `.gbl` files will be present in the release. Other files will only be present as artifacts.