### PR TITLE
Treat build-time warnings as errors

### DIFF
--- a/gecko_sdk_extensions/nc_efr32_watchdog_extension/inc/nc_efr32_wdog.h
+++ b/gecko_sdk_extensions/nc_efr32_watchdog_extension/inc/nc_efr32_wdog.h
@@ -19,8 +19,7 @@
 #include "em_cmu.h"
 #include "em_wdog.h"
 #include "em_rmu.h"
-#include "sli_cpc_timer.h"
 #include "sl_component_catalog.h"
 
 void nc_enable_watchdog(void);
-void nc_periodic_timer(sli_cpc_timer_handle_t *handle, void *data);
+void nc_poke_watchdog(void);

--- a/gecko_sdk_extensions/nc_efr32_watchdog_extension/src/nc_efr32_wdog.c
+++ b/gecko_sdk_extensions/nc_efr32_watchdog_extension/src/nc_efr32_wdog.c
@@ -83,7 +83,7 @@ void nc_enable_watchdog(void)
 }
 
 
-void nc_poke_watchdog()
+void nc_poke_watchdog(void)
 {
   CORE_DECLARE_IRQ_STATE;
   CORE_ENTER_ATOMIC();

--- a/src/ot-rcp/app.c
+++ b/src/ot-rcp/app.c
@@ -21,6 +21,7 @@
 #include <openthread/ncp.h>
 #include <openthread/diag.h>
 #include <openthread/tasklet.h>
+#include <openthread/logging.h>
 
 #include "openthread-system.h"
 #include "app.h"

--- a/src/ot-rcp/app.c
+++ b/src/ot-rcp/app.c
@@ -21,7 +21,6 @@
 #include <openthread/ncp.h>
 #include <openthread/diag.h>
 #include <openthread/tasklet.h>
-#include <openthread/logging.h>
 
 #include "openthread-system.h"
 #include "app.h"

--- a/src/rcp-uart-802154/app.c
+++ b/src/rcp-uart-802154/app.c
@@ -21,6 +21,7 @@
 #include <openthread/ncp.h>
 #include <openthread/diag.h>
 #include <openthread/tasklet.h>
+#include <openthread/logging.h>
 
 #include "openthread-system.h"
 #include "app.h"

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -325,8 +325,14 @@ def main():
 
     # Extend configuration and C defines
     for input_config, output_config in [
-        (manifest.get("configuration", {}), output_project.get("configuration", [])),
-        (manifest.get("slcp_defines", {}), output_project.get("define", [])),
+        (
+            manifest.get("configuration", {}),
+            output_project.setdefault("configuration", []),
+        ),
+        (
+            manifest.get("slcp_defines", {}),
+            output_project.setdefault("define", []),
+        ),
     ]:
         for name, value in input_config.items():
             # Values are always strings

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -322,6 +322,7 @@ def main():
             LOGGER.warning(
                 "Component %s is not present in manifest, cannot remove", component
             )
+            sys.exit(1)
 
     # Extend configuration and C defines
     for input_config, output_config in [

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -549,6 +549,18 @@ def main():
         LOGGER.error("Defines were unused, aborting: %s", unused_defines)
         sys.exit(1)
 
+    # Fix Gecko SDK bugs
+    sl_rail_util_pti_config_h = args.build_dir / "config/sl_rail_util_pti_config.h"
+
+    # PTI seemingly cannot be excluded, even if it is disabled
+    if sl_rail_util_pti_config_h.exists():
+        sl_rail_util_pti_config_h.write_text(
+            sl_rail_util_pti_config_h.read_text().replace(
+                '#warning "RAIL PTI peripheral not configured"\n',
+                '// #warning "RAIL PTI peripheral not configured"\n',
+            )
+        )
+
     # Remove absolute paths from the build for reproducibility
     extra_compiler_flags = [
         f"-ffile-prefix-map={str(src.absolute())}={dst}"
@@ -557,7 +569,7 @@ def main():
             args.build_dir: "/src",
             toolchain: "/toolchain",
         }.items()
-    ]
+    ] + ["-Wall", "-Wextra", "-Werror"]
 
     output_artifact = (args.build_dir / "build/debug" / base_project_name).with_suffix(
         ".gbl"


### PR DESCRIPTION
Enables `-Wall -Wextra -Werror` and fixes a few warnings and bugs with compilation.

There is a persistent warning with the PTI interface that can only be fixed if PTI is re-enabled verbosely in every config. I think this is a bug, as this component cannot be excluded:

```c
// <<< sl:start pin_tool >>>
// <pti signal=DOUT,(DFRAME),(DCLK)> SL_RAIL_UTIL_PTI
// $[PTI_SL_RAIL_UTIL_PTI]
#ifndef SL_RAIL_UTIL_PTI_PERIPHERAL             
#warning "RAIL PTI peripheral not configured"
#define SL_RAIL_UTIL_PTI_PERIPHERAL              PTI
#endif
```

Until this is fixed in the Gecko SDK, this warning is explicitly disabled.