### PR TITLE
More `.cproject` normalization

### DIFF
--- a/misc/firmware-eraser/.cproject
+++ b/misc/firmware-eraser/.cproject
@@ -48,14 +48,66 @@
         ], 
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
-        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/common/inc/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/common/inc/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/common/inc/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-mcmse\&quot;,
 
 \&quot;--specs=nano.specs\&quot;,
 
 \&quot;-fmessage-length=0\&quot;,
 
-\&quot;-c\&quot;\n        ],
+\&quot;-c\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -65,15 +117,27 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-c\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -83,15 +147,27 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-mcmse\&quot;,
 
 \&quot;--specs=nano.specs\&quot;,
 
 \&quot;-fmessage-length=0\&quot;,
 
-\&quot;-c\&quot;\n        ],
+\&quot;-c\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -101,15 +177,27 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-c\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -119,9 +207,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -131,9 +227,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -143,9 +243,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -155,9 +259,17 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -167,9 +279,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
 
@@ -179,9 +299,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
 
@@ -191,9 +315,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.linker.base\&quot;,
 
@@ -203,9 +331,17 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;DEBUG\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;DEBUG\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -215,9 +351,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;DEBUG\&quot;: \&quot;PARENT\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;DEBUG\&quot;: \&quot;PARENT\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -227,9 +371,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -239,9 +387,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -251,9 +403,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -263,9 +419,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -275,9 +435,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -287,9 +451,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -299,9 +467,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -311,9 +487,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -323,9 +507,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -335,9 +523,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -347,9 +539,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -359,9 +555,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -371,9 +571,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -383,9 +587,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -395,9 +603,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -407,9 +619,13 @@
 
 \&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -419,9 +635,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -431,9 +651,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -443,9 +667,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -455,9 +683,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -467,9 +699,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -479,9 +715,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -491,9 +731,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -503,9 +747,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -515,9 +763,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler\&quot;,
 
@@ -527,9 +779,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.none\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -539,9 +795,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -551,9 +815,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -563,9 +835,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -575,9 +851,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -587,9 +867,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -599,9 +883,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -611,9 +899,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -623,9 +915,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -635,9 +931,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level.default\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -647,9 +947,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -659,9 +963,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -671,9 +979,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -683,9 +995,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -695,9 +1011,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -707,9 +1027,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -719,9 +1043,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -731,9 +1059,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -743,9 +1075,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -755,9 +1091,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -767,9 +1107,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -779,9 +1123,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -791,9 +1139,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -803,9 +1155,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -815,9 +1171,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -827,9 +1187,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -839,9 +1203,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -851,9 +1219,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -863,9 +1235,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -875,21 +1251,25 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    }\n]&quot;
+\&quot;listValuesMap\&quot;: {}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -908,7 +1288,7 @@
             &quot;config/sl_device_init_lfxo_config.h&quot;, 
             &quot;config/sl_memory_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -927,7 +1307,7 @@
             &quot;autogen/sl_event_handler.c&quot;, 
             &quot;autogen/sl_event_handler.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1096,14 +1476,14 @@
             &quot;main.cpp&quot;, 
             &quot;readme.md&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1112,7 +1492,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
@@ -1365,7 +1745,11 @@
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
         &quot;builtinIncludesStr&quot;: &quot;&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [],
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -1375,9 +1759,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
 
@@ -1387,9 +1775,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
 
@@ -1399,9 +1791,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.linker.base\&quot;,
 
@@ -1411,9 +1807,17 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;NDEBUG\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;NDEBUG\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -1423,9 +1827,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;NDEBUG\&quot;: \&quot;PARENT\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;NDEBUG\&quot;: \&quot;PARENT\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -1435,9 +1847,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -1447,9 +1863,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -1459,9 +1879,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -1471,9 +1895,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level.none\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1483,9 +1911,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1495,9 +1927,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1507,9 +1943,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1519,9 +1959,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1531,9 +1975,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1543,9 +1991,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1555,9 +2007,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1567,9 +2023,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1579,9 +2039,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1591,9 +2055,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1603,9 +2071,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
 
@@ -1615,7 +2087,11 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    }\n]&quot;
+\&quot;listValuesMap\&quot;: {}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.buildArtifactType="EXE" projectCommon.referencedModules="[
     {
@@ -1642,7 +2118,7 @@
             &quot;autogen/sl_event_handler.c&quot;, 
             &quot;autogen/sl_event_handler.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1969,7 +2445,7 @@
             &quot;main.cpp&quot;, 
             &quot;readme.md&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -2000,7 +2476,7 @@
             &quot;config/sl_device_init_lfxo_config.h&quot;, 
             &quot;config/sl_memory_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -2011,7 +2487,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>

--- a/misc/firmware-eraser/.cproject
+++ b/misc/firmware-eraser/.cproject
@@ -23,7 +23,1099 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{&quot;SL_BOARD_NAME&quot;:&quot;\&quot;BRD4179B\&quot;&quot;,&quot;HFXO_FREQ&quot;:&quot;38400000&quot;,&quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;:&quot;1&quot;,&quot;EFR32MG21A010F1024IM32&quot;:&quot;1&quot;,&quot;SL_BOARD_REV&quot;:&quot;\&quot;A05\&quot;&quot;,&quot;DEBUG_EFM&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;:&quot;1&quot;,&quot;SL_COMPONENT_CATALOG_PRESENT&quot;:&quot;1&quot;,&quot;SL_APP_PROPERTIES&quot;:&quot;1&quot;},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[&quot;stdc++&quot;,&quot;gcc&quot;,&quot;c&quot;,&quot;m&quot;,&quot;nosys&quot;],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.builtin\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.prolog\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;DEBUG\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.def.symbols\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;DEBUG\&quot;:\&quot;PARENT\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,\&quot;value\&quot;:\&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.none\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level.default\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.autoInline\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.commonBlockSubroutines\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.constantFolding\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.globalCSE\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.inlining\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.localCSE\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.loopOptimizing\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.optimizeForDebug\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.peephole\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.registerVariables\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.switchOptimizing\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.tailMerging\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;config/sl_memory_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[&quot;autogen&quot;],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen&quot;,&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[&quot;gecko_sdk_4.4.3&quot;],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;app.cpp&quot;,&quot;app.h&quot;,&quot;gecko_sdk_4.4.3&quot;,&quot;gecko_sdk_4.4.3/hardware&quot;,&quot;gecko_sdk_4.4.3/hardware/board&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/service&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;,&quot;main.cpp&quot;,&quot;readme.md&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {
+            &quot;SL_BOARD_NAME&quot;: &quot;\&quot;BRD4179B\&quot;&quot;, 
+            &quot;HFXO_FREQ&quot;: &quot;38400000&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;EFR32MG21A010F1024IM32&quot;: &quot;1&quot;, 
+            &quot;SL_BOARD_REV&quot;: &quot;\&quot;A05\&quot;&quot;, 
+            &quot;DEBUG_EFM&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;SL_COMPONENT_CATALOG_PRESENT&quot;: &quot;1&quot;, 
+            &quot;SL_APP_PROPERTIES&quot;: &quot;1&quot;
+        }, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [
+            &quot;stdc++&quot;, 
+            &quot;gcc&quot;, 
+            &quot;c&quot;, 
+            &quot;m&quot;, 
+            &quot;nosys&quot;
+        ], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.builtin\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.prolog\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;DEBUG\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.def.symbols\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;DEBUG\&quot;: \&quot;PARENT\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,
+
+\&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.none\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level.default\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.autoInline\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.commonBlockSubroutines\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.constantFolding\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.globalCSE\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.inlining\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.localCSE\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.loopOptimizing\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.optimizeForDebug\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.peephole\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.registerVariables\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.switchOptimizing\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.tailMerging\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfrco_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_device_init_lfxo_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [
+            &quot;autogen&quot;
+        ], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen&quot;, 
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [
+            &quot;gecko_sdk_4.4.3&quot;
+        ], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;app.cpp&quot;, 
+            &quot;app.h&quot;, 
+            &quot;gecko_sdk_4.4.3&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;, 
+            &quot;main.cpp&quot;, 
+            &quot;readme.md&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" id="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Debug" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe" postbuildStep="../../../tools/create_gbl.py postbuild &quot;${workspace_loc:/${ProjName}}/${ProjName}.slpb&quot; --parameter build_dir:&quot;${workspace_loc:/${ProjName}/${ConfigName}}&quot; --parameter sdk_dir:&quot;${StudioSdkPath}&quot;">
 					<folderInfo id="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -264,7 +1356,665 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.release#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.builtin\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.prolog\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;NDEBUG\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.def.symbols\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;NDEBUG\&quot;:\&quot;PARENT\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level.none\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.autoInline\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.commonBlockSubroutines\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.constantFolding\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.globalCSE\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.inlining\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.localCSE\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.loopOptimizing\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.optimizeForDebug\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.peephole\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.registerVariables\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.switchOptimizing\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;toolOption.generic.compiler.c\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;toolOption.generic.compiler.c.tailMerging\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.buildArtifactType="EXE" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[&quot;autogen&quot;,&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;],&quot;removed&quot;:true,&quot;builtinSources&quot;:[&quot;autogen&quot;,&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[&quot;app.cpp&quot;,&quot;app.h&quot;,&quot;gecko_sdk_4.4.3&quot;,&quot;gecko_sdk_4.4.3/hardware&quot;,&quot;gecko_sdk_4.4.3/hardware/board&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/service&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;,&quot;main.cpp&quot;,&quot;readme.md&quot;],&quot;removed&quot;:true,&quot;builtinSources&quot;:[&quot;app.cpp&quot;,&quot;app.h&quot;,&quot;gecko_sdk_4.4.3&quot;,&quot;gecko_sdk_4.4.3/hardware&quot;,&quot;gecko_sdk_4.4.3/hardware/board&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/service&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;,&quot;main.cpp&quot;,&quot;readme.md&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;config/sl_memory_config.h&quot;],&quot;removed&quot;:true,&quot;builtinSources&quot;:[&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;config/sl_memory_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;removed&quot;:true,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.release#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {}, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.builtin\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.compiler.debug.prolog\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c(pp)?.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c$1.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;NDEBUG\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.def.symbols\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;NDEBUG\&quot;: \&quot;PARENT\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.debug.level.none\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.autoInline\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.commonBlockSubroutines\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.constantFolding\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.globalCSE\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.inlining\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.localCSE\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.loopOptimizing\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.optimizeForDebug\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.peephole\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.registerVariables\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.switchOptimizing\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;toolOption.generic.compiler.c\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;toolOption.generic.compiler.c.tailMerging\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.buildArtifactType="EXE" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [
+            &quot;autogen&quot;, 
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;
+        ], 
+        &quot;removed&quot;: true, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen&quot;, 
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [
+            &quot;app.cpp&quot;, 
+            &quot;app.h&quot;, 
+            &quot;gecko_sdk_4.4.3&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;, 
+            &quot;main.cpp&quot;, 
+            &quot;readme.md&quot;
+        ], 
+        &quot;removed&quot;: true, 
+        &quot;builtinSources&quot;: [
+            &quot;app.cpp&quot;, 
+            &quot;app.h&quot;, 
+            &quot;gecko_sdk_4.4.3&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;, 
+            &quot;main.cpp&quot;, 
+            &quot;readme.md&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfrco_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_device_init_lfxo_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;
+        ], 
+        &quot;removed&quot;: true, 
+        &quot;builtinSources&quot;: [
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfrco_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_device_init_lfxo_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;removed&quot;: true, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.debug#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" id="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.release#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Release" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe">
 					<folderInfo id="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt.release#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -330,7 +2080,176 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
-	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="28" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.cpp&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1498572884},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1884076390},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;main.cpp&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1841401344},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;readme.md&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:93364861},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/.crc_config.crc&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:652630299},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/RTE_Components.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-753128665},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/linkerfile.ld&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-2003353113},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_application_type.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1938797144},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_board_default_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1764316703},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_component_catalog.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2139240202},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_device_init_clocks.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-158784453},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1091328185},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-730778998},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/app_properties_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:464657923},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:675916386},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1462694363},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/emlib_core_debug_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-78822137},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_board_control_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:60804688},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_debug_swo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-367262434},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_emu_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1488208825},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:92619244},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:977362596},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-960917308},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_memory_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:989839506}]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="28" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.cpp&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1498572884
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1884076390
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;main.cpp&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1841401344
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;readme.md&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 93364861
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/.crc_config.crc&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 652630299
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/RTE_Components.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -753128665
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/linkerfile.ld&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -2003353113
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_application_type.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1938797144
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_board_default_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1764316703
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_component_catalog.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2139240202
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_device_init_clocks.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -158784453
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1091328185
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -730778998
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/app_properties_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 464657923
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 675916386
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1462694363
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/emlib_core_debug_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -78822137
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_board_control_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 60804688
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_debug_swo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -367262434
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_emu_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1488208825
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfrco_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 92619244
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 977362596
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_lfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -960917308
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_memory_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 989839506
+    }
+]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="firmware-eraser.com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType.1711980667" name="SLS CDT Project" projectType="com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType"/>
 	</storageModule>

--- a/src/bootloader-uart-xmodem/.cproject
+++ b/src/bootloader-uart-xmodem/.cproject
@@ -58,8 +58,69 @@
         ], 
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
-        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/debug/ studio:/sdk/platform/bootloader/gpio/gpio-activation/ studio:/sdk/platform/bootloader/parser/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/bootloader/security/ studio:/sdk/platform/bootloader/driver/ studio:/sdk/platform/bootloader/communication/ studio:/sdk/platform/bootloader/communication/xmodem-parser/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/ studio:/sdk/util/third_party/trusted-firmware-m/platform/include/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/udelay/inc/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/debug/ studio:/sdk/platform/bootloader/gpio/gpio-activation/ studio:/sdk/platform/bootloader/parser/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/bootloader/security/ studio:/sdk/platform/bootloader/driver/ studio:/sdk/platform/bootloader/communication/ studio:/sdk/platform/bootloader/communication/xmodem-parser/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/ studio:/sdk/util/third_party/trusted-firmware-m/platform/include/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/udelay/inc/&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/
+studio:/project/autogen/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/debug/
+studio:/sdk/platform/bootloader/gpio/gpio-activation/
+studio:/sdk/platform/bootloader/parser/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/bootloader/security/
+studio:/sdk/platform/bootloader/driver/
+studio:/sdk/platform/bootloader/communication/
+studio:/sdk/platform/bootloader/communication/xmodem-parser/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/common/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/
+studio:/sdk/util/third_party/trusted-firmware-m/platform/include/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/udelay/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/debug/
+studio:/sdk/platform/bootloader/gpio/gpio-activation/
+studio:/sdk/platform/bootloader/parser/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/bootloader/security/
+studio:/sdk/platform/bootloader/driver/
+studio:/sdk/platform/bootloader/communication/
+studio:/sdk/platform/bootloader/communication/xmodem-parser/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/common/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/
+studio:/sdk/util/third_party/trusted-firmware-m/platform/include/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/udelay/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-mcmse\&quot;,
 
 \&quot;-Wno-sign-compare\&quot;,
 
@@ -69,7 +130,9 @@
 
 \&quot;-c\&quot;,
 
-\&quot;-Wno-ignored-qualifiers\&quot;\n        ],
+\&quot;-Wno-ignored-qualifiers\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -79,7 +142,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Wno-sign-compare\&quot;: \&quot;TRUE\&quot;,
 
@@ -89,9 +154,19 @@
 
 \&quot;-c\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-Wno-ignored-qualifiers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-Wno-ignored-qualifiers\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -101,9 +176,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-mcmse\&quot;,
 
 \&quot;-Wno-sign-compare\&quot;,
 
@@ -113,7 +198,9 @@
 
 \&quot;-c\&quot;,
 
-\&quot;-Wno-ignored-qualifiers\&quot;\n        ],
+\&quot;-Wno-ignored-qualifiers\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -123,7 +210,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Wno-sign-compare\&quot;: \&quot;TRUE\&quot;,
 
@@ -133,9 +222,19 @@
 
 \&quot;-c\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-Wno-ignored-qualifiers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-Wno-ignored-qualifiers\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -145,9 +244,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -157,9 +264,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -169,9 +280,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -181,9 +296,17 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -193,9 +316,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -205,9 +336,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -217,9 +352,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -229,9 +368,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -241,9 +384,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -253,9 +400,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -265,9 +416,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -277,9 +432,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -289,9 +452,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -301,9 +472,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -313,9 +488,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -325,9 +504,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -337,9 +520,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -349,9 +536,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -361,9 +552,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -373,9 +568,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -385,9 +584,13 @@
 
 \&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -397,9 +600,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -409,9 +616,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -421,9 +632,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -433,9 +648,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -445,9 +664,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -457,9 +680,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -469,9 +696,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -481,9 +712,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -493,9 +728,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -505,9 +744,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -517,9 +764,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -529,9 +784,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -541,9 +800,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -553,9 +816,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -565,9 +832,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -577,9 +848,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -589,9 +864,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -601,9 +880,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -613,9 +896,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -625,9 +912,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -637,9 +928,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -649,9 +944,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -661,9 +960,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -673,9 +976,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -685,21 +992,25 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    }\n]&quot;
+\&quot;listValuesMap\&quot;: {}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -719,7 +1030,7 @@
             &quot;config/sl_mbedtls_device_config.h&quot;, 
             &quot;config/sl_memory_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -734,7 +1045,7 @@
             &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
             &quot;autogen/sli_psa_config_autogen.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1138,14 +1449,14 @@
             &quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/include/tfm_hal_platform.h&quot;, 
             &quot;readme.md&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1154,7 +1465,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>

--- a/src/bootloader-uart-xmodem/.cproject
+++ b/src/bootloader-uart-xmodem/.cproject
@@ -23,7 +23,1141 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{&quot;SE_MANAGER_CONFIG_FILE&quot;:&quot;\&quot;btl_aes_ctr_stream_block_cfg.h\&quot;&quot;,&quot;BOOTLOADER_SUPPORT_COMMUNICATION&quot;:&quot;1&quot;,&quot;HFXO_FREQ&quot;:&quot;38400000&quot;,&quot;BTL_GPIO_ACTIVATION&quot;:&quot;1&quot;,&quot;__STARTUP_CLEAR_BSS&quot;:&quot;1&quot;,&quot;SL_TRUSTZONE_SECURE&quot;:&quot;1&quot;,&quot;SL_RAMFUNC_DISABLE&quot;:&quot;1&quot;,&quot;__START&quot;:&quot;main&quot;,&quot;SL_BOARD_REV&quot;:&quot;\&quot;A05\&quot;&quot;,&quot;BTL_UART_ENABLE&quot;:&quot;1&quot;,&quot;MBEDTLS_PSA_CRYPTO_CLIENT&quot;:&quot;1&quot;,&quot;SL_BOARD_NAME&quot;:&quot;\&quot;BRD4179B\&quot;&quot;,&quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;:&quot;&lt;psa_crypto_config.h&gt;&quot;,&quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;:&quot;1&quot;,&quot;EFR32MG21A010F1024IM32&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;:&quot;1&quot;,&quot;MBEDTLS_CONFIG_FILE&quot;:&quot;&lt;sl_mbedtls_config.h&gt;&quot;,&quot;BOOTLOADER_ENABLE&quot;:&quot;1&quot;,&quot;BOOTLOADER_SECOND_STAGE&quot;:&quot;1&quot;,&quot;SL_COMPONENT_CATALOG_PRESENT&quot;:&quot;1&quot;},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[&quot;gcc&quot;,&quot;c&quot;,&quot;m&quot;,&quot;nosys&quot;],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/debug/ studio:/sdk/platform/bootloader/gpio/gpio-activation/ studio:/sdk/platform/bootloader/parser/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/bootloader/security/ studio:/sdk/platform/bootloader/driver/ studio:/sdk/platform/bootloader/communication/ studio:/sdk/platform/bootloader/communication/xmodem-parser/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/ studio:/sdk/util/third_party/trusted-firmware-m/platform/include/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/udelay/inc/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/debug/ studio:/sdk/platform/bootloader/gpio/gpio-activation/ studio:/sdk/platform/bootloader/parser/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/bootloader/security/ studio:/sdk/platform/bootloader/driver/ studio:/sdk/platform/bootloader/communication/ studio:/sdk/platform/bootloader/communication/xmodem-parser/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/ studio:/sdk/util/third_party/trusted-firmware-m/platform/include/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/udelay/inc/&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[\&quot;-mcmse\&quot;,\&quot;-Wno-sign-compare\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;,\&quot;-Wno-ignored-qualifiers\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-sign-compare\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-ignored-qualifiers\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-mcmse\&quot;,\&quot;-Wno-sign-compare\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;,\&quot;-Wno-ignored-qualifiers\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-sign-compare\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-ignored-qualifiers\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,\&quot;value\&quot;:\&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;config/btl_aes_ctr_stream_block_cfg.h&quot;,&quot;config/btl_core_cfg.h&quot;,&quot;config/btl_debug_cfg.h&quot;,&quot;config/btl_gpio_activation_cfg.h&quot;,&quot;config/btl_uart_driver_cfg.h&quot;,&quot;config/btl_xmodem_config.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/psa_crypto_config.h&quot;,&quot;config/sl_fault_injection_hardening_cfg.h&quot;,&quot;config/sl_mbedtls_config.h&quot;,&quot;config/sl_mbedtls_device_config.h&quot;,&quot;config/sl_memory_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;autogen/sli_psa_config_autogen.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/communication/btl_communication.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-parser/btl_xmodem.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-parser/btl_xmodem.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem_common.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/config/btl_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_bootload.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_bootload.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_helper.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_main.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_parse.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_parse.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_reset.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_reset.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_upgrade.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/flash/btl_internal_flash.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/core/flash/btl_internal_flash.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/debug/btl_debug.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/debug/btl_debug.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/debug/btl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_delay.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_delay.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_uart.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_util.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_serial_driver.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/gpio/gpio-activation/btl_gpio_activation.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/gpio/gpio-activation/btl_gpio_activation.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_custom_tags.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_custom_tags.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_format.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_format.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_parser.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc16.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc16.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc32.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc32.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_aes.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_ecdsa.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_ecdsa.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_sha256.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_sha256.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_tokens.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_tokens.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/ecc/ecc.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/ecc/ecc.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/btl_sha256.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/btl_sha256.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/crypto_sha.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/cryptoacc_sha.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/se_sha.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_dbg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_acmp.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_dbg.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpcrc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_i2c.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_iadc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_letimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/udelay/inc/sl_udelay.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/udelay/src/sl_udelay.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/udelay/src/sl_udelay_armv6m_gcc.S&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/aes.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/lib/fih/inc/fih.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/lib/fih/src/fih.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/ext/target/siliconlabs/hse/sli_se.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/include/tfm_hal_defs.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/include/tfm_hal_platform.h&quot;,&quot;readme.md&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {
+            &quot;SE_MANAGER_CONFIG_FILE&quot;: &quot;\&quot;btl_aes_ctr_stream_block_cfg.h\&quot;&quot;, 
+            &quot;BOOTLOADER_SUPPORT_COMMUNICATION&quot;: &quot;1&quot;, 
+            &quot;HFXO_FREQ&quot;: &quot;38400000&quot;, 
+            &quot;BTL_GPIO_ACTIVATION&quot;: &quot;1&quot;, 
+            &quot;__STARTUP_CLEAR_BSS&quot;: &quot;1&quot;, 
+            &quot;SL_TRUSTZONE_SECURE&quot;: &quot;1&quot;, 
+            &quot;SL_RAMFUNC_DISABLE&quot;: &quot;1&quot;, 
+            &quot;__START&quot;: &quot;main&quot;, 
+            &quot;SL_BOARD_REV&quot;: &quot;\&quot;A05\&quot;&quot;, 
+            &quot;BTL_UART_ENABLE&quot;: &quot;1&quot;, 
+            &quot;MBEDTLS_PSA_CRYPTO_CLIENT&quot;: &quot;1&quot;, 
+            &quot;SL_BOARD_NAME&quot;: &quot;\&quot;BRD4179B\&quot;&quot;, 
+            &quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;: &quot;&lt;psa_crypto_config.h&gt;&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;EFR32MG21A010F1024IM32&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;MBEDTLS_CONFIG_FILE&quot;: &quot;&lt;sl_mbedtls_config.h&gt;&quot;, 
+            &quot;BOOTLOADER_ENABLE&quot;: &quot;1&quot;, 
+            &quot;BOOTLOADER_SECOND_STAGE&quot;: &quot;1&quot;, 
+            &quot;SL_COMPONENT_CATALOG_PRESENT&quot;: &quot;1&quot;
+        }, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [
+            &quot;gcc&quot;, 
+            &quot;c&quot;, 
+            &quot;m&quot;, 
+            &quot;nosys&quot;
+        ], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/debug/ studio:/sdk/platform/bootloader/gpio/gpio-activation/ studio:/sdk/platform/bootloader/parser/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/bootloader/security/ studio:/sdk/platform/bootloader/driver/ studio:/sdk/platform/bootloader/communication/ studio:/sdk/platform/bootloader/communication/xmodem-parser/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/ studio:/sdk/util/third_party/trusted-firmware-m/platform/include/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/udelay/inc/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/debug/ studio:/sdk/platform/bootloader/gpio/gpio-activation/ studio:/sdk/platform/bootloader/parser/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/bootloader/security/ studio:/sdk/platform/bootloader/driver/ studio:/sdk/platform/bootloader/communication/ studio:/sdk/platform/bootloader/communication/xmodem-parser/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/common/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/util/third_party/trusted-firmware-m/lib/fih/inc/ studio:/sdk/util/third_party/trusted-firmware-m/platform/include/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/udelay/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+
+\&quot;-Wno-sign-compare\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;,
+
+\&quot;-Wno-ignored-qualifiers\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-sign-compare\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-ignored-qualifiers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-mcmse\&quot;,
+
+\&quot;-Wno-sign-compare\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;,
+
+\&quot;-Wno-ignored-qualifiers\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-sign-compare\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-ignored-qualifiers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,
+
+\&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;config/btl_aes_ctr_stream_block_cfg.h&quot;, 
+            &quot;config/btl_core_cfg.h&quot;, 
+            &quot;config/btl_debug_cfg.h&quot;, 
+            &quot;config/btl_gpio_activation_cfg.h&quot;, 
+            &quot;config/btl_uart_driver_cfg.h&quot;, 
+            &quot;config/btl_xmodem_config.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/psa_crypto_config.h&quot;, 
+            &quot;config/sl_fault_injection_hardening_cfg.h&quot;, 
+            &quot;config/sl_mbedtls_config.h&quot;, 
+            &quot;config/sl_mbedtls_device_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+            &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+            &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+            &quot;autogen/sli_psa_config_autogen.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/communication/btl_communication.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-parser/btl_xmodem.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-parser/btl_xmodem.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem_common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/config/btl_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_bootload.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_bootload.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_helper.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_main.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_parse.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_parse.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_reset.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_reset.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_upgrade.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/btl_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/flash/btl_internal_flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/core/flash/btl_internal_flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/debug/btl_debug.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/debug/btl_debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/debug/btl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_delay.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_delay.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_driver_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/driver/btl_serial_driver.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/gpio/gpio-activation/btl_gpio_activation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/gpio/gpio-activation/btl_gpio_activation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_custom_tags.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_custom_tags.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_format.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_format.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_parser.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/parser/gbl/btl_gbl_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc16.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc16.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_crc32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_ecdsa.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_ecdsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_sha256.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_sha256.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_tokens.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_tokens.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/btl_security_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/ecc/ecc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/ecc/ecc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/btl_sha256.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/btl_sha256.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/crypto_sha.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/cryptoacc_sha.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/security/sha/se_sha.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_dbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_acmp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_dbg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpcrc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_i2c.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_iadc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_letimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/udelay/inc/sl_udelay.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/udelay/src/sl_udelay.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/udelay/src/sl_udelay_armv6m_gcc.S&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/lib/fih/inc/fih.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/lib/fih/src/fih.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/ext/target/siliconlabs/hse/sli_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/include/tfm_hal_defs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/trusted-firmware-m/platform/include/tfm_hal_platform.h&quot;, 
+            &quot;readme.md&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Default" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe" postbuildStep="../../../tools/create_gbl.py postbuild &quot;${workspace_loc:/${ProjName}}/${ProjName}.slpb&quot; --parameter build_dir:&quot;${workspace_loc:/${ProjName}/${ConfigName}}&quot; --parameter sdk_dir:&quot;${StudioSdkPath}&quot;">
 					<folderInfo id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -245,7 +1379,162 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
-	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="24" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;readme.md&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1403783975},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/.crc_config.crc&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:362028918},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/RTE_Components.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-753128665},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/linkerfile.ld&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-460377608},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_component_catalog.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1471761184},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1464623507},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1799123423},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-460465170},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1695769262},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;bootloader-uart-xmodem.slpb&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:774968358},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_aes_ctr_stream_block_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1159753198},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_core_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1504429391},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_debug_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-59866738},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_gpio_activation_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:192032361},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_uart_driver_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1447711074},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_xmodem_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1410904415},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/emlib_core_debug_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-78822137},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/psa_crypto_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:361377680},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_fault_injection_hardening_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1747034526},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1637757762},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_device_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1138397796},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_memory_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:989839506}]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="24" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;readme.md&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1403783975
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/.crc_config.crc&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 362028918
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/RTE_Components.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -753128665
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/linkerfile.ld&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -460377608
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_component_catalog.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1471761184
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1464623507
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1799123423
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -460465170
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1695769262
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;bootloader-uart-xmodem.slpb&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 774968358
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_aes_ctr_stream_block_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1159753198
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_core_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1504429391
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_debug_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -59866738
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_gpio_activation_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 192032361
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_uart_driver_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1447711074
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_xmodem_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1410904415
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/emlib_core_debug_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -78822137
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/psa_crypto_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 361377680
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_fault_injection_hardening_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1747034526
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1637757762
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_device_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1138397796
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_memory_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 989839506
+    }
+]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="bootloader-uart-xmodem.com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType.363836861" name="SLS CDT Project" projectType="com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType"/>
 	</storageModule>

--- a/src/ncp-uart-hw/.cproject
+++ b/src/ncp-uart-hw/.cproject
@@ -23,7 +23,1640 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{&quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;:&quot;&lt;sl_rail_util_pa_config.h&gt;&quot;,&quot;CORTEXM3_EFM32_MICRO&quot;:&quot;1&quot;,&quot;SL_ZIGBEE_PHY_SELECT_STACK_SUPPORT&quot;:&quot;1&quot;,&quot;SL_BOARD_REV&quot;:&quot;\&quot;A05\&quot;&quot;,&quot;CORTEXM3&quot;:&quot;1&quot;,&quot;PLATFORM_HEADER&quot;:&quot;\&quot;platform-header.h\&quot;&quot;,&quot;SEGGER_RTT_SECTION&quot;:&quot;\&quot;SEGGER_RTT\&quot;&quot;,&quot;SEGGER_RTT_ALIGNMENT&quot;:&quot;1024&quot;,&quot;EMBER_AF_NCP&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;:&quot;1&quot;,&quot;EMBER_CUSTOM_MAC_FILTER_TABLE_SIZE&quot;:&quot;15&quot;,&quot;SL_COMPONENT_CATALOG_PRESENT&quot;:&quot;1&quot;,&quot;USE_NVM3&quot;:&quot;1&quot;,&quot;HFXO_FREQ&quot;:&quot;38400000&quot;,&quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;:&quot;0&quot;,&quot;CUSTOM_TOKEN_HEADER&quot;:&quot;\&quot;sl_token_manager_af_token_header.h\&quot;&quot;,&quot;PHY_RAIL&quot;:&quot;1&quot;,&quot;EMBER_MULTI_NETWORK_STRIPPED&quot;:&quot;1&quot;,&quot;SL_LEGACY_HAL_ENABLE_WATCHDOG&quot;:&quot;1&quot;,&quot;SL_BOARD_NAME&quot;:&quot;\&quot;BRD4179B\&quot;&quot;,&quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;:&quot;&lt;psa_crypto_config.h&gt;&quot;,&quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;:&quot;1&quot;,&quot;UC_BUILD&quot;:&quot;1&quot;,&quot;CORTEXM3_EFR32&quot;:&quot;1&quot;,&quot;EMBER_SERIAL1_RTSCTS&quot;:&quot;1&quot;,&quot;EFR32MG21A010F1024IM32&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;:&quot;1&quot;,&quot;MBEDTLS_CONFIG_FILE&quot;:&quot;&lt;sl_mbedtls_config.h&gt;&quot;,&quot;RTT_USE_ASM&quot;:&quot;0&quot;,&quot;EZSP_UART&quot;:&quot;1&quot;,&quot;SL_APP_PROPERTIES&quot;:&quot;1&quot;,&quot;SL_ZIGBEE_STACK_COMPLIANCE_REVISION&quot;:&quot;22&quot;},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[&quot;gcc&quot;,&quot;c&quot;,&quot;m&quot;,&quot;nosys&quot;],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[\&quot;-Wno-unused-parameter\&quot;,\&quot;-mcmse\&quot;,\&quot;-fno-builtin-sprintf\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;,\&quot;-fno-builtin-printf\&quot;,\&quot;-Wno-missing-braces\&quot;,\&quot;-Wno-missing-field-initializers\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wno-unused-parameter\&quot;:\&quot;TRUE\&quot;,\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;-fno-builtin-sprintf\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;,\&quot;-fno-builtin-printf\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-missing-braces\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-missing-field-initializers\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wno-unused-parameter\&quot;,\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;,\&quot;-Wno-missing-braces\&quot;,\&quot;-Wno-missing-field-initializers\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wno-unused-parameter\&quot;:\&quot;TRUE\&quot;,\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-missing-braces\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-missing-field-initializers\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,\&quot;value\&quot;:\&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.c.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.cpp.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;:\&quot;TRUE\&quot;}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;config/SEGGER_RTT_Conf.h&quot;,&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;config/dmadrv_config.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/legacy_common_ash_config.h&quot;,&quot;config/legacy_hal_config.h&quot;,&quot;config/nvm3_default_config.h&quot;,&quot;config/psa_crypto_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_custom_manufacturing_token_header.h&quot;,&quot;config/sl_custom_token_header.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;config/sl_iostream_usart_vcom_config.h&quot;,&quot;config/sl_iostream_vuart_config.h&quot;,&quot;config/sl_legacy_hal_wdog_config.h&quot;,&quot;config/sl_mbedtls_config.h&quot;,&quot;config/sl_mbedtls_device_config.h&quot;,&quot;config/sl_memory_config.h&quot;,&quot;config/sl_power_manager_config.h&quot;,&quot;config/sl_rail_util_pa_config.h&quot;,&quot;config/sl_rail_util_power_manager_init_config.h&quot;,&quot;config/sl_rail_util_pti_config.h&quot;,&quot;config/sl_rail_util_rf_path_config.h&quot;,&quot;config/sl_sleeptimer_config.h&quot;,&quot;config/sl_token_manager_config.h&quot;,&quot;config/sl_zigbee_debug_print_config.h&quot;,&quot;config/sl_zigbee_green_power_config.h&quot;,&quot;config/sl_zigbee_light_link_config.h&quot;,&quot;config/sl_zigbee_pro_stack_config.h&quot;,&quot;config/sl_zigbee_security_link_keys_config.h&quot;,&quot;config/sl_zigbee_source_route_config.h&quot;,&quot;config/zigbee_sleep_config.h&quot;,&quot;config/zigbee_watchdog_periodic_refresh_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;,&quot;autogen/sl_iostream_handles.c&quot;,&quot;autogen/sl_iostream_handles.h&quot;,&quot;autogen/sl_iostream_init_instances.h&quot;,&quot;autogen/sl_iostream_init_usart_instances.c&quot;,&quot;autogen/sl_iostream_init_usart_instances.h&quot;,&quot;autogen/sl_power_manager_handler.c&quot;,&quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;,&quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;,&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;autogen/sli_psa_config_autogen.h&quot;,&quot;autogen/zigbee_af_token_headers.h&quot;,&quot;autogen/zigbee_common_callback_dispatcher.c&quot;,&quot;autogen/zigbee_common_callback_dispatcher.h&quot;,&quot;autogen/zigbee_ncp_callback_dispatcher.c&quot;,&quot;autogen/zigbee_ncp_callback_dispatcher.h&quot;,&quot;autogen/zigbee_stack_callback_dispatcher.c&quot;,&quot;autogen/zigbee_stack_callback_dispatcher.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;app.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_endianness.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_slist.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_string.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_slist.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_string.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/inc/dmadrv.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/src/dmadrv.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/indirect-queue.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/lower-mac-debug.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/lower-mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-child.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-command.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-flat-header.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-header.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-multi-network.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-packet-header.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-phy.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/mac-types.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/multi-mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/rail_mux/sl_rail_mux.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/rail_mux/sl_rail_mux_rename.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/scan.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/mac/upper-mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg2x/rail_chip_specific.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/sl_rail_util_pa_curves.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ant_div/sl_rail_util_ant_div.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ant_div/sl_rail_util_ant_div.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_phy_select.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_stack_event.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sli_psa_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sli_psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_trng.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_debug.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_swo_itm_8.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_uart.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_vuart.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sli_iostream_swo_itm_8.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sli_iostream_uart.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_debug.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_swo_itm_8.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_uart.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_usart.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_vuart.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_common_ash/inc/ash-common.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_common_ash/inc/ash-protocol.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_common_ash/src/ash-common.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/asm.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/bootloader-interface-app.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/bootloader-interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/button.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/cortexm3/diagnostic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/crc.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/efm32_micro.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/em2xx-reset-defs.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/emlib_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/hal/hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/interrupts-efm32.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/led.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-common.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-types.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/platform-header.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/random.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/reset-def.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/serial.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/serial/serial.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/sl_legacy_hal_integration_hooks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/token-manufacturing-series-1.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/token-manufacturing-series-2.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/token-manufacturing.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/base-replacement.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/crc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/diagnostic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/ember-phy.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/faults.s&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/random.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/token_legacy.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal_wdog/inc/sl_legacy_hal_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal_wdog/src/sl_legacy_hal_wdog.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_ncp_ash/inc/ash-ncp.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_ncp_ash/src/ash-ncp.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_printf/inc/sl_legacy_printf.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_printf/src/sl_legacy_printf.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager_debug.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sli_power_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_debug.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_hal_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sli_power_manager_private.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_api.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manager_af_token_header.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_api.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_series_1.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_series_2.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_def.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_manufacturing.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_manufacturing_generic.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-context.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-binding-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-binding.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-cbke.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-green-power-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-messaging-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-mfglib-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-mfglib.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-networking-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-security-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-security.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-token-interface-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-token-interface.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-trust-center-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-zigbee-pro.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-zll-generated.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-zll.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/em260-callbacks.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/em260-common.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/ncp-stack-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/serial-interface-uart.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/serial-interface.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_callback.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_common.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_common.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_event.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_sleep.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_stack_cb.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_enhanced_routing.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_ncp_framework_cb.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_token_interface.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_token_interface_stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/plugin/debug-print/sl_zigbee_debug_print.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/plugin/debug-print/sl_zigbee_debug_print.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/util/af-ncp-token.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/ezsp/ezsp-enum.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/ezsp/ezsp-frame-utilities.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/ezsp/ezsp-protocol.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/security/security-address-cache.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/security/security.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/xncp/xncp-stubs.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/app/xncp/xncp.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/ember-configuration-access.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/ember-configuration-defaults.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/ember-configuration.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/token-phy.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/token-stack.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/ember-multi-network-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/ember-multi-network.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan-common.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan-token-config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/aes-ecb.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/strong-random-api.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/zigbee-debug-extended.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/zigbee-event-logger-stub-gen.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/zigbee_debug_channel.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/gp/gp-proxy-table.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/gp/gp-sink-table.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/gp/gp-token-config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/aes-mmo.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/binding-table.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/bootload.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/byte-utilities.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/cbke-crypto-engine.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/child.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-alternate-mac.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-debug.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-duty-cycle.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-random-api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-types-internal.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-types.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/error-def.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/error.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/gp-types.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/library.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/mac-layer.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/message.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/mfglib.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/multi-network.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/multi-phy.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/network-formation.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/raw-message.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/security.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/sl_zigbee_address_info.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/sl_zigbee_dynamic_commissioning.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/sl_zigbee_tlv_core.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/source-route.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/stack-info.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/trust-center.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-device-stack.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-event-logger-gen.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-security-manager-types.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-security-manager.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zll-api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zll-types.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/mac/multi-mac.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/platform/micro/aes.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-163k1-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-283k1-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-dsa-sign-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-dsa-verify-283k1-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-dsa-verify-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-stub.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager-internal.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager-no-vault.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager-vault-support.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/stubs/sl_zigbee_dynamic_commissioning_stubs.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/stubs/sl_zigbee_fragmentation_stubs.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/stubs/sl_zigbee_r23_misc_support_stubs.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/aps-keys-full.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/aps-keys-full.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/sli_zigbee_zdo_cluster_filter.c&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/sli_zigbee_zdo_cluster_filter.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/source-route-table-update.h&quot;,&quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zll/zll-token-config.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/buffer_manager/buffer-management.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/buffer_manager/buffer-queue.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/buffer_manager/legacy-packet-buffer.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/event_queue/event-queue.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/check_crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_its.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_random_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/printf/inc/iostream_printf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/printf/printf.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/printf/printf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/printf/src/iostream_printf.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/segger/systemview/SEGGER/SEGGER.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.h&quot;,&quot;main.c&quot;,&quot;readme.html&quot;,&quot;sl_zigbee_watchdog_periodic_refresh.c&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {
+            &quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;: &quot;&lt;sl_rail_util_pa_config.h&gt;&quot;, 
+            &quot;CORTEXM3_EFM32_MICRO&quot;: &quot;1&quot;, 
+            &quot;SL_ZIGBEE_PHY_SELECT_STACK_SUPPORT&quot;: &quot;1&quot;, 
+            &quot;SL_BOARD_REV&quot;: &quot;\&quot;A05\&quot;&quot;, 
+            &quot;CORTEXM3&quot;: &quot;1&quot;, 
+            &quot;PLATFORM_HEADER&quot;: &quot;\&quot;platform-header.h\&quot;&quot;, 
+            &quot;SEGGER_RTT_SECTION&quot;: &quot;\&quot;SEGGER_RTT\&quot;&quot;, 
+            &quot;SEGGER_RTT_ALIGNMENT&quot;: &quot;1024&quot;, 
+            &quot;EMBER_AF_NCP&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;EMBER_CUSTOM_MAC_FILTER_TABLE_SIZE&quot;: &quot;15&quot;, 
+            &quot;SL_COMPONENT_CATALOG_PRESENT&quot;: &quot;1&quot;, 
+            &quot;USE_NVM3&quot;: &quot;1&quot;, 
+            &quot;HFXO_FREQ&quot;: &quot;38400000&quot;, 
+            &quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;: &quot;0&quot;, 
+            &quot;CUSTOM_TOKEN_HEADER&quot;: &quot;\&quot;sl_token_manager_af_token_header.h\&quot;&quot;, 
+            &quot;PHY_RAIL&quot;: &quot;1&quot;, 
+            &quot;EMBER_MULTI_NETWORK_STRIPPED&quot;: &quot;1&quot;, 
+            &quot;SL_LEGACY_HAL_ENABLE_WATCHDOG&quot;: &quot;1&quot;, 
+            &quot;SL_BOARD_NAME&quot;: &quot;\&quot;BRD4179B\&quot;&quot;, 
+            &quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;: &quot;&lt;psa_crypto_config.h&gt;&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;: &quot;1&quot;, 
+            &quot;UC_BUILD&quot;: &quot;1&quot;, 
+            &quot;CORTEXM3_EFR32&quot;: &quot;1&quot;, 
+            &quot;EMBER_SERIAL1_RTSCTS&quot;: &quot;1&quot;, 
+            &quot;EFR32MG21A010F1024IM32&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;MBEDTLS_CONFIG_FILE&quot;: &quot;&lt;sl_mbedtls_config.h&gt;&quot;, 
+            &quot;RTT_USE_ASM&quot;: &quot;0&quot;, 
+            &quot;EZSP_UART&quot;: &quot;1&quot;, 
+            &quot;SL_APP_PROPERTIES&quot;: &quot;1&quot;, 
+            &quot;SL_ZIGBEE_STACK_COMPLIANCE_REVISION&quot;: &quot;22&quot;
+        }, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [
+            &quot;gcc&quot;, 
+            &quot;c&quot;, 
+            &quot;m&quot;, 
+            &quot;nosys&quot;
+        ], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Wno-unused-parameter\&quot;,
+
+\&quot;-mcmse\&quot;,
+
+\&quot;-fno-builtin-sprintf\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;,
+
+\&quot;-fno-builtin-printf\&quot;,
+
+\&quot;-Wno-missing-braces\&quot;,
+
+\&quot;-Wno-missing-field-initializers\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wno-unused-parameter\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fno-builtin-sprintf\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fno-builtin-printf\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-missing-braces\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-missing-field-initializers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wno-unused-parameter\&quot;,
+
+\&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;,
+
+\&quot;-Wno-missing-braces\&quot;,
+
+\&quot;-Wno-missing-field-initializers\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wno-unused-parameter\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-missing-braces\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-missing-field-initializers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,
+
+\&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;config/SEGGER_RTT_Conf.h&quot;, 
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+            &quot;config/dmadrv_config.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/legacy_common_ash_config.h&quot;, 
+            &quot;config/legacy_hal_config.h&quot;, 
+            &quot;config/nvm3_default_config.h&quot;, 
+            &quot;config/psa_crypto_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_custom_manufacturing_token_header.h&quot;, 
+            &quot;config/sl_custom_token_header.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfrco_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_device_init_lfxo_config.h&quot;, 
+            &quot;config/sl_iostream_usart_vcom_config.h&quot;, 
+            &quot;config/sl_iostream_vuart_config.h&quot;, 
+            &quot;config/sl_legacy_hal_wdog_config.h&quot;, 
+            &quot;config/sl_mbedtls_config.h&quot;, 
+            &quot;config/sl_mbedtls_device_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;, 
+            &quot;config/sl_power_manager_config.h&quot;, 
+            &quot;config/sl_rail_util_pa_config.h&quot;, 
+            &quot;config/sl_rail_util_power_manager_init_config.h&quot;, 
+            &quot;config/sl_rail_util_pti_config.h&quot;, 
+            &quot;config/sl_rail_util_rf_path_config.h&quot;, 
+            &quot;config/sl_sleeptimer_config.h&quot;, 
+            &quot;config/sl_token_manager_config.h&quot;, 
+            &quot;config/sl_zigbee_debug_print_config.h&quot;, 
+            &quot;config/sl_zigbee_green_power_config.h&quot;, 
+            &quot;config/sl_zigbee_light_link_config.h&quot;, 
+            &quot;config/sl_zigbee_pro_stack_config.h&quot;, 
+            &quot;config/sl_zigbee_security_link_keys_config.h&quot;, 
+            &quot;config/sl_zigbee_source_route_config.h&quot;, 
+            &quot;config/zigbee_sleep_config.h&quot;, 
+            &quot;config/zigbee_watchdog_periodic_refresh_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;, 
+            &quot;autogen/sl_iostream_handles.c&quot;, 
+            &quot;autogen/sl_iostream_handles.h&quot;, 
+            &quot;autogen/sl_iostream_init_instances.h&quot;, 
+            &quot;autogen/sl_iostream_init_usart_instances.c&quot;, 
+            &quot;autogen/sl_iostream_init_usart_instances.h&quot;, 
+            &quot;autogen/sl_power_manager_handler.c&quot;, 
+            &quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;, 
+            &quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;, 
+            &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+            &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+            &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+            &quot;autogen/sli_psa_config_autogen.h&quot;, 
+            &quot;autogen/zigbee_af_token_headers.h&quot;, 
+            &quot;autogen/zigbee_common_callback_dispatcher.c&quot;, 
+            &quot;autogen/zigbee_common_callback_dispatcher.h&quot;, 
+            &quot;autogen/zigbee_ncp_callback_dispatcher.c&quot;, 
+            &quot;autogen/zigbee_ncp_callback_dispatcher.h&quot;, 
+            &quot;autogen/zigbee_stack_callback_dispatcher.c&quot;, 
+            &quot;autogen/zigbee_stack_callback_dispatcher.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;app.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_endianness.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_slist.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_string.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_slist.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_string.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/inc/dmadrv.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/src/dmadrv.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/indirect-queue.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/lower-mac-debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/lower-mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-child.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-command.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-flat-header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-multi-network.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-packet-header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-phy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/mac-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/multi-mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/rail_mux/sl_rail_mux.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/rail_mux/sl_rail_mux_rename.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/scan.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/mac/upper-mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg2x/rail_chip_specific.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/sl_rail_util_pa_curves.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ant_div/sl_rail_util_ant_div.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ant_div/sl_rail_util_ant_div.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_phy_select.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_stack_event.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sli_psa_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sli_psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_trng.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_swo_itm_8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sl_iostream_vuart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sli_iostream_swo_itm_8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/inc/sli_iostream_uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_debug.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_swo_itm_8.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_usart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/iostream/src/sl_iostream_vuart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_common_ash/inc/ash-common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_common_ash/inc/ash-protocol.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_common_ash/src/ash-common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/asm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/bootloader-interface-app.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/bootloader-interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/button.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/cortexm3/diagnostic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/crc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/efm32_micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/em2xx-reset-defs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/emlib_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/hal/hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/interrupts-efm32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/led.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/platform-header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/random.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/reset-def.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/serial.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/serial/serial.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/sl_legacy_hal_integration_hooks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/token-manufacturing-series-1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/token-manufacturing-series-2.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/token-manufacturing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/base-replacement.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/crc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/diagnostic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/ember-phy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/faults.s&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/random.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/token_legacy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal_wdog/inc/sl_legacy_hal_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal_wdog/src/sl_legacy_hal_wdog.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_ncp_ash/inc/ash-ncp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_ncp_ash/src/ash-ncp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_printf/inc/sl_legacy_printf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_printf/src/sl_legacy_printf.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager_debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sli_power_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_debug.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_hal_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sli_power_manager_private.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manager_af_token_header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_series_1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/inc/sl_token_manufacturing_series_2.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_def.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_manufacturing.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/token_manager/src/sl_token_manufacturing_generic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-binding-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-binding.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-cbke.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-green-power-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-messaging-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-mfglib-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-mfglib.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-networking-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-security-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-security.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-token-interface-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-token-interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-trust-center-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-zigbee-pro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-zll-generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/command-handlers-zll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/em260-callbacks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/em260-common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/ncp-stack-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/serial-interface-uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/em260/serial-interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_callback.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_event.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_sleep.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_app_framework_stack_cb.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_enhanced_routing.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_ncp_framework_cb.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_token_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/common/zigbee_token_interface_stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/plugin/debug-print/sl_zigbee_debug_print.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/plugin/debug-print/sl_zigbee_debug_print.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/framework/util/af-ncp-token.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/ezsp/ezsp-enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/ezsp/ezsp-frame-utilities.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/ezsp/ezsp-protocol.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/security/security-address-cache.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/util/security/security.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/xncp/xncp-stubs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/app/xncp/xncp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-gp-library/release_singlenetwork/libncp-gp-library.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-pro-library/release_singlenetwork/libncp-pro-library.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-source-route-library/release_singlenetwork/libncp-source-route-library.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-basic/release_singlenetwork/libzigbee-debug-basic.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-debug-extended/release_singlenetwork/libzigbee-debug-extended.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-gp/release_singlenetwork/libzigbee-gp.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-mfglib/release_singlenetwork/libzigbee-mfglib.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-pro-stack/release_singlenetwork/libzigbee-pro-stack.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-r22-support/release_singlenetwork/libzigbee-r22-support.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-source-route/release_singlenetwork/libzigbee-source-route.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/build/gcc/cortex-m33/zigbee-zll/release_singlenetwork/libzigbee-zll.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/ember-configuration-access.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/ember-configuration-defaults.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/ember-configuration.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/token-phy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/config/token-stack.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/ember-multi-network-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/ember-multi-network.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan-common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan-token-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/core/multi-pan.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/aes-ecb.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/strong-random-api.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/zigbee-debug-extended.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/zigbee-event-logger-stub-gen.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/framework/zigbee_debug_channel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/gp/gp-proxy-table.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/gp/gp-sink-table.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/gp/gp-token-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/aes-mmo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/binding-table.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/bootload.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/byte-utilities.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/cbke-crypto-engine.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/child.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-alternate-mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-duty-cycle.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-random-api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-types-internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/ember.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/error-def.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/gp-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/library.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/mac-layer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/message.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/mfglib.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/multi-network.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/multi-phy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/network-formation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/raw-message.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/security.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/sl_zigbee_address_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/sl_zigbee_dynamic_commissioning.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/sl_zigbee_tlv_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/source-route.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/stack-info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/trust-center.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-device-stack.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-event-logger-gen.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-security-manager-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zigbee-security-manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zll-api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/include/zll-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/mac/multi-mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/platform/micro/aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-163k1-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-283k1-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-dsa-sign-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-dsa-verify-283k1-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-dsa-verify-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/cbke-crypto-engine-stub.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager-internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager-no-vault.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager-vault-support.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/security/zigbee-security-manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/stubs/sl_zigbee_dynamic_commissioning_stubs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/stubs/sl_zigbee_fragmentation_stubs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/stubs/sl_zigbee_r23_misc_support_stubs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/aps-keys-full.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/aps-keys-full.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/sli_zigbee_zdo_cluster_filter.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/sli_zigbee_zdo_cluster_filter.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zigbee/source-route-table-update.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/zigbee/stack/zll/zll-token-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/buffer_manager/buffer-management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/buffer_manager/buffer-queue.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/buffer_manager/legacy-packet-buffer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/event_queue/event-queue.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/check_crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_its.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_random_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/printf/inc/iostream_printf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/printf/printf.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/printf/printf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/printf/src/iostream_printf.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/segger/systemview/SEGGER/SEGGER.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.h&quot;, 
+            &quot;main.c&quot;, 
+            &quot;readme.html&quot;, 
+            &quot;sl_zigbee_watchdog_periodic_refresh.c&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Default" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe" postbuildStep="../../../tools/create_gbl.py postbuild &quot;${workspace_loc:/${ProjName}}/${ProjName}.slpb&quot; --parameter build_dir:&quot;${workspace_loc:/${ProjName}/${ConfigName}}&quot; --parameter sdk_dir:&quot;${StudioSdkPath}&quot;">
 					<folderInfo id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -515,7 +2148,512 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
-	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="32" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1660574726},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;main.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:556158389},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;readme.html&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1061452483},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;sl_zigbee_watchdog_periodic_refresh.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1014650037},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/.crc_config.crc&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1013323439},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/RTE_Components.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-753128665},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/linkerfile.ld&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1707743586},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_application_type.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1715270780},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_board_default_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1764316703},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_component_catalog.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:678533625},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_device_init_clocks.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-158784453},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-740693164},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1086505909},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_iostream_handles.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2074343864},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_iostream_handles.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1918296760},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_iostream_init_instances.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1489781933},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_iostream_init_usart_instances.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1576392349},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_iostream_init_usart_instances.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1772890704},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_power_manager_handler.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:101316260},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1906064707},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1123279099},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-2032949495},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1799123423},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-460465170},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-170329886},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_af_token_headers.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1893072452},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_common_callback_dispatcher.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1763407247},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_common_callback_dispatcher.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1825851058},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_ncp_callback_dispatcher.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:141832512},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_ncp_callback_dispatcher.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1568362542},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_stack_callback_dispatcher.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1364497267},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/zigbee_stack_callback_dispatcher.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:631221060},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/SEGGER_RTT_Conf.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1609024748},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/app_properties_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:464657923},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:675916386},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1462694363},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/dmadrv_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-79062493},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/emlib_core_debug_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-78822137},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/legacy_common_ash_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1901763695},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/legacy_hal_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1515095883},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/nvm3_default_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-155805239},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/psa_crypto_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:361377680},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_board_control_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1316174372},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_custom_manufacturing_token_header.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1951957043},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_custom_token_header.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-188329699},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_debug_swo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-367262434},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_emu_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1488208825},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:92619244},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:977362596},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-960917308},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_iostream_usart_vcom_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:464255961},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_iostream_vuart_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:826125987},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_legacy_hal_wdog_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1239008106},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1637757762},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_device_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1138397796},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_memory_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:989839506},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_power_manager_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:467325263},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pa_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-623975504},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_power_manager_init_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:593561233},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pti_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-310135592},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_rf_path_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-437119590},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_sleeptimer_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1204146860},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_token_manager_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:935209795},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_zigbee_debug_print_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-901396548},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_zigbee_green_power_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1259407358},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_zigbee_light_link_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-206749819},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_zigbee_pro_stack_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-45239357},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_zigbee_security_link_keys_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-719301110},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_zigbee_source_route_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:401653799},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zigbee_sleep_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1375973860},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zigbee_watchdog_periodic_refresh_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1362455274},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;ncp-uart-hw.slpb&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1997366034}]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="32" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1660574726
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;main.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 556158389
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;readme.html&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1061452483
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;sl_zigbee_watchdog_periodic_refresh.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1014650037
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/.crc_config.crc&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1013323439
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/RTE_Components.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -753128665
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/linkerfile.ld&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1707743586
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_application_type.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1715270780
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_board_default_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1764316703
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_component_catalog.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 678533625
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_device_init_clocks.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -158784453
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -740693164
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1086505909
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_iostream_handles.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2074343864
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_iostream_handles.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1918296760
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_iostream_init_instances.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1489781933
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_iostream_init_usart_instances.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1576392349
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_iostream_init_usart_instances.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1772890704
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_power_manager_handler.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 101316260
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1906064707
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1123279099
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -2032949495
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1799123423
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -460465170
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -170329886
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_af_token_headers.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1893072452
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_common_callback_dispatcher.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1763407247
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_common_callback_dispatcher.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1825851058
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_ncp_callback_dispatcher.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 141832512
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_ncp_callback_dispatcher.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1568362542
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_stack_callback_dispatcher.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1364497267
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/zigbee_stack_callback_dispatcher.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 631221060
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/SEGGER_RTT_Conf.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1609024748
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/app_properties_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 464657923
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 675916386
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1462694363
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/dmadrv_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -79062493
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/emlib_core_debug_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -78822137
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/legacy_common_ash_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1901763695
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/legacy_hal_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1515095883
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/nvm3_default_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -155805239
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/psa_crypto_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 361377680
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_board_control_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1316174372
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_custom_manufacturing_token_header.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1951957043
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_custom_token_header.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -188329699
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_debug_swo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -367262434
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_emu_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1488208825
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfrco_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 92619244
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 977362596
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_lfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -960917308
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_iostream_usart_vcom_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 464255961
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_iostream_vuart_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 826125987
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_legacy_hal_wdog_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1239008106
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1637757762
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_device_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1138397796
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_memory_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 989839506
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_power_manager_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 467325263
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pa_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -623975504
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_power_manager_init_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 593561233
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pti_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -310135592
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_rf_path_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -437119590
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_sleeptimer_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1204146860
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_token_manager_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 935209795
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_zigbee_debug_print_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -901396548
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_zigbee_green_power_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1259407358
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_zigbee_light_link_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -206749819
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_zigbee_pro_stack_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -45239357
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_zigbee_security_link_keys_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -719301110
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_zigbee_source_route_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 401653799
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zigbee_sleep_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1375973860
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zigbee_watchdog_periodic_refresh_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1362455274
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;ncp-uart-hw.slpb&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1997366034
+    }
+]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="ncp-uart-hw.com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType.1515587568" name="SLS CDT Project" projectType="com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType"/>
 	</storageModule>

--- a/src/ncp-uart-hw/.cproject
+++ b/src/ncp-uart-hw/.cproject
@@ -69,8 +69,232 @@
         ], 
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
-        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/ studio:/project/config/ studio:/project/autogen/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/service/iostream/inc/ studio:/sdk/platform/service/legacy_common_ash/inc/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/platform/service/legacy_hal_wdog/inc/ studio:/sdk/platform/service/legacy_ncp_ash/inc/ studio:/sdk/platform/service/legacy_printf/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/util/third_party/printf/ studio:/sdk/util/third_party/printf/inc/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/third_party/segger/systemview/SEGGER/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/service/token_manager/inc/ studio:/sdk/protocol/zigbee/app/framework/common/ studio:/sdk/protocol/zigbee/stack/platform/micro/ studio:/sdk/protocol/zigbee/stack/framework/ studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/ studio:/sdk/protocol/zigbee/stack/include/ studio:/sdk/protocol/zigbee/stack/gp/ studio:/sdk/protocol/zigbee/app/em260/ studio:/sdk/protocol/zigbee/app/xncp/ studio:/sdk/protocol/zigbee/app/util/ezsp/ studio:/sdk/protocol/zigbee/app/framework/util/ studio:/sdk/protocol/zigbee/app/util/security/ studio:/sdk/protocol/zigbee/stack/zigbee/ studio:/sdk/protocol/zigbee/stack/security/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/protocol/zigbee/ studio:/sdk/protocol/zigbee/stack/ studio:/sdk/platform/radio/mac/rail_mux/ studio:/sdk/platform/radio/mac/ studio:/sdk/util/silicon_labs/silabs_core/ studio:/sdk/protocol/zigbee/stack/core/ studio:/sdk/protocol/zigbee/stack/mac/ studio:/sdk/protocol/zigbee/stack/zll/&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Wno-unused-parameter\&quot;,
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/
+studio:/project/autogen/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/service/iostream/inc/
+studio:/sdk/platform/service/legacy_common_ash/inc/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/platform/service/legacy_hal_wdog/inc/
+studio:/sdk/platform/service/legacy_ncp_ash/inc/
+studio:/sdk/platform/service/legacy_printf/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/platform/service/power_manager/inc/
+studio:/sdk/util/third_party/printf/
+studio:/sdk/util/third_party/printf/inc/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/third_party/segger/systemview/SEGGER/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/service/token_manager/inc/
+studio:/sdk/protocol/zigbee/app/framework/common/
+studio:/sdk/protocol/zigbee/stack/platform/micro/
+studio:/sdk/protocol/zigbee/stack/framework/
+studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/
+studio:/sdk/protocol/zigbee/stack/include/
+studio:/sdk/protocol/zigbee/stack/gp/
+studio:/sdk/protocol/zigbee/app/em260/
+studio:/sdk/protocol/zigbee/app/xncp/
+studio:/sdk/protocol/zigbee/app/util/ezsp/
+studio:/sdk/protocol/zigbee/app/framework/util/
+studio:/sdk/protocol/zigbee/app/util/security/
+studio:/sdk/protocol/zigbee/stack/zigbee/
+studio:/sdk/protocol/zigbee/stack/security/
+studio:/sdk/platform/radio/rail_lib/plugin/
+studio:/sdk/protocol/zigbee/
+studio:/sdk/protocol/zigbee/stack/
+studio:/sdk/platform/radio/mac/rail_mux/
+studio:/sdk/platform/radio/mac/
+studio:/sdk/util/silicon_labs/silabs_core/
+studio:/sdk/protocol/zigbee/stack/core/
+studio:/sdk/protocol/zigbee/stack/mac/
+studio:/sdk/protocol/zigbee/stack/zll/
+studio:/project/config/
+studio:/project/autogen/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/service/iostream/inc/
+studio:/sdk/platform/service/legacy_common_ash/inc/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/platform/service/legacy_hal_wdog/inc/
+studio:/sdk/platform/service/legacy_ncp_ash/inc/
+studio:/sdk/platform/service/legacy_printf/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/platform/service/power_manager/inc/
+studio:/sdk/util/third_party/printf/
+studio:/sdk/util/third_party/printf/inc/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/third_party/segger/systemview/SEGGER/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/service/token_manager/inc/
+studio:/sdk/protocol/zigbee/app/framework/common/
+studio:/sdk/protocol/zigbee/stack/platform/micro/
+studio:/sdk/protocol/zigbee/stack/framework/
+studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/
+studio:/sdk/protocol/zigbee/stack/include/
+studio:/sdk/protocol/zigbee/stack/gp/
+studio:/sdk/protocol/zigbee/app/em260/
+studio:/sdk/protocol/zigbee/app/xncp/
+studio:/sdk/protocol/zigbee/app/util/ezsp/
+studio:/sdk/protocol/zigbee/app/framework/util/
+studio:/sdk/protocol/zigbee/app/util/security/
+studio:/sdk/protocol/zigbee/stack/zigbee/
+studio:/sdk/protocol/zigbee/stack/security/
+studio:/sdk/platform/radio/rail_lib/plugin/
+studio:/sdk/protocol/zigbee/
+studio:/sdk/protocol/zigbee/stack/
+studio:/sdk/platform/radio/mac/rail_mux/
+studio:/sdk/platform/radio/mac/
+studio:/sdk/util/silicon_labs/silabs_core/
+studio:/sdk/protocol/zigbee/stack/core/
+studio:/sdk/protocol/zigbee/stack/mac/
+studio:/sdk/protocol/zigbee/stack/zll/
+studio:/project/config/
+studio:/project/autogen/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/service/iostream/inc/
+studio:/sdk/platform/service/legacy_common_ash/inc/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/platform/service/legacy_hal_wdog/inc/
+studio:/sdk/platform/service/legacy_ncp_ash/inc/
+studio:/sdk/platform/service/legacy_printf/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/platform/service/power_manager/inc/
+studio:/sdk/util/third_party/printf/
+studio:/sdk/util/third_party/printf/inc/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/third_party/segger/systemview/SEGGER/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/service/token_manager/inc/
+studio:/sdk/protocol/zigbee/app/framework/common/
+studio:/sdk/protocol/zigbee/stack/platform/micro/
+studio:/sdk/protocol/zigbee/stack/framework/
+studio:/sdk/protocol/zigbee/app/framework/plugin/debug-print/
+studio:/sdk/protocol/zigbee/stack/include/
+studio:/sdk/protocol/zigbee/stack/gp/
+studio:/sdk/protocol/zigbee/app/em260/
+studio:/sdk/protocol/zigbee/app/xncp/
+studio:/sdk/protocol/zigbee/app/util/ezsp/
+studio:/sdk/protocol/zigbee/app/framework/util/
+studio:/sdk/protocol/zigbee/app/util/security/
+studio:/sdk/protocol/zigbee/stack/zigbee/
+studio:/sdk/protocol/zigbee/stack/security/
+studio:/sdk/platform/radio/rail_lib/plugin/
+studio:/sdk/protocol/zigbee/
+studio:/sdk/protocol/zigbee/stack/
+studio:/sdk/platform/radio/mac/rail_mux/
+studio:/sdk/platform/radio/mac/
+studio:/sdk/util/silicon_labs/silabs_core/
+studio:/sdk/protocol/zigbee/stack/core/
+studio:/sdk/protocol/zigbee/stack/mac/
+studio:/sdk/protocol/zigbee/stack/zll/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wno-unused-parameter\&quot;,
 
 \&quot;-mcmse\&quot;,
 
@@ -86,7 +310,9 @@
 
 \&quot;-Wno-missing-braces\&quot;,
 
-\&quot;-Wno-missing-field-initializers\&quot;\n        ],
+\&quot;-Wno-missing-field-initializers\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -96,7 +322,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wno-unused-parameter\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Wno-unused-parameter\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
 
@@ -112,9 +340,19 @@
 
 \&quot;-Wno-missing-braces\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-Wno-missing-field-initializers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-Wno-missing-field-initializers\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -124,9 +362,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wno-unused-parameter\&quot;,
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wno-unused-parameter\&quot;,
 
 \&quot;-mcmse\&quot;,
 
@@ -138,7 +386,9 @@
 
 \&quot;-Wno-missing-braces\&quot;,
 
-\&quot;-Wno-missing-field-initializers\&quot;\n        ],
+\&quot;-Wno-missing-field-initializers\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -148,7 +398,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wno-unused-parameter\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Wno-unused-parameter\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
 
@@ -160,9 +412,19 @@
 
 \&quot;-Wno-missing-braces\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-Wno-missing-field-initializers\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-Wno-missing-field-initializers\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -172,9 +434,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -184,9 +454,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -196,9 +470,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -208,9 +486,17 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -220,9 +506,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -232,9 +526,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -244,9 +542,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -256,9 +558,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -268,9 +574,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -280,9 +590,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -292,9 +606,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -304,9 +622,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -316,9 +642,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -328,9 +662,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -340,9 +678,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -352,9 +694,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -364,9 +710,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -376,9 +726,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -388,9 +742,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -400,9 +758,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -412,9 +774,13 @@
 
 \&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -424,9 +790,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -436,9 +806,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -448,9 +822,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -460,9 +838,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -472,9 +854,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -484,9 +870,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -496,9 +886,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -508,9 +902,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -520,9 +918,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -532,9 +934,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -544,9 +954,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -556,9 +974,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -568,9 +990,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -580,9 +1006,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -592,9 +1022,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -604,9 +1038,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -616,9 +1054,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -628,9 +1070,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -640,9 +1086,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -652,9 +1102,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -664,9 +1118,15 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;,
 
@@ -696,7 +1156,9 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -706,7 +1168,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;: \&quot;TRUE\&quot;,
 
@@ -736,9 +1200,15 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -748,9 +1218,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -760,9 +1234,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -772,9 +1250,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -784,9 +1266,15 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;,
 
@@ -816,7 +1304,9 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -826,7 +1316,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/zigbee-ncp-uart/release_singlenetwork/libzigbee-ncp-uart.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-zll-library/release_singlenetwork/libncp-zll-library.a\&quot;: \&quot;TRUE\&quot;,
 
@@ -856,21 +1348,27 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+\&quot;${StudioSdkPath}/protocol/zigbee/build/gcc/cortex-m33/ncp-mfglib-library/release_singlenetwork/libncp-mfglib-library.a\&quot;: \&quot;TRUE\&quot;
+
+}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -917,7 +1415,7 @@
             &quot;config/zigbee_sleep_config.h&quot;, 
             &quot;config/zigbee_watchdog_periodic_refresh_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -952,7 +1450,7 @@
             &quot;autogen/zigbee_stack_callback_dispatcher.c&quot;, 
             &quot;autogen/zigbee_stack_callback_dispatcher.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1637,14 +2135,14 @@
             &quot;readme.html&quot;, 
             &quot;sl_zigbee_watchdog_periodic_refresh.c&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1653,7 +2151,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>

--- a/src/ot-rcp/.cproject
+++ b/src/ot-rcp/.cproject
@@ -23,7 +23,1782 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{&quot;OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE&quot;:&quot;0&quot;,&quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;:&quot;&lt;sl_rail_util_pa_config.h&gt;&quot;,&quot;CORTEXM3_EFM32_MICRO&quot;:&quot;1&quot;,&quot;SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE&quot;:&quot;\&quot;sl_openthread_features_config.h\&quot;&quot;,&quot;SL_BOARD_REV&quot;:&quot;\&quot;A05\&quot;&quot;,&quot;OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS&quot;:&quot;0&quot;,&quot;OPENTHREAD_ENABLE_VENDOR_EXTENSION&quot;:&quot;1&quot;,&quot;OPENTHREAD_PROJECT_CORE_CONFIG_FILE&quot;:&quot;\&quot;openthread-core-efr32-config.h\&quot;&quot;,&quot;CORTEXM3&quot;:&quot;1&quot;,&quot;SLI_RADIOAES_REQUIRES_MASKING&quot;:&quot;1&quot;,&quot;PLATFORM_HEADER&quot;:&quot;\&quot;platform-header.h\&quot;&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;:&quot;1&quot;,&quot;SL_COMPONENT_CATALOG_PRESENT&quot;:&quot;1&quot;,&quot;OPENTHREAD_RADIO&quot;:&quot;1&quot;,&quot;HFXO_FREQ&quot;:&quot;38400000&quot;,&quot;SPINEL_PLATFORM_HEADER&quot;:&quot;\&quot;spinel_platform.h\&quot;&quot;,&quot;_GNU_SOURCE&quot;:&quot;1&quot;,&quot;OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE&quot;:&quot;\&quot;openthread-core-efr32-config-check.h\&quot;&quot;,&quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;:&quot;0&quot;,&quot;OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE&quot;:&quot;0&quot;,&quot;OPENTHREAD_CONFIG_DEFAULT_TRANSMIT_POWER&quot;:&quot;6&quot;,&quot;PHY_RAIL&quot;:&quot;1&quot;,&quot;OPENTHREAD_CONFIG_FILE&quot;:&quot;\&quot;sl_openthread_generic_config.h\&quot;&quot;,&quot;SL_BOARD_NAME&quot;:&quot;\&quot;BRD4179B\&quot;&quot;,&quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;:&quot;&lt;psa_crypto_config.h&gt;&quot;,&quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;:&quot;1&quot;,&quot;CORTEXM3_EFR32&quot;:&quot;1&quot;,&quot;EFR32MG21A010F1024IM32&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;:&quot;1&quot;,&quot;MBEDTLS_CONFIG_FILE&quot;:&quot;&lt;sl_mbedtls_config.h&gt;&quot;,&quot;SL_APP_PROPERTIES&quot;:&quot;1&quot;},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[&quot;stdc++&quot;,&quot;gcc&quot;,&quot;c&quot;,&quot;m&quot;,&quot;nosys&quot;],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[\&quot;-Werror=unused-function\&quot;,\&quot;-Werror=unused-variable\&quot;,\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Werror=unused-function\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror=unused-variable\&quot;:\&quot;TRUE\&quot;,\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Werror=unused-function\&quot;,\&quot;-Werror=unused-variable\&quot;,\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Werror=unused-function\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror=unused-variable\&quot;:\&quot;TRUE\&quot;,\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,\&quot;value\&quot;:\&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.c.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.cpp.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;:\&quot;TRUE\&quot;}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;config/dmadrv_config.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/nvm3_default_config.h&quot;,&quot;config/psa_crypto_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;config/sl_mbedtls_config.h&quot;,&quot;config/sl_mbedtls_device_config.h&quot;,&quot;config/sl_memory_config.h&quot;,&quot;config/sl_openthread_features_config.h&quot;,&quot;config/sl_openthread_generic_config.h&quot;,&quot;config/sl_rail_util_pa_config.h&quot;,&quot;config/sl_rail_util_pti_config.h&quot;,&quot;config/sl_rail_util_rf_path_config.h&quot;,&quot;config/sl_rail_util_rssi_config.h&quot;,&quot;config/sl_sleeptimer_config.h&quot;,&quot;config/sl_uartdrv_usart_vcom_config.h&quot;,&quot;config/uartdrv_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;,&quot;autogen/sl_ot_init.c&quot;,&quot;autogen/sl_ot_init.h&quot;,&quot;autogen/sl_uartdrv_init.c&quot;,&quot;autogen/sl_uartdrv_instances.h&quot;,&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;autogen/sli_psa_config_autogen.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;README-OT-RCP.md&quot;,&quot;app.c&quot;,&quot;app.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/inc/dmadrv.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/src/dmadrv.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/inc/gpiointerrupt.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/uartdrv/inc/uartdrv.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/uartdrv/src/uartdrv.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg2x/rail_chip_specific.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/sl_rail_util_pa_curves.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sli_psa_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ccm.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_cmac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ecdsa_ecdh.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_sha.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_jpake.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_entropy_hardware.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sli_psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/error.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/internal_trusted_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/sli_internal_trusted_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sl_psa_its_nvm3.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_trng.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/asm.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/cortexm3/diagnostic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/efm32_micro.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-common.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-types.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/platform-header.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/reset-def.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/faults.s&quot;,&quot;gecko_sdk_4.4.3/platform/service/mpu/inc/sl_mpu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/mpu/src/sl_mpu.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/alarm.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/board_config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/crypto.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/entropy.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/flash.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.hpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154mac.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/memory.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/misc.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config-check.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-band.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-efr32.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio_extension.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/rail_config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_openthread.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_packet_utils.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/startup-gcc.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/system.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/uartdrv_uart.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_counters.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_extension.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/core/vendor_extension.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/crash_handler.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/diagnostic.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/include/crash_handler.h&quot;,&quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.c&quot;,&quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/aes.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1parse.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1write.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ccm.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/check_crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cmac.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ctr_drbg.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecdsa.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecjpake.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves_new.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/hmac_drbg.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/oid.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pem.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkparse.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_its.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_random_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/sha256.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cache.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ciphersuites.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cookie.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers_generated.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_msg.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ticket.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_server.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_create.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crl.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crt.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_csr.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_crt.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_csr.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/apps/ncp/ncp.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/openthread-system.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/code_utils.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/debug_uart.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings_ram.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router_ftd.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_agent.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_routing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_monitor.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/child_supervision.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/cli.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap_secure.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/commissioner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_ftd.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_updater.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dnssd_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/heap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/history_tracker.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/icmp6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/instance.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ip6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/jam_detection.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/joiner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_metrics.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/logging.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/mesh_diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/message.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/multi_radio.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/nat64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ncp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata_publisher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdiag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/network_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ping_sender.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-micro.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-milli.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/border_routing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/debug_uart.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dns.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dso_transport.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/entropy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/flash.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/infra_if.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/logging.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/memory.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/messagepool.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/otns.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/radio.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/settings.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/spi-slave.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/toolchain.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/trel.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/udp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/radio_stats.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_noncrypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/sntp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client_buffers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tasklet.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp_ext.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread_ftd.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/trel.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/udp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/diags_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/error_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/instance_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/link_raw_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/logging_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/random_noncrypto_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/tasklet_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/backbone_tmf.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_leader.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_local.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/multicast_listeners_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/ndproxy_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/infra_if.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/routing_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_message.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_secure.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/appender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/arg_macros.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/array.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/as_core_type.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/bit_vector.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/callback.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/clearable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/code_utils.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/const_cast.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/crc16.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/debug.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/encoding.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/equatable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_allocatable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_array.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_string.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/iterator_utils.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/linked_list.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator_getters.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/logging.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/message.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/new.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/non_copyable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/notifier.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/num_utils.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/numeric_limits.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owned_ptr.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owning_list.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/pool.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/preference.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/ptr_wrapper.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/retain_ptr.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/serial_number.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings_driver.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time_ticker.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/trickle_timer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/type_traits.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/announce_sender.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/backbone_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_agent.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_routing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_monitor.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/child_supervision.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/coap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/commissioner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dataset_updater.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_dso.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dnssd_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dtls.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/history_tracker.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ip6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/joiner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_metrics_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_quality.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/logging.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_forwarder.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mle.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/nat64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/netdata_publisher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/network_diagnostic.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/openthread-core-config-check.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/parent_search.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ping_sender.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/power_calibration.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/radio_link.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/sntp_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/time_sync.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/tmf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/context_size.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/crypto_platform.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/ecdsa.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hkdf_sha256.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hmac_sha256.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/mbedtls.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/sha256.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/extension.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/channel_mask.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_handler.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_filter.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_links.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac_callbacks.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/announce_begin_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/border_agent.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/commissioner.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_local.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_updater.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dtls.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/energy_scan_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/extended_panid.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner_router.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_leader.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/network_name.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/panid_query_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/timestamp.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/checksum.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_dso.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dnssd_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/icmp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip4_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_address.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_filter.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_headers.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_mpl.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nat64_translator.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd_agent.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/netif.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/sntp_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/socket.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6_ext.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/udp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/openthread-core-config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/max_power_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_callbacks.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_platform.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_interface.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_link.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_packet.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/address_resolver.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_begin_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/anycast_locator.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_mask.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_supervision.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/csl_tx_scheduler.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/discover_scanner.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/dua_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/energy_scan_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender_frame_context.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/key_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/lowpan.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mesh_forwarder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_router.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader_ftd.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_local.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_notifier.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_publisher.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_service.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/panid_query_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/radio_selector.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/src_match_controller.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_netif.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/time_sync_service.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/tmf.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/uri_paths.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/version.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_monitor.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/flash.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/heap.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/history_tracker.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/jam_detector.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/link_metrics_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/mesh_diag.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/otns.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/ping_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/slaac_address.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/srp_client_buffers.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/platform/exit_code.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/multi_frame_buffer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/openthread-spinel-config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel_metrics.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spi_frame.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encrypter.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_interface.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_dispatcher.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_ftd.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_mtd.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_radio.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc/cc_module.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/icmp_var.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/sys/queue.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_const.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fastopen.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fsm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_seq.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_timer.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_var.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/bitmap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/cbuf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/lbuf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/tcplp.h&quot;,&quot;main.c&quot;,&quot;reset_util.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {
+            &quot;OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE&quot;: &quot;0&quot;, 
+            &quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;: &quot;&lt;sl_rail_util_pa_config.h&gt;&quot;, 
+            &quot;CORTEXM3_EFM32_MICRO&quot;: &quot;1&quot;, 
+            &quot;SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE&quot;: &quot;\&quot;sl_openthread_features_config.h\&quot;&quot;, 
+            &quot;SL_BOARD_REV&quot;: &quot;\&quot;A05\&quot;&quot;, 
+            &quot;OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS&quot;: &quot;0&quot;, 
+            &quot;OPENTHREAD_ENABLE_VENDOR_EXTENSION&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_PROJECT_CORE_CONFIG_FILE&quot;: &quot;\&quot;openthread-core-efr32-config.h\&quot;&quot;, 
+            &quot;CORTEXM3&quot;: &quot;1&quot;, 
+            &quot;SLI_RADIOAES_REQUIRES_MASKING&quot;: &quot;1&quot;, 
+            &quot;PLATFORM_HEADER&quot;: &quot;\&quot;platform-header.h\&quot;&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;SL_COMPONENT_CATALOG_PRESENT&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_RADIO&quot;: &quot;1&quot;, 
+            &quot;HFXO_FREQ&quot;: &quot;38400000&quot;, 
+            &quot;SPINEL_PLATFORM_HEADER&quot;: &quot;\&quot;spinel_platform.h\&quot;&quot;, 
+            &quot;_GNU_SOURCE&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE&quot;: &quot;\&quot;openthread-core-efr32-config-check.h\&quot;&quot;, 
+            &quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;: &quot;0&quot;, 
+            &quot;OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE&quot;: &quot;0&quot;, 
+            &quot;OPENTHREAD_CONFIG_DEFAULT_TRANSMIT_POWER&quot;: &quot;6&quot;, 
+            &quot;PHY_RAIL&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_CONFIG_FILE&quot;: &quot;\&quot;sl_openthread_generic_config.h\&quot;&quot;, 
+            &quot;SL_BOARD_NAME&quot;: &quot;\&quot;BRD4179B\&quot;&quot;, 
+            &quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;: &quot;&lt;psa_crypto_config.h&gt;&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;: &quot;1&quot;, 
+            &quot;CORTEXM3_EFR32&quot;: &quot;1&quot;, 
+            &quot;EFR32MG21A010F1024IM32&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;MBEDTLS_CONFIG_FILE&quot;: &quot;&lt;sl_mbedtls_config.h&gt;&quot;, 
+            &quot;SL_APP_PROPERTIES&quot;: &quot;1&quot;
+        }, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [
+            &quot;stdc++&quot;, 
+            &quot;gcc&quot;, 
+            &quot;c&quot;, 
+            &quot;m&quot;, 
+            &quot;nosys&quot;
+        ], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;,
+
+\&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;,
+
+\&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,
+
+\&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+            &quot;config/dmadrv_config.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/nvm3_default_config.h&quot;, 
+            &quot;config/psa_crypto_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfrco_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_device_init_lfxo_config.h&quot;, 
+            &quot;config/sl_mbedtls_config.h&quot;, 
+            &quot;config/sl_mbedtls_device_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;, 
+            &quot;config/sl_openthread_features_config.h&quot;, 
+            &quot;config/sl_openthread_generic_config.h&quot;, 
+            &quot;config/sl_rail_util_pa_config.h&quot;, 
+            &quot;config/sl_rail_util_pti_config.h&quot;, 
+            &quot;config/sl_rail_util_rf_path_config.h&quot;, 
+            &quot;config/sl_rail_util_rssi_config.h&quot;, 
+            &quot;config/sl_sleeptimer_config.h&quot;, 
+            &quot;config/sl_uartdrv_usart_vcom_config.h&quot;, 
+            &quot;config/uartdrv_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;, 
+            &quot;autogen/sl_ot_init.c&quot;, 
+            &quot;autogen/sl_ot_init.h&quot;, 
+            &quot;autogen/sl_uartdrv_init.c&quot;, 
+            &quot;autogen/sl_uartdrv_instances.h&quot;, 
+            &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+            &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+            &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+            &quot;autogen/sli_psa_config_autogen.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;README-OT-RCP.md&quot;, 
+            &quot;app.c&quot;, 
+            &quot;app.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/inc/dmadrv.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/src/dmadrv.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/inc/gpiointerrupt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/uartdrv/inc/uartdrv.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/uartdrv/src/uartdrv.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg2x/rail_chip_specific.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/sl_rail_util_pa_curves.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sli_psa_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ccm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_cmac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ecdsa_ecdh.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_sha.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_jpake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_entropy_hardware.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sli_psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/internal_trusted_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/sli_internal_trusted_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sl_psa_its_nvm3.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_trng.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/asm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/cortexm3/diagnostic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/efm32_micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/platform-header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/reset-def.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/faults.s&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mpu/inc/sl_mpu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mpu/src/sl_mpu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/alarm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/board_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/misc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config-check.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-band.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio_extension.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/rail_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_openthread.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_packet_utils.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/startup-gcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/uartdrv_uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_counters.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_extension.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/core/vendor_extension.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/crash_handler.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/diagnostic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/include/crash_handler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1parse.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1write.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ccm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/check_crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cmac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ctr_drbg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecdsa.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecjpake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves_new.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/hmac_drbg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/oid.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pem.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkparse.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_its.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_random_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/sha256.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cache.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ciphersuites.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cookie.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers_generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_msg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ticket.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_server.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_create.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crl.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_csr.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_crt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_csr.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/apps/ncp/ncp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/openthread-system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/code_utils.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/debug_uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings_ram.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router_ftd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_agent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_routing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_monitor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/child_supervision.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/cli.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap_secure.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/commissioner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_ftd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_updater.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dnssd_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/heap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/history_tracker.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/icmp6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/instance.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ip6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/jam_detection.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/joiner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_metrics.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/logging.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/mesh_diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/message.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/multi_radio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/nat64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ncp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata_publisher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdiag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/network_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ping_sender.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-milli.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/border_routing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/debug_uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dns.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dso_transport.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/infra_if.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/logging.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/messagepool.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/otns.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/radio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/settings.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/spi-slave.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/toolchain.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/trel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/udp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/radio_stats.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_noncrypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/sntp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client_buffers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tasklet.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp_ext.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread_ftd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/trel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/udp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/diags_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/error_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/instance_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/link_raw_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/logging_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/random_noncrypto_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/tasklet_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/backbone_tmf.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_leader.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_local.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/multicast_listeners_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/ndproxy_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/infra_if.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/routing_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_message.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_secure.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/appender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/arg_macros.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/array.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/as_core_type.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/bit_vector.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/callback.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/clearable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/code_utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/const_cast.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/crc16.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/debug.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/encoding.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/equatable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_allocatable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_array.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_string.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/iterator_utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/linked_list.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator_getters.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/logging.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/message.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/new.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/non_copyable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/notifier.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/num_utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/numeric_limits.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owned_ptr.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owning_list.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/pool.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/preference.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/ptr_wrapper.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/retain_ptr.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/serial_number.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings_driver.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time_ticker.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/trickle_timer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/type_traits.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/announce_sender.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/backbone_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_agent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_routing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_monitor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/child_supervision.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/coap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/commissioner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dataset_updater.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_dso.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dnssd_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dtls.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/history_tracker.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ip6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/joiner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_metrics_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_quality.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/logging.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_forwarder.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mle.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/nat64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/netdata_publisher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/network_diagnostic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/openthread-core-config-check.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/parent_search.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ping_sender.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/power_calibration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/radio_link.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/sntp_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/time_sync.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/tmf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/context_size.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/crypto_platform.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/ecdsa.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hkdf_sha256.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hmac_sha256.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/mbedtls.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/sha256.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/extension.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/channel_mask.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_handler.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_filter.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_links.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac_callbacks.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/announce_begin_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/border_agent.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/commissioner.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_local.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_updater.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dtls.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/energy_scan_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/extended_panid.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner_router.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_leader.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/network_name.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/panid_query_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/timestamp.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/checksum.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_dso.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dnssd_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/icmp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip4_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_address.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_filter.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_headers.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_mpl.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nat64_translator.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd_agent.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/netif.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/sntp_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/socket.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6_ext.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/udp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/openthread-core-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/max_power_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_callbacks.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_platform.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_interface.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_link.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_packet.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/address_resolver.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_begin_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/anycast_locator.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_mask.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_supervision.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/csl_tx_scheduler.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/discover_scanner.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/dua_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/energy_scan_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender_frame_context.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/key_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/lowpan.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mesh_forwarder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_router.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader_ftd.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_local.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_notifier.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_publisher.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_service.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/panid_query_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/radio_selector.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/src_match_controller.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_netif.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/time_sync_service.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/tmf.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/uri_paths.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/version.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_monitor.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/flash.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/heap.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/history_tracker.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/jam_detector.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/link_metrics_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/mesh_diag.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/otns.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/ping_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/slaac_address.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/srp_client_buffers.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/platform/exit_code.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/multi_frame_buffer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/openthread-spinel-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel_metrics.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spi_frame.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encrypter.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_interface.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_dispatcher.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_ftd.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_mtd.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_radio.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc/cc_module.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/icmp_var.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/sys/queue.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_const.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fastopen.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fsm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_seq.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_var.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/bitmap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/cbuf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/lbuf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/tcplp.h&quot;, 
+            &quot;main.c&quot;, 
+            &quot;reset_util.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Default" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe" postbuildStep="../../../tools/create_gbl.py postbuild &quot;${workspace_loc:/${ProjName}}/${ProjName}.slpb&quot; --parameter build_dir:&quot;${workspace_loc:/${ProjName}/${ConfigName}}&quot; --parameter sdk_dir:&quot;${StudioSdkPath}&quot;">
 					<folderInfo id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -445,7 +2220,344 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
-	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="16" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;README-OT-RCP.md&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1989948998},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:78883933},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1613654230},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;main.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:799961525},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;reset_util.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:892091293},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/.crc_config.crc&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:864156336},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/RTE_Components.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-753128665},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/linkerfile.ld&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-2003353113},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_application_type.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1788130656},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_board_default_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1764316703},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_component_catalog.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1130571133},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_device_init_clocks.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-158784453},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-634596465},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-730778998},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_ot_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:923838929},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_ot_init.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:932662188},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_uartdrv_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1388479790},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_uartdrv_instances.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1234828854},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1970952751},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2137996508},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1169265805},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:626403648},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/app_properties_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:464657923},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:675916386},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1462694363},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/dmadrv_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-79062493},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/emlib_core_debug_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-78822137},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/nvm3_default_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-553893285},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/psa_crypto_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:361377680},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_board_control_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1316174372},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_debug_swo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-367262434},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_emu_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1488208825},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:92619244},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:977362596},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-960917308},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1637757762},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_device_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1138397796},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_memory_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:989839506},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_openthread_features_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1272200328},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_openthread_generic_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2006533701},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pa_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-623975504},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pti_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-310135592},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_rf_path_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-437119590},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_rssi_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-234191042},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_sleeptimer_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1204146860},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_uartdrv_usart_vcom_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:645375412},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/uartdrv_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1654431398},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;ot-rcp.slpb&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-527085367}]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="16" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;README-OT-RCP.md&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1989948998
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 78883933
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1613654230
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;main.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 799961525
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;reset_util.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 892091293
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/.crc_config.crc&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 864156336
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/RTE_Components.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -753128665
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/linkerfile.ld&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -2003353113
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_application_type.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1788130656
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_board_default_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1764316703
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_component_catalog.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1130571133
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_device_init_clocks.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -158784453
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -634596465
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -730778998
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_ot_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 923838929
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_ot_init.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 932662188
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_uartdrv_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1388479790
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_uartdrv_instances.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1234828854
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1970952751
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2137996508
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1169265805
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 626403648
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/app_properties_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 464657923
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 675916386
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1462694363
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/dmadrv_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -79062493
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/emlib_core_debug_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -78822137
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/nvm3_default_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -553893285
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/psa_crypto_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 361377680
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_board_control_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1316174372
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_debug_swo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -367262434
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_emu_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1488208825
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfrco_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 92619244
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 977362596
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_lfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -960917308
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1637757762
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_device_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1138397796
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_memory_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 989839506
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_openthread_features_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1272200328
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_openthread_generic_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2006533701
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pa_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -623975504
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pti_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -310135592
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_rf_path_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -437119590
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_rssi_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -234191042
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_sleeptimer_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1204146860
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_uartdrv_usart_vcom_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 645375412
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/uartdrv_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1654431398
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;ot-rcp.slpb&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -527085367
+    }
+]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="ot-rcp.com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType.710125272" name="SLS CDT Project" projectType="com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType"/>
 	</storageModule>

--- a/src/ot-rcp/.cproject
+++ b/src/ot-rcp/.cproject
@@ -69,8 +69,193 @@
         ], 
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
-        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/uartdrv/inc/&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/protocol/openthread/src/legacy_hal/include/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/util/third_party/openthread/include/
+studio:/sdk/util/third_party/openthread/include/openthread/
+studio:/sdk/util/third_party/openthread/src/core/
+studio:/sdk/util/third_party/openthread/src/lib/
+studio:/sdk/util/third_party/openthread/third_party/tcplp/
+studio:/sdk/util/third_party/openthread/src/
+studio:/sdk/util/third_party/openthread/src/ncp/
+studio:/sdk/util/third_party/openthread/src/lib/spinel/
+studio:/sdk/util/third_party/openthread/src/lib/hdlc/
+studio:/sdk/util/third_party/openthread/examples/platforms/
+studio:/sdk/util/third_party/openthread/examples/platforms/utils/
+studio:/sdk/protocol/openthread/platform-abstraction/efr32/
+studio:/sdk/protocol/openthread/platform-abstraction/include/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/plugin/security_manager/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/
+studio:/sdk/platform/emdrv/uartdrv/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/protocol/openthread/src/legacy_hal/include/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/util/third_party/openthread/include/
+studio:/sdk/util/third_party/openthread/include/openthread/
+studio:/sdk/util/third_party/openthread/src/core/
+studio:/sdk/util/third_party/openthread/src/lib/
+studio:/sdk/util/third_party/openthread/third_party/tcplp/
+studio:/sdk/util/third_party/openthread/src/
+studio:/sdk/util/third_party/openthread/src/ncp/
+studio:/sdk/util/third_party/openthread/src/lib/spinel/
+studio:/sdk/util/third_party/openthread/src/lib/hdlc/
+studio:/sdk/util/third_party/openthread/examples/platforms/
+studio:/sdk/util/third_party/openthread/examples/platforms/utils/
+studio:/sdk/protocol/openthread/platform-abstraction/efr32/
+studio:/sdk/protocol/openthread/platform-abstraction/include/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/plugin/security_manager/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/
+studio:/sdk/platform/emdrv/uartdrv/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/protocol/openthread/src/legacy_hal/include/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/util/third_party/openthread/include/
+studio:/sdk/util/third_party/openthread/include/openthread/
+studio:/sdk/util/third_party/openthread/src/core/
+studio:/sdk/util/third_party/openthread/src/lib/
+studio:/sdk/util/third_party/openthread/third_party/tcplp/
+studio:/sdk/util/third_party/openthread/src/
+studio:/sdk/util/third_party/openthread/src/ncp/
+studio:/sdk/util/third_party/openthread/src/lib/spinel/
+studio:/sdk/util/third_party/openthread/src/lib/hdlc/
+studio:/sdk/util/third_party/openthread/examples/platforms/
+studio:/sdk/util/third_party/openthread/examples/platforms/utils/
+studio:/sdk/protocol/openthread/platform-abstraction/efr32/
+studio:/sdk/protocol/openthread/platform-abstraction/include/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/plugin/security_manager/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/
+studio:/sdk/platform/emdrv/uartdrv/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Werror=unused-function\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;,
 
@@ -80,7 +265,9 @@
 
 \&quot;-fmessage-length=0\&quot;,
 
-\&quot;-c\&quot;\n        ],
+\&quot;-c\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -90,7 +277,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
 
@@ -100,9 +289,19 @@
 
 \&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-c\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -112,9 +311,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Werror=unused-function\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;,
 
@@ -124,7 +333,9 @@
 
 \&quot;-fmessage-length=0\&quot;,
 
-\&quot;-c\&quot;\n        ],
+\&quot;-c\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -134,7 +345,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
 
@@ -144,9 +357,19 @@
 
 \&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-c\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -156,9 +379,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -168,9 +399,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -180,9 +415,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -192,9 +431,17 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -204,9 +451,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -216,9 +471,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -228,9 +487,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -240,9 +503,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -252,9 +519,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -264,9 +535,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -276,9 +551,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -288,9 +567,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -300,9 +587,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -312,9 +607,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -324,9 +623,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -336,9 +639,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -348,9 +655,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -360,9 +671,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -372,9 +687,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -384,9 +703,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -396,9 +719,13 @@
 
 \&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -408,9 +735,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -420,9 +751,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -432,9 +767,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -444,9 +783,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -456,9 +799,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -468,9 +815,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -480,9 +831,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -492,9 +847,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -504,9 +863,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -516,9 +879,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -528,9 +899,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -540,9 +919,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -552,9 +935,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -564,9 +951,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -576,9 +967,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -588,9 +983,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -600,9 +999,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -612,9 +1015,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -624,9 +1031,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -636,9 +1047,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -648,13 +1063,21 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -664,13 +1087,21 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -680,9 +1111,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -692,9 +1127,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -704,9 +1143,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -716,13 +1159,21 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -732,25 +1183,33 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;
+
+}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -783,7 +1242,7 @@
             &quot;config/sl_uartdrv_usart_vcom_config.h&quot;, 
             &quot;config/uartdrv_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -807,7 +1266,7 @@
             &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
             &quot;autogen/sli_psa_config_autogen.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1779,14 +2238,14 @@
             &quot;main.c&quot;, 
             &quot;reset_util.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1795,7 +2254,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;         \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>

--- a/src/rcp-uart-802154/.cproject
+++ b/src/rcp-uart-802154/.cproject
@@ -23,7 +23,1861 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{&quot;OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE&quot;:&quot;0&quot;,&quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;:&quot;&lt;sl_rail_util_pa_config.h&gt;&quot;,&quot;OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT&quot;:&quot;1&quot;,&quot;CORTEXM3_EFM32_MICRO&quot;:&quot;1&quot;,&quot;SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE&quot;:&quot;\&quot;sl_openthread_features_config.h\&quot;&quot;,&quot;SL_BOARD_REV&quot;:&quot;\&quot;A05\&quot;&quot;,&quot;OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS&quot;:&quot;0&quot;,&quot;OPENTHREAD_ENABLE_VENDOR_EXTENSION&quot;:&quot;1&quot;,&quot;OPENTHREAD_PROJECT_CORE_CONFIG_FILE&quot;:&quot;\&quot;openthread-core-efr32-config.h\&quot;&quot;,&quot;CORTEXM3&quot;:&quot;1&quot;,&quot;SLI_RADIOAES_REQUIRES_MASKING&quot;:&quot;1&quot;,&quot;PLATFORM_HEADER&quot;:&quot;\&quot;platform-header.h\&quot;&quot;,&quot;OPENTHREAD_CONFIG_NCP_CPC_ENABLE&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;:&quot;1&quot;,&quot;OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE&quot;:&quot;1&quot;,&quot;OPENTHREAD_CONFIG_NCP_HDLC_ENABLE&quot;:&quot;0&quot;,&quot;SL_COMPONENT_CATALOG_PRESENT&quot;:&quot;1&quot;,&quot;OPENTHREAD_RADIO&quot;:&quot;1&quot;,&quot;HFXO_FREQ&quot;:&quot;38400000&quot;,&quot;SPINEL_PLATFORM_HEADER&quot;:&quot;\&quot;spinel_platform.h\&quot;&quot;,&quot;_GNU_SOURCE&quot;:&quot;1&quot;,&quot;OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE&quot;:&quot;\&quot;openthread-core-efr32-config-check.h\&quot;&quot;,&quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;:&quot;0&quot;,&quot;OPENTHREAD_CONFIG_NCP_CPC_TX_CHUNK_SIZE&quot;:&quot;2048&quot;,&quot;OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE&quot;:&quot;0&quot;,&quot;PHY_RAIL&quot;:&quot;1&quot;,&quot;OPENTHREAD_CONFIG_FILE&quot;:&quot;\&quot;sl_openthread_generic_config.h\&quot;&quot;,&quot;OPENTHREAD_ENABLE_NCP_VENDOR_HOOK&quot;:&quot;1&quot;,&quot;SL_OPENTHREAD_PHY_SELECT_STACK_SUPPORT&quot;:&quot;1&quot;,&quot;SL_BOARD_NAME&quot;:&quot;\&quot;BRD4179B\&quot;&quot;,&quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;:&quot;&lt;psa_crypto_config.h&gt;&quot;,&quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;:&quot;1&quot;,&quot;CORTEXM3_EFR32&quot;:&quot;1&quot;,&quot;EFR32MG21A010F1024IM32&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;:&quot;1&quot;,&quot;MBEDTLS_CONFIG_FILE&quot;:&quot;&lt;sl_mbedtls_config.h&gt;&quot;,&quot;SL_APP_PROPERTIES&quot;:&quot;1&quot;},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[&quot;stdc++&quot;,&quot;gcc&quot;,&quot;c&quot;,&quot;m&quot;,&quot;nosys&quot;],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[\&quot;-Werror=unused-function\&quot;,\&quot;-Werror=unused-variable\&quot;,\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Werror=unused-function\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror=unused-variable\&quot;:\&quot;TRUE\&quot;,\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Werror=unused-function\&quot;,\&quot;-Werror=unused-variable\&quot;,\&quot;-mcmse\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-c\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Werror=unused-function\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror=unused-variable\&quot;:\&quot;TRUE\&quot;,\&quot;-mcmse\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;,\&quot;sl_openthread_coex_config.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;,\&quot;sl_openthread_coex_config.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;,\&quot;sl_openthread_coex_config.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;,\&quot;sl_openthread_coex_config.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,\&quot;value\&quot;:\&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;,\&quot;sl_openthread_coex_config.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;,\&quot;sl_openthread_coex_config.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.hard\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.c.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.cpp.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;:\&quot;TRUE\&quot;}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;config/dmadrv_config.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/nvm3_default_config.h&quot;,&quot;config/psa_crypto_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_cpc_config.h&quot;,&quot;config/sl_cpc_drv_uart_usart_vcom_config.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;config/sl_mbedtls_config.h&quot;,&quot;config/sl_mbedtls_device_config.h&quot;,&quot;config/sl_memory_config.h&quot;,&quot;config/sl_openthread_coex_config.h&quot;,&quot;config/sl_openthread_features_config.h&quot;,&quot;config/sl_openthread_generic_config.h&quot;,&quot;config/sl_rail_util_coex_common_config.h&quot;,&quot;config/sl_rail_util_coex_config.h&quot;,&quot;config/sl_rail_util_dma_config.h&quot;,&quot;config/sl_rail_util_ieee802154_fast_channel_switching_config.h&quot;,&quot;config/sl_rail_util_pa_config.h&quot;,&quot;config/sl_rail_util_pti_config.h&quot;,&quot;config/sl_rail_util_rf_path_config.h&quot;,&quot;config/sl_rail_util_rssi_config.h&quot;,&quot;config/sl_rcp_gp_interface_config.h&quot;,&quot;config/sl_sleeptimer_config.h&quot;,&quot;config/ustimer_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/RTE_Components.h&quot;,&quot;autogen/coexistence_event.c&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_cpc_drv_uart_config.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;,&quot;autogen/sl_ot_init.c&quot;,&quot;autogen/sl_ot_init.h&quot;,&quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;,&quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;,&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;autogen/sli_psa_config_autogen.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;README-MP-RCP.md&quot;,&quot;app.c&quot;,&quot;app.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_gsdk_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_slist.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_slist.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/inc/dmadrv.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/src/dmadrv.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/inc/gpiointerrupt.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/ustimer/inc/ustimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/ustimer/src/ustimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpcrc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg2x/rail_chip_specific.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence-pwm.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/hal/efr32/coexistence-directional-priority.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/hal/efr32/coexistence-hal.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/hal/efr32/coexistence-hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/sl_rail_util_pa_curves.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_dma/sl_rail_util_dma.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_dma/sl_rail_util_dma.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_phy_select.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_stack_event.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sli_psa_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ccm.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_cmac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ecdsa_ecdh.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_sha.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_jpake.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_entropy_hardware.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sli_psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/error.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/internal_trusted_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/sli_internal_trusted_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sl_psa_its_nvm3.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_trng.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;,&quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sl_cpc.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sl_cpc_secondary_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sl_cpc_weak_prototypes.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_bootloader.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_crc.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_debug.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_drv.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_hdlc.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_system_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_system_secondary.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_trace.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_crc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_dispatcher.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_drv_uart.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_hdlc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_system_secondary.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/asm.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/cortexm3/diagnostic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/efm32_micro.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-common.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-types.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/platform-header.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/reset-def.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/faults.s&quot;,&quot;gecko_sdk_4.4.3/platform/service/mem_pool/inc/sli_mem_pool.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/mem_pool/src/sl_mem_pool.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/mpu/inc/sl_mpu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/mpu/src/sl_mpu.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/include/sl_ot_phy_select.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/alarm.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/board_config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/crypto.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/entropy.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/flash.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.hpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154mac.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/memory.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/misc.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config-check.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-band.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-efr32.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio_extension.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/rail_config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_openthread.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_packet_utils.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_rcp_gp_interface.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_rcp_gp_interface.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/startup-gcc.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/system.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_counters.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_extension.h&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/vendor_spinel.hpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_coex.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_coex.hpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_cpc.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_cpc.hpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_dispatcher.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_init.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/core/vendor_extension.cpp&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/crash_handler.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/diagnostic.c&quot;,&quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/include/crash_handler.h&quot;,&quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.c&quot;,&quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;,&quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/aes.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1parse.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1write.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ccm.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/check_crypto_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cmac.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ctr_drbg.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecdsa.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecjpake.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves_new.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/hmac_drbg.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/oid.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pem.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkparse.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core_common.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_its.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_random_impl.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/sha256.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cache.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ciphersuites.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cookie.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers_generated.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_msg.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ticket.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_client.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_server.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_create.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crl.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crt.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_csr.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_crt.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_csr.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/openthread-system.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/code_utils.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/debug_uart.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings_ram.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router_ftd.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_agent.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_routing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_monitor.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/child_supervision.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/cli.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap_secure.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/commissioner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_ftd.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_updater.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dnssd_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/error.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/heap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/history_tracker.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/icmp6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/instance.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ip6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/jam_detection.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/joiner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_metrics.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/logging.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/mesh_diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/message.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/multi_radio.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/nat64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ncp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata_publisher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdiag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/network_time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ping_sender.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-micro.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-milli.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/border_routing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/debug_uart.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dns.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dso_transport.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/entropy.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/flash.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/infra_if.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/logging.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/memory.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/messagepool.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/otns.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/radio.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/settings.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/spi-slave.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/time.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/toolchain.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/trel.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/udp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/radio_stats.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_noncrypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/sntp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client_buffers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tasklet.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp_ext.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread_ftd.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/trel.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/udp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/diags_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/error_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/instance_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/link_raw_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/logging_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/random_noncrypto_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/tasklet_api.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/backbone_tmf.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_leader.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_local.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/multicast_listeners_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/ndproxy_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/infra_if.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/routing_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_message.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_secure.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/appender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/arg_macros.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/array.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/as_core_type.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/bit_vector.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/callback.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/clearable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/code_utils.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/const_cast.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/crc16.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/debug.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/encoding.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/equatable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_allocatable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_array.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_string.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/iterator_utils.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/linked_list.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator_getters.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/logging.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/message.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/new.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/non_copyable.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/notifier.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/num_utils.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/numeric_limits.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owned_ptr.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owning_list.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/pool.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/preference.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/ptr_wrapper.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/retain_ptr.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/serial_number.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings_driver.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time_ticker.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/trickle_timer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/type_traits.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/announce_sender.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/backbone_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_agent.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_router.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_routing.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_monitor.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/child_supervision.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/coap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/commissioner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/crypto.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dataset_updater.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_dso.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dnssd_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dtls.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/history_tracker.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ip6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/joiner.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_metrics_manager.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_quality.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_raw.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/logging.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mac.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_diag.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_forwarder.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/misc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mle.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/nat64.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/netdata_publisher.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/network_diagnostic.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/openthread-core-config-check.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/parent_search.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ping_sender.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/power_calibration.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/radio_link.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/sntp_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_client.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_server.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/time_sync.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/tmf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/context_size.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/crypto_platform.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/ecdsa.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hkdf_sha256.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hmac_sha256.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/mbedtls.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/sha256.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/extension.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/channel_mask.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_handler.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_filter.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_links.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac_callbacks.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/announce_begin_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/border_agent.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/commissioner.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_local.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_updater.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dtls.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/energy_scan_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/extended_panid.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner_router.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_leader.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/network_name.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/panid_query_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/timestamp.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/checksum.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_dso.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dnssd_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/icmp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip4_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_address.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_filter.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_headers.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_mpl.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nat64_translator.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd_agent.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/netif.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/sntp_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/socket.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_client.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6_ext.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/udp6.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/openthread-core-config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/max_power_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_callbacks.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_platform.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_interface.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_link.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_packet.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/address_resolver.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_begin_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/anycast_locator.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_mask.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_supervision.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/csl_tx_scheduler.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/discover_scanner.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/dua_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/energy_scan_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender_frame_context.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/key_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/lowpan.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mesh_forwarder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_router.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader_ftd.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_local.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_notifier.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_publisher.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_service.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_types.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/panid_query_server.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/radio_selector.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router_table.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/src_match_controller.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_netif.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_tlvs.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/time_sync_service.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/tmf.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/uri_paths.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/version.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_monitor.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/flash.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/heap.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/history_tracker.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/jam_detector.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/link_metrics_manager.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/mesh_diag.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/otns.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/ping_sender.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/slaac_address.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/srp_client_buffers.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/platform/exit_code.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/multi_frame_buffer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/openthread-spinel-config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel_metrics.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spi_frame.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encrypter.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_interface.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_platform.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_dispatcher.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_ftd.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_mtd.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_radio.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_config.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.cpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.hpp&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc/cc_module.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/icmp_var.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip6.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/sys/queue.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_const.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fastopen.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fsm.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_seq.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_timer.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_var.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/types.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/bitmap.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/cbuf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/lbuf.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/tcplp.h&quot;,&quot;main.c&quot;,&quot;nc_efr32_watchdog_1.0.0/inc/nc_efr32_wdog.h&quot;,&quot;nc_efr32_watchdog_1.0.0/src/nc_efr32_wdog.c&quot;,&quot;reset_util.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {
+            &quot;OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE&quot;: &quot;0&quot;, 
+            &quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;: &quot;&lt;sl_rail_util_pa_config.h&gt;&quot;, 
+            &quot;OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT&quot;: &quot;1&quot;, 
+            &quot;CORTEXM3_EFM32_MICRO&quot;: &quot;1&quot;, 
+            &quot;SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE&quot;: &quot;\&quot;sl_openthread_features_config.h\&quot;&quot;, 
+            &quot;SL_BOARD_REV&quot;: &quot;\&quot;A05\&quot;&quot;, 
+            &quot;OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS&quot;: &quot;0&quot;, 
+            &quot;OPENTHREAD_ENABLE_VENDOR_EXTENSION&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_PROJECT_CORE_CONFIG_FILE&quot;: &quot;\&quot;openthread-core-efr32-config.h\&quot;&quot;, 
+            &quot;CORTEXM3&quot;: &quot;1&quot;, 
+            &quot;SLI_RADIOAES_REQUIRES_MASKING&quot;: &quot;1&quot;, 
+            &quot;PLATFORM_HEADER&quot;: &quot;\&quot;platform-header.h\&quot;&quot;, 
+            &quot;OPENTHREAD_CONFIG_NCP_CPC_ENABLE&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_CONFIG_NCP_HDLC_ENABLE&quot;: &quot;0&quot;, 
+            &quot;SL_COMPONENT_CATALOG_PRESENT&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_RADIO&quot;: &quot;1&quot;, 
+            &quot;HFXO_FREQ&quot;: &quot;38400000&quot;, 
+            &quot;SPINEL_PLATFORM_HEADER&quot;: &quot;\&quot;spinel_platform.h\&quot;&quot;, 
+            &quot;_GNU_SOURCE&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE&quot;: &quot;\&quot;openthread-core-efr32-config-check.h\&quot;&quot;, 
+            &quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;: &quot;0&quot;, 
+            &quot;OPENTHREAD_CONFIG_NCP_CPC_TX_CHUNK_SIZE&quot;: &quot;2048&quot;, 
+            &quot;OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE&quot;: &quot;0&quot;, 
+            &quot;PHY_RAIL&quot;: &quot;1&quot;, 
+            &quot;OPENTHREAD_CONFIG_FILE&quot;: &quot;\&quot;sl_openthread_generic_config.h\&quot;&quot;, 
+            &quot;OPENTHREAD_ENABLE_NCP_VENDOR_HOOK&quot;: &quot;1&quot;, 
+            &quot;SL_OPENTHREAD_PHY_SELECT_STACK_SUPPORT&quot;: &quot;1&quot;, 
+            &quot;SL_BOARD_NAME&quot;: &quot;\&quot;BRD4179B\&quot;&quot;, 
+            &quot;MBEDTLS_PSA_CRYPTO_CONFIG_FILE&quot;: &quot;&lt;psa_crypto_config.h&gt;&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_1_RF_BAND&quot;: &quot;1&quot;, 
+            &quot;CORTEXM3_EFR32&quot;: &quot;1&quot;, 
+            &quot;EFR32MG21A010F1024IM32&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_DEFAULT_RF_BAND_2400&quot;: &quot;1&quot;, 
+            &quot;MBEDTLS_CONFIG_FILE&quot;: &quot;&lt;sl_mbedtls_config.h&gt;&quot;, 
+            &quot;SL_APP_PROPERTIES&quot;: &quot;1&quot;
+        }, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [
+            &quot;stdc++&quot;, 
+            &quot;gcc&quot;, 
+            &quot;c&quot;, 
+            &quot;m&quot;, 
+            &quot;nosys&quot;
+        ], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;,
+
+\&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;,
+
+\&quot;-mcmse\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-c\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-mcmse\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,
+
+\&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+            &quot;config/dmadrv_config.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/nvm3_default_config.h&quot;, 
+            &quot;config/psa_crypto_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_cpc_config.h&quot;, 
+            &quot;config/sl_cpc_drv_uart_usart_vcom_config.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfrco_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_device_init_lfxo_config.h&quot;, 
+            &quot;config/sl_mbedtls_config.h&quot;, 
+            &quot;config/sl_mbedtls_device_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;, 
+            &quot;config/sl_openthread_coex_config.h&quot;, 
+            &quot;config/sl_openthread_features_config.h&quot;, 
+            &quot;config/sl_openthread_generic_config.h&quot;, 
+            &quot;config/sl_rail_util_coex_common_config.h&quot;, 
+            &quot;config/sl_rail_util_coex_config.h&quot;, 
+            &quot;config/sl_rail_util_dma_config.h&quot;, 
+            &quot;config/sl_rail_util_ieee802154_fast_channel_switching_config.h&quot;, 
+            &quot;config/sl_rail_util_pa_config.h&quot;, 
+            &quot;config/sl_rail_util_pti_config.h&quot;, 
+            &quot;config/sl_rail_util_rf_path_config.h&quot;, 
+            &quot;config/sl_rail_util_rssi_config.h&quot;, 
+            &quot;config/sl_rcp_gp_interface_config.h&quot;, 
+            &quot;config/sl_sleeptimer_config.h&quot;, 
+            &quot;config/ustimer_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/coexistence_event.c&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_cpc_drv_uart_config.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;, 
+            &quot;autogen/sl_ot_init.c&quot;, 
+            &quot;autogen/sl_ot_init.h&quot;, 
+            &quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;, 
+            &quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;, 
+            &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+            &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+            &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+            &quot;autogen/sli_psa_config_autogen.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;README-MP-RCP.md&quot;, 
+            &quot;app.c&quot;, 
+            &quot;app.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm33.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv8.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_bufc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_buram.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_dpll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_fsrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_gpio_port.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_iadc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_icache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ldmaxbar_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_lvgd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_semailbox.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_ulfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Include/system_efr32mg21.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/startup_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_gsdk_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_slist.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_slist.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/inc/dmadrv.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/dmadrv/src/dmadrv.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/inc/gpiointerrupt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/ustimer/inc/ustimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/ustimer/src/ustimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_burtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_syscfg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpcrc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg2x/rail_chip_specific.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence-pwm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/common/coexistence.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/hal/efr32/coexistence-directional-priority.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/hal/efr32/coexistence-hal.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/hal/efr32/coexistence-hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/coexistence-802154.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/sl_rail_util_pa_curves.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_dma/sl_rail_util_dma.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_dma/sl_rail_util_dma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_phy_select.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_ieee802154/sl_rail_util_ieee802154_stack_event.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rf_path/sl_rail_util_rf_path.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_attestation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_defines.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_internal_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_key_handling.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_signature.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sl_se_manager_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/inc/sli_se_manager_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_key_handling.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sl_se_manager_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/se_manager/src/sli_se_manager_osal_baremetal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_mbedtls_omnipresent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/config/sli_psa_acceleration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/aes_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ccm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/cmac_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/ecjpake_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/gcm_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/se_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha1_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha256_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sha512_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_mbedtls.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sl_psa_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/inc/sli_psa_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ccm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_cmac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_ecdsa_ecdh.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/mbedtls_sha.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/se_jpake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_entropy_hardware.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_mbedtls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sl_psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_mbedtls_support/src/sli_psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_protocol_crypto/src/sli_radioaes_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/internal_trusted_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/psa/sli_internal_trusted_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_psa_driver_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_key_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_driver_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_opaque_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_functions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_transparent_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/inc/sli_se_version_dependencies.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sl_psa_its_nvm3.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_common.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_driver_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_psa_trng.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_builtin_keys.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_key_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_driver_signature.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_opaque_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_driver_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_transparent_key_derivation.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/security/sl_component/sl_psa_driver/src/sli_se_version_dependencies.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sl_cpc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sl_cpc_secondary_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sl_cpc_weak_prototypes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_bootloader.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_crc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_drv.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_hdlc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_system_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_system_secondary.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_trace.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/inc/sli_cpc_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_crc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_dispatcher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_drv_uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_hdlc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/cpc/src/sl_cpc_system_secondary.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfrco.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_lfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfrco.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_lfxo_s2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/asm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/cortexm3/diagnostic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/efm32_micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/platform-header.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/inc/reset-def.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/legacy_hal/src/faults.s&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mem_pool/inc/sli_mem_pool.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mem_pool/src/sl_mem_pool.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mpu/inc/sl_mpu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mpu/src/sl_mpu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_process_action.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_process_action.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/include/sl_ot_phy_select.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/alarm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/board_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154-packet-utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/ieee802154mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/misc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config-check.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/openthread-core-efr32-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-band.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/platform-efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/radio_extension.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/rail_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_openthread.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_packet_utils.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_rcp_gp_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/sl_rcp_gp_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/soft_source_match_table.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/startup-gcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/efr32/system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_counters.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/radio_extension.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/include/vendor_spinel.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_coex.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_coex.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_cpc.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_cpc.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_dispatcher.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/platform-abstraction/ncp/ncp_init.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/core/vendor_extension.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/crash_handler.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/diagnostic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/openthread/src/legacy_hal/include/crash_handler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/plugin/security_manager/security_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/silicon_labs/silabs_core/memory_manager/sl_malloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/aria.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/asn1write.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/base64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/bignum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/camellia.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ccm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chacha20.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/chachapoly.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/check_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/cmac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/compat-2.x.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_legacy_from_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_from_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_psa_superset_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_adjust_x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/config_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/constant_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ctr_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/des.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/dhm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecdsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecjpake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/gcm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hkdf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/hmac_drbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/lms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/mbedtls_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/md5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/net_sockets.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/nist_kw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/oid.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pem.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs12.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs5.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/pkcs7.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/platform_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/poly1305.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/private_access.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/psa_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ripemd160.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha1.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha256.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/sha512.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cache.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ciphersuites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_cookie.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/ssl_ticket.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/threading.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/timing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_crt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/mbedtls/x509_csr.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/build_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_auto_enabled.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_key_pair_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_adjust_config_synonyms.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_builtin_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_composites.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_key_derivation.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_driver_contexts_primitives.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_extra.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_legacy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_se_driver.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_sizes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_struct.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/include/psa/crypto_values.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/aes.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/alignment.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1parse.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/asn1write.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/base64_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bignum_mod_raw_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/bn_mul.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ccm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/check_crypto_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cipher_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/cmac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/constant_time_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ctr_drbg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecdsa.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecjpake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_curves_new.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_internal_alt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ecp_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/entropy_poll.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/hmac_drbg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/lmots.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_psa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/md_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_reader.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/mps_trace.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/oid.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/padlock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pem.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pk_wrap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkparse.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/pkwrite.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/platform_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_aead.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_cipher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_core_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_driver_wrappers_no_static.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ecp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_ffdh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_hash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_its.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_pake.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_random_impl.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_rsa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_se.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_slot_management.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_crypto_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/psa_util_internal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/rsa_alt_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/sha256.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cache.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ciphersuites.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_cookie.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_debug_helpers_generated.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_msg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_ticket.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_client.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls12_server.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_invasive.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/ssl_tls13_keys.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/threading.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_create.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crl.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_crt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509_csr.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_crt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/mbedtls/library/x509write_csr.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/openthread-system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/code_utils.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/debug_uart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/link_metrics.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/mac_frame.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/settings_ram.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/examples/platforms/utils/uart_rtt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/backbone_router_ftd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_agent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/border_routing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/channel_monitor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/child_supervision.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/cli.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/coap_secure.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/commissioner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_ftd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dataset_updater.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dns_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/dnssd_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/error.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/heap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/history_tracker.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/icmp6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/instance.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ip6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/jam_detection.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/joiner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_metrics.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/link_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/logging.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/mesh_diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/message.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/multi_radio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/nat64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ncp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdata_publisher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/netdiag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/network_time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/ping_sender.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-micro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/alarm-milli.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/border_routing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/debug_uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dns.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/dso_transport.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/infra_if.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/logging.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/messagepool.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/otns.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/radio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/settings.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/spi-slave.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/time.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/toolchain.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/trel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/platform/udp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/radio_stats.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/random_noncrypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/sntp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_client_buffers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/srp_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tasklet.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/tcp_ext.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/thread_ftd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/trel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/include/openthread/udp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/diags_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/error_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/instance_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/link_raw_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/logging_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/random_noncrypto_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/api/tasklet_api.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/backbone_tmf.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_leader.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_local.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/bbr_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/multicast_listeners_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/backbone_router/ndproxy_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/infra_if.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/border_router/routing_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_message.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/coap/coap_secure.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/appender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/arg_macros.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/array.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/as_core_type.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/binary_search.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/bit_vector.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/callback.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/clearable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/code_utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/const_cast.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/crc16.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/debug.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/encoding.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/equatable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/error.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_builder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/frame_data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_allocatable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_array.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/heap_string.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/iterator_utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/linked_list.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/locator_getters.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/log.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/logging.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/message.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/new.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/non_copyable.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/notifier.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/num_utils.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/numeric_limits.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owned_ptr.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/owning_list.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/pool.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/preference.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/ptr_wrapper.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/random.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/retain_ptr.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/serial_number.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/settings_driver.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/string.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tasklet.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/time_ticker.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/timer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/trickle_timer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/type_traits.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/common/uptime.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/announce_sender.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/backbone_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_agent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_router.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/border_routing.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/channel_monitor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/child_supervision.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/coap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/commissioner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dataset_updater.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dhcp6_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dns_dso.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dnssd_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/dtls.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/history_tracker.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ip6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/joiner.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_metrics_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_quality.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/link_raw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/logging.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_diag.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mesh_forwarder.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/mle.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/nat64.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/netdata_publisher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/network_diagnostic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/openthread-core-config-check.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/parent_search.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/ping_sender.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/power_calibration.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/radio_link.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/sntp_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_client.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/srp_server.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/time_sync.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/config/tmf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ccm.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/aes_ecb.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/context_size.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/crypto_platform.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/ecdsa.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hkdf_sha256.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/hmac_sha256.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/mbedtls.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/sha256.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/crypto/storage.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/diags/factory_diags.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/extension.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/instance/instance.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/channel_mask.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_handler.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/data_poll_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/link_raw.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_filter.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_frame.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_links.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/mac_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/mac/sub_mac_callbacks.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/announce_begin_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/border_agent.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/commissioner.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_local.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dataset_updater.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/dtls.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/energy_scan_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/extended_panid.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/joiner_router.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_leader.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/meshcop_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/network_name.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/panid_query_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/meshcop/timestamp.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/checksum.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dhcp6_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_dso.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dns_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/dnssd_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/icmp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip4_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_address.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_filter.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_headers.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_mpl.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/ip6_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nat64_translator.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/nd_agent.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/netif.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/sntp_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/socket.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_client.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/srp_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/tcp6_ext.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/net/udp6.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/openthread-core-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/max_power_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_callbacks.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/radio_platform.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_interface.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_link.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/radio/trel_packet.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/address_resolver.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_begin_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/announce_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/anycast_locator.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_mask.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_supervision.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/child_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/csl_tx_scheduler.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/discover_scanner.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/dua_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/energy_scan_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/indirect_sender_frame_context.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/key_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_metrics_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/link_quality.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/lowpan.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mesh_forwarder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_router.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mle_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/mlr_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/neighbor_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_leader_ftd.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_local.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_notifier.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_publisher.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_service.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_data_types.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/network_diagnostic_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/panid_query_server.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/radio_selector.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/router_table.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/src_match_controller.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_netif.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/thread_tlvs.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/time_sync_service.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/tmf.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/uri_paths.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/thread/version.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/channel_monitor.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/flash.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/heap.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/history_tracker.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/jam_detector.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/link_metrics_manager.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/mesh_diag.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/otns.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/parse_cmdline.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/ping_sender.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/power_calibration.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/slaac_address.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/core/utils/srp_client_buffers.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/hdlc/hdlc.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/platform/exit_code.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/multi_frame_buffer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/openthread-spinel-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/radio_spinel_metrics.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spi_frame.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_buffer.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_decoder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encoder.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_encrypter.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_interface.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/lib/spinel/spinel_platform.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/changed_props_set.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_dispatcher.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_ftd.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_mtd.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_base_radio.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_hdlc.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.cpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/src/ncp/ncp_spi.hpp&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/cc/cc_module.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/icmp_var.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/ip6.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/sys/queue.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_const.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fastopen.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_fsm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_seq.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/tcp_var.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/bsdtcp/types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/bitmap.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/cbuf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/lib/lbuf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/openthread/third_party/tcplp/tcplp.h&quot;, 
+            &quot;main.c&quot;, 
+            &quot;nc_efr32_watchdog_1.0.0/inc/nc_efr32_wdog.h&quot;, 
+            &quot;nc_efr32_watchdog_1.0.0/src/nc_efr32_wdog.c&quot;, 
+            &quot;reset_util.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Default" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe" postbuildStep="../../../tools/create_gbl.py postbuild &quot;${workspace_loc:/${ProjName}}/${ProjName}.slpb&quot; --parameter build_dir:&quot;${workspace_loc:/${ProjName}/${ConfigName}}&quot; --parameter sdk_dir:&quot;${StudioSdkPath}&quot;">
 					<folderInfo id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -499,7 +2353,407 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
-	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="36" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;README-MP-RCP.md&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-777110821},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:78883933},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1613654230},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;main.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:799961525},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;reset_util.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:892091293},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/.crc_config.crc&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1868496732},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/RTE_Components.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-753128665},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/coexistence_event.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1262005708},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/linkerfile.ld&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-2003353113},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_application_type.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1788130656},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_board_default_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1764316703},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_component_catalog.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1088247447},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_cpc_drv_uart_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-320930904},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_device_init_clocks.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-158784453},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1316242213},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-730778998},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_ot_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:923838929},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_ot_init.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:932662188},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1753834412},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:588216489},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1970952751},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2137996508},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_builtin_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1169265805},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sli_psa_config_autogen.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:626403648},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/app_properties_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:464657923},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:675916386},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg_s2c1.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1462694363},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/dmadrv_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-79062493},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/emlib_core_debug_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-78822137},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/nvm3_default_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-553893285},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/psa_crypto_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:361377680},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_board_control_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1316174372},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_cpc_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1591991927},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_cpc_drv_uart_usart_vcom_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:676509963},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_debug_swo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-367262434},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_emu_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1488208825},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfrco_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:92619244},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:977362596},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_lfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-960917308},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1637757762},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_mbedtls_device_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1138397796},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_memory_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-998730749},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_openthread_coex_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2063204214},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_openthread_features_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:639022430},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_openthread_generic_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2006533701},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_coex_common_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1383792543},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_coex_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1734426472},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_dma_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1215204330},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_ieee802154_fast_channel_switching_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1405445119},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pa_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-623975504},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pti_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-310135592},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_rf_path_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-437119590},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_rssi_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-234191042},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rcp_gp_interface_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1968836155},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_sleeptimer_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1204146860},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/ustimer_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2076159003},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;rcp-uart-802154.slpb&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-659020886}]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="36" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;README-MP-RCP.md&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -777110821
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 78883933
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1613654230
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;main.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 799961525
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;reset_util.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 892091293
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/.crc_config.crc&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1868496732
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/RTE_Components.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -753128665
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/coexistence_event.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1262005708
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/linkerfile.ld&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -2003353113
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_application_type.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1788130656
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_board_default_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1764316703
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_component_catalog.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1088247447
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_cpc_drv_uart_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -320930904
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_device_init_clocks.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -158784453
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1316242213
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -730778998
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_ot_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 923838929
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_ot_init.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 932662188
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_rail_util_ieee802154_phy_select.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1753834412
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_rail_util_ieee802154_stack_event.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 588216489
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1970952751
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_mbedtls_config_transform_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2137996508
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1169265805
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sli_psa_config_autogen.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 626403648
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/app_properties_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 464657923
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 675916386
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg_s2c1.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1462694363
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/dmadrv_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -79062493
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/emlib_core_debug_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -78822137
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/nvm3_default_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -553893285
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/psa_crypto_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 361377680
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_board_control_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1316174372
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_cpc_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1591991927
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_cpc_drv_uart_usart_vcom_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 676509963
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_debug_swo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -367262434
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_emu_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1488208825
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfrco_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 92619244
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 977362596
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_lfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -960917308
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1637757762
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_mbedtls_device_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1138397796
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_memory_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -998730749
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_openthread_coex_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2063204214
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_openthread_features_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 639022430
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_openthread_generic_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2006533701
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_coex_common_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1383792543
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_coex_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1734426472
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_dma_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1215204330
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_ieee802154_fast_channel_switching_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1405445119
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pa_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -623975504
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pti_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -310135592
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_rf_path_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -437119590
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_rssi_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -234191042
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rcp_gp_interface_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1968836155
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_sleeptimer_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1204146860
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/ustimer_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2076159003
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;rcp-uart-802154.slpb&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -659020886
+    }
+]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="rcp-uart-802154.com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType.1483005875" name="SLS CDT Project" projectType="com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType"/>
 	</storageModule>

--- a/src/rcp-uart-802154/.cproject
+++ b/src/rcp-uart-802154/.cproject
@@ -75,8 +75,226 @@
         ], 
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
-        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/extension/nc_efr32_watchdog_extension/inc/ studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/service/cpc/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/dmadrv/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/ studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/ studio:/sdk/util/third_party/mbedtls/include/ studio:/sdk/util/third_party/mbedtls/library/ studio:/sdk/platform/service/mem_pool/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/protocol/openthread/include/ studio:/sdk/protocol/openthread/platform-abstraction/ncp/ studio:/sdk/protocol/openthread/src/legacy_hal/include/ studio:/sdk/platform/service/legacy_hal/inc/ studio:/sdk/util/third_party/openthread/include/ studio:/sdk/util/third_party/openthread/include/openthread/ studio:/sdk/util/third_party/openthread/src/core/ studio:/sdk/util/third_party/openthread/src/lib/ studio:/sdk/util/third_party/openthread/third_party/tcplp/ studio:/sdk/util/third_party/openthread/src/ studio:/sdk/util/third_party/openthread/src/ncp/ studio:/sdk/util/third_party/openthread/src/lib/spinel/ studio:/sdk/util/third_party/openthread/src/lib/hdlc/ studio:/sdk/protocol/openthread/platform-abstraction/include/ studio:/sdk/util/third_party/openthread/examples/platforms/ studio:/sdk/util/third_party/openthread/examples/platforms/utils/ studio:/sdk/protocol/openthread/platform-abstraction/efr32/ studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/ studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/ studio:/sdk/platform/security/sl_component/se_manager/inc/ studio:/sdk/platform/security/sl_component/se_manager/src/ studio:/sdk/util/plugin/security_manager/ studio:/sdk/util/silicon_labs/silabs_core/memory_manager/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/ studio:/sdk/platform/emdrv/ustimer/inc/&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/extension/nc_efr32_watchdog_extension/inc/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/service/cpc/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/service/mem_pool/inc/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/protocol/openthread/include/
+studio:/sdk/protocol/openthread/platform-abstraction/ncp/
+studio:/sdk/protocol/openthread/src/legacy_hal/include/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/util/third_party/openthread/include/
+studio:/sdk/util/third_party/openthread/include/openthread/
+studio:/sdk/util/third_party/openthread/src/core/
+studio:/sdk/util/third_party/openthread/src/lib/
+studio:/sdk/util/third_party/openthread/third_party/tcplp/
+studio:/sdk/util/third_party/openthread/src/
+studio:/sdk/util/third_party/openthread/src/ncp/
+studio:/sdk/util/third_party/openthread/src/lib/spinel/
+studio:/sdk/util/third_party/openthread/src/lib/hdlc/
+studio:/sdk/protocol/openthread/platform-abstraction/include/
+studio:/sdk/util/third_party/openthread/examples/platforms/
+studio:/sdk/util/third_party/openthread/examples/platforms/utils/
+studio:/sdk/protocol/openthread/platform-abstraction/efr32/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/plugin/security_manager/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/
+studio:/sdk/platform/emdrv/ustimer/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/extension/nc_efr32_watchdog_extension/inc/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/service/cpc/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/service/mem_pool/inc/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/protocol/openthread/include/
+studio:/sdk/protocol/openthread/platform-abstraction/ncp/
+studio:/sdk/protocol/openthread/src/legacy_hal/include/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/util/third_party/openthread/include/
+studio:/sdk/util/third_party/openthread/include/openthread/
+studio:/sdk/util/third_party/openthread/src/core/
+studio:/sdk/util/third_party/openthread/src/lib/
+studio:/sdk/util/third_party/openthread/third_party/tcplp/
+studio:/sdk/util/third_party/openthread/src/
+studio:/sdk/util/third_party/openthread/src/ncp/
+studio:/sdk/util/third_party/openthread/src/lib/spinel/
+studio:/sdk/util/third_party/openthread/src/lib/hdlc/
+studio:/sdk/protocol/openthread/platform-abstraction/include/
+studio:/sdk/util/third_party/openthread/examples/platforms/
+studio:/sdk/util/third_party/openthread/examples/platforms/utils/
+studio:/sdk/protocol/openthread/platform-abstraction/efr32/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/plugin/security_manager/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/
+studio:/sdk/platform/emdrv/ustimer/inc/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/extension/nc_efr32_watchdog_extension/inc/
+studio:/sdk/platform/Device/SiliconLabs/EFR32MG21/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/service/cpc/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/dmadrv/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/config/preset/
+studio:/sdk/platform/security/sl_component/sl_mbedtls_support/inc/
+studio:/sdk/util/third_party/mbedtls/include/
+studio:/sdk/util/third_party/mbedtls/library/
+studio:/sdk/platform/service/mem_pool/inc/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/protocol/openthread/include/
+studio:/sdk/protocol/openthread/platform-abstraction/ncp/
+studio:/sdk/protocol/openthread/src/legacy_hal/include/
+studio:/sdk/platform/service/legacy_hal/inc/
+studio:/sdk/util/third_party/openthread/include/
+studio:/sdk/util/third_party/openthread/include/openthread/
+studio:/sdk/util/third_party/openthread/src/core/
+studio:/sdk/util/third_party/openthread/src/lib/
+studio:/sdk/util/third_party/openthread/third_party/tcplp/
+studio:/sdk/util/third_party/openthread/src/
+studio:/sdk/util/third_party/openthread/src/ncp/
+studio:/sdk/util/third_party/openthread/src/lib/spinel/
+studio:/sdk/util/third_party/openthread/src/lib/hdlc/
+studio:/sdk/protocol/openthread/platform-abstraction/include/
+studio:/sdk/util/third_party/openthread/examples/platforms/
+studio:/sdk/util/third_party/openthread/examples/platforms/utils/
+studio:/sdk/protocol/openthread/platform-abstraction/efr32/
+studio:/sdk/platform/security/sl_component/sl_psa_driver/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg2x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/common/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/hal/efr32/
+studio:/sdk/platform/radio/rail_lib/plugin/coexistence/protocol/ieee802154_uc/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_dma/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_ieee802154/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_pti/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rf_path/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_rssi/
+studio:/sdk/platform/security/sl_component/se_manager/inc/
+studio:/sdk/platform/security/sl_component/se_manager/src/
+studio:/sdk/util/plugin/security_manager/
+studio:/sdk/util/silicon_labs/silabs_core/memory_manager/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/platform/security/sl_component/sl_protocol_crypto/src/
+studio:/sdk/platform/emdrv/ustimer/inc/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Werror=unused-function\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;,
 
@@ -86,7 +304,9 @@
 
 \&quot;-fmessage-length=0\&quot;,
 
-\&quot;-c\&quot;\n        ],
+\&quot;-c\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -96,7 +316,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
 
@@ -106,9 +328,19 @@
 
 \&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-c\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -118,9 +350,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-function\&quot;,
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Werror=unused-function\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;,
 
@@ -130,7 +372,9 @@
 
 \&quot;-fmessage-length=0\&quot;,
 
-\&quot;-c\&quot;\n        ],
+\&quot;-c\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -140,7 +384,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Werror=unused-function\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Werror=unused-variable\&quot;: \&quot;TRUE\&quot;,
 
@@ -150,9 +396,19 @@
 
 \&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-c\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-c\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -162,9 +418,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -174,9 +438,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -186,9 +454,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -198,11 +470,19 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;,
+},
 
-\&quot;sl_openthread_coex_config.h\&quot;\n        ],
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -212,11 +492,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
 
-\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -226,9 +514,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -238,9 +530,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -250,9 +546,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -262,9 +562,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -274,9 +578,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -286,9 +594,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -298,11 +610,19 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;,
+},
 
-\&quot;sl_openthread_coex_config.h\&quot;\n        ],
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -312,11 +632,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
 
-\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -326,9 +654,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -338,9 +670,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -350,9 +686,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -362,9 +702,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -374,9 +718,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -386,9 +734,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -398,9 +750,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -410,9 +766,13 @@
 
 \&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -422,9 +782,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -434,9 +798,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -446,9 +814,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -458,9 +830,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -470,9 +846,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -482,9 +862,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -494,9 +878,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -506,9 +894,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -518,9 +910,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -530,11 +926,19 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;,
+},
 
-\&quot;sl_openthread_coex_config.h\&quot;\n        ],
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;,
+
+\&quot;sl_openthread_coex_config.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -544,11 +948,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
 
-\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;,
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_openthread_coex_config.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -558,9 +970,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -570,9 +986,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -582,9 +1002,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -594,9 +1018,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -606,9 +1034,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.hard\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -618,9 +1050,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -630,9 +1066,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -642,9 +1082,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -654,9 +1098,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -666,13 +1114,21 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -682,13 +1138,21 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -698,9 +1162,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -710,9 +1178,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -722,9 +1194,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -734,13 +1210,21 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -750,25 +1234,33 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg21_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a\&quot;: \&quot;TRUE\&quot;
+
+}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4001a:0.0.0.A01 brd4179b:0.0.0.A05" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.mg21.efr32mg21a010f1024im32" projectCommon.referencedModules="[
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -808,7 +1300,7 @@
             &quot;config/sl_sleeptimer_config.h&quot;, 
             &quot;config/ustimer_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -834,7 +1326,7 @@
             &quot;autogen/sli_psa_builtin_config_autogen.h&quot;, 
             &quot;autogen/sli_psa_config_autogen.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1858,14 +2350,14 @@
             &quot;nc_efr32_watchdog_1.0.0/src/nc_efr32_wdog.c&quot;, 
             &quot;reset_util.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1874,7 +2366,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;   \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;efr32mg21a010f1024im32&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>

--- a/src/zwave_ncp_serial_api_controller/.cproject
+++ b/src/zwave_ncp_serial_api_controller/.cproject
@@ -73,8 +73,137 @@
         ], 
         &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
         &quot;id&quot;: &quot;&quot;, 
-        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/CMSIS/RTOS2/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/radio/rail_lib/plugin/fem_util/ studio:/sdk/util/third_party/freertos/cmsis/Include/ studio:/sdk/util/third_party/freertos/kernel/include/ studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/ studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/ studio:/sdk/protocol/z-wave/ZWave/API/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/ studio:/sdk/protocol/z-wave/AppsHw/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/ studio:/sdk/protocol/z-wave/PAL/inc/ studio:/sdk/protocol/z-wave/Components/SwTimer/ studio:/sdk/protocol/z-wave/Components/Utils/ studio:/sdk/protocol/z-wave/Components/QueueNotifying/ studio:/sdk/protocol/z-wave/Components/NodeMask/ studio:/sdk/protocol/z-wave/Components/DebugPrint/ studio:/sdk/protocol/z-wave/Components/Assert/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/ studio:/sdk/platform/halconfig/inc/hal-config/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ studio:/sdk/protocol/z-wave/Components/CRC/ studio:/sdk/protocol/z-wave/Components/EventDistributor/ studio:/sdk/protocol/z-wave/Components/SyncEvent/ studio:/sdk/protocol/z-wave/Components/MfgTokens/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/CMSIS/RTOS2/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/radio/rail_lib/plugin/fem_util/ studio:/sdk/util/third_party/freertos/cmsis/Include/ studio:/sdk/util/third_party/freertos/kernel/include/ studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/ studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/ studio:/sdk/protocol/z-wave/ZWave/API/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/ studio:/sdk/protocol/z-wave/AppsHw/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/ studio:/sdk/protocol/z-wave/PAL/inc/ studio:/sdk/protocol/z-wave/Components/SwTimer/ studio:/sdk/protocol/z-wave/Components/Utils/ studio:/sdk/protocol/z-wave/Components/QueueNotifying/ studio:/sdk/protocol/z-wave/Components/NodeMask/ studio:/sdk/protocol/z-wave/Components/DebugPrint/ studio:/sdk/protocol/z-wave/Components/Assert/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/ studio:/sdk/platform/halconfig/inc/hal-config/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ studio:/sdk/protocol/z-wave/Components/CRC/ studio:/sdk/protocol/z-wave/Components/EventDistributor/ studio:/sdk/protocol/z-wave/Components/SyncEvent/ studio:/sdk/protocol/z-wave/Components/MfgTokens/&quot;, 
-        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-parameter\&quot;,
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/platform/CMSIS/RTOS2/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/radio/rail_lib/plugin/fem_util/
+studio:/sdk/util/third_party/freertos/cmsis/Include/
+studio:/sdk/util/third_party/freertos/kernel/include/
+studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/platform/service/power_manager/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/
+studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/
+studio:/sdk/protocol/z-wave/ZWave/API/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/
+studio:/sdk/protocol/z-wave/AppsHw/inc/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/
+studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/
+studio:/sdk/protocol/z-wave/PAL/inc/
+studio:/sdk/protocol/z-wave/Components/SwTimer/
+studio:/sdk/protocol/z-wave/Components/Utils/
+studio:/sdk/protocol/z-wave/Components/QueueNotifying/
+studio:/sdk/protocol/z-wave/Components/NodeMask/
+studio:/sdk/protocol/z-wave/Components/DebugPrint/
+studio:/sdk/protocol/z-wave/Components/Assert/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/
+studio:/sdk/platform/halconfig/inc/hal-config/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/
+studio:/sdk/protocol/z-wave/Components/CRC/
+studio:/sdk/protocol/z-wave/Components/EventDistributor/
+studio:/sdk/protocol/z-wave/Components/SyncEvent/
+studio:/sdk/protocol/z-wave/Components/MfgTokens/
+studio:/project/config/
+studio:/project/autogen/
+studio:/project/
+studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/
+studio:/sdk/platform/common/inc/
+studio:/sdk/hardware/board/inc/
+studio:/sdk/platform/bootloader/
+studio:/sdk/platform/bootloader/api/
+studio:/sdk/platform/CMSIS/Core/Include/
+studio:/sdk/platform/CMSIS/RTOS2/Include/
+studio:/sdk/hardware/driver/configuration_over_swo/inc/
+studio:/sdk/platform/driver/debug/inc/
+studio:/sdk/platform/service/device_init/inc/
+studio:/sdk/platform/emdrv/common/inc/
+studio:/sdk/platform/emlib/inc/
+studio:/sdk/platform/radio/rail_lib/plugin/fem_util/
+studio:/sdk/util/third_party/freertos/cmsis/Include/
+studio:/sdk/util/third_party/freertos/kernel/include/
+studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/
+studio:/sdk/platform/emdrv/gpiointerrupt/inc/
+studio:/sdk/platform/service/mpu/inc/
+studio:/sdk/platform/emdrv/nvm3/inc/
+studio:/sdk/platform/service/power_manager/inc/
+studio:/sdk/platform/radio/rail_lib/common/
+studio:/sdk/platform/radio/rail_lib/protocol/ble/
+studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/
+studio:/sdk/platform/radio/rail_lib/protocol/wmbus/
+studio:/sdk/platform/radio/rail_lib/protocol/zwave/
+studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/
+studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/
+studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/
+studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/
+studio:/sdk/platform/common/toolchain/inc/
+studio:/sdk/platform/service/system/inc/
+studio:/sdk/platform/service/sleeptimer/inc/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/
+studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/
+studio:/sdk/protocol/z-wave/ZWave/API/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/
+studio:/sdk/protocol/z-wave/AppsHw/inc/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/
+studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/
+studio:/sdk/protocol/z-wave/PAL/inc/
+studio:/sdk/protocol/z-wave/Components/SwTimer/
+studio:/sdk/protocol/z-wave/Components/Utils/
+studio:/sdk/protocol/z-wave/Components/QueueNotifying/
+studio:/sdk/protocol/z-wave/Components/NodeMask/
+studio:/sdk/protocol/z-wave/Components/DebugPrint/
+studio:/sdk/protocol/z-wave/Components/Assert/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/
+studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/
+studio:/sdk/platform/halconfig/inc/hal-config/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/
+studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/
+studio:/sdk/protocol/z-wave/Components/CRC/
+studio:/sdk/protocol/z-wave/Components/EventDistributor/
+studio:/sdk/protocol/z-wave/Components/SyncEvent/
+studio:/sdk/protocol/z-wave/Components/MfgTokens/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Werror=unused-parameter\&quot;,
 
 \&quot;-Wextra\&quot;,
 
@@ -94,7 +223,9 @@
 
 \&quot;-Werror=vla\&quot;,
 
-\&quot;-fmerge-all-constants\&quot;\n        ],
+\&quot;-fmerge-all-constants\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -104,7 +235,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-parameter\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Werror=unused-parameter\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Wextra\&quot;: \&quot;TRUE\&quot;,
 
@@ -124,11 +257,21 @@
 
 \&quot;-Werror=vla\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-fmerge-all-constants\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-fmerge-all-constants\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,
+}
 
-\&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -138,11 +281,21 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
 
-\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;: \&quot;TRUE\&quot;,
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-parameter\&quot;,
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Werror=unused-parameter\&quot;,
 
 \&quot;-Wextra\&quot;,
 
@@ -162,7 +315,9 @@
 
 \&quot;-Werror=vla\&quot;,
 
-\&quot;-fmerge-all-constants\&quot;\n        ],
+\&quot;-fmerge-all-constants\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -172,7 +327,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-parameter\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;-Werror=unused-parameter\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;-Wextra\&quot;: \&quot;TRUE\&quot;,
 
@@ -192,11 +349,21 @@
 
 \&quot;-Werror=vla\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;-fmerge-all-constants\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-fmerge-all-constants\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,
+}
 
-\&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -206,11 +373,19 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
 
-\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;: \&quot;TRUE\&quot;,
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
 
@@ -220,9 +395,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -232,9 +411,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -244,9 +427,17 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
 
@@ -256,9 +447,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -268,9 +467,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -280,9 +483,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -292,9 +499,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -304,9 +515,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -316,9 +531,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -328,9 +547,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -340,9 +563,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -352,9 +583,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -364,9 +603,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -376,9 +619,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -388,9 +635,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -400,9 +651,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -412,9 +667,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -424,9 +683,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -436,9 +699,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -448,9 +715,13 @@
 
 \&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
 
@@ -460,9 +731,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -472,9 +747,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -484,9 +763,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -496,9 +779,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -508,9 +795,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -520,9 +811,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -532,9 +827,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -544,9 +843,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -556,9 +859,13 @@
 
 \&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -568,9 +875,17 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;sl_gcc_preinclude.h\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -580,9 +895,17 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;listValuesMap\&quot;: {
 
-{\n        \&quot;listValues\&quot;: [],
+\&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;
+
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -592,9 +915,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -604,9 +931,13 @@
 
 \&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -616,9 +947,13 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -628,9 +963,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -640,9 +979,13 @@
 
 \&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -652,9 +995,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -664,9 +1011,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -676,9 +1027,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -688,9 +1043,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
 
@@ -700,9 +1059,15 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,
 
 \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;,
 
@@ -710,7 +1075,9 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
 
@@ -720,7 +1087,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
@@ -728,9 +1097,15 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;: \&quot;TRUE\&quot;
 
-{\n        \&quot;listValues\&quot;: [],
+}
+
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -740,9 +1115,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -752,9 +1131,13 @@
 
 \&quot;value\&quot;: \&quot;true\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -764,9 +1147,13 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [],
+},
+
+{
+
+\&quot;listValues\&quot;: [],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
 
@@ -776,9 +1163,15 @@
 
 \&quot;value\&quot;: \&quot;false\&quot;,
 
-\&quot;listValuesMap\&quot;: {}\n    },
+\&quot;listValuesMap\&quot;: {}
 
-{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,
+},
+
+{
+
+\&quot;listValues\&quot;: [
+
+\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,
 
 \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;,
 
@@ -786,7 +1179,9 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;\n        ],
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;
+
+],
 
 \&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
 
@@ -796,7 +1191,9 @@
 
 \&quot;value\&quot;: \&quot;\&quot;,
 
-\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;: \&quot;TRUE\&quot;,
+\&quot;listValuesMap\&quot;: {
+
+\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;: \&quot;TRUE\&quot;,
 
 \&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
@@ -804,7 +1201,13 @@
 
 \&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;: \&quot;TRUE\&quot;,
 
-\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;: \&quot;TRUE\&quot;
+
+}
+
+}
+
+]&quot;
     }
 ]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4207a:0.0.0 brd4001a:0.0.0.A01" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.zg13.zgm130s037hgn" projectCommon.referencedModules="[
     {
@@ -842,7 +1245,7 @@
             &quot;config/zw_region_config.h&quot;, 
             &quot;config/zw_version_config.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -858,7 +1261,7 @@
             &quot;autogen/sl_event_handler.c&quot;, 
             &quot;autogen/sl_event_handler.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1249,28 +1652,28 @@
             &quot;virtual_slave_node_info.h&quot;, 
             &quot;zaf_config_security.h&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
         &quot;builtinExcludes&quot;: [], 
         &quot;removed&quot;: false, 
         &quot;builtinSources&quot;: [], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }, 
     {
@@ -1279,7 +1682,7 @@
         &quot;builtinSources&quot;: [
             &quot;autogen/.crc_config.crc&quot;
         ], 
-        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;  &lt;/project:MModule&gt;&quot;, 
         &quot;builtin&quot;: true
     }
 ]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;zgm130s037hgn&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>

--- a/src/zwave_ncp_serial_api_controller/.cproject
+++ b/src/zwave_ncp_serial_api_controller/.cproject
@@ -23,7 +23,1266 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
-			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[{&quot;builtinMacrosMap&quot;:{&quot;EFR32ZG&quot;:&quot;1&quot;,&quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;:&quot;&lt;sl_rail_util_pa_config.h&gt;&quot;,&quot;ZW_CONTROLLER_BRIDGE&quot;:&quot;1&quot;,&quot;ZW_CONTROLLER_STATIC&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_DEFAULT_RF_BAND_868&quot;:&quot;1&quot;,&quot;SL_BOARD_REV&quot;:&quot;\&quot;A00\&quot;&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_914&quot;:&quot;1&quot;,&quot;SDK_VERSION_MAJOR&quot;:&quot;7&quot;,&quot;configPRE_SLEEP_PROCESSING&quot;:&quot;enterPowerDown&quot;,&quot;ZW_MIGRATION_FROM_7_20&quot;:&quot;1&quot;,&quot;SDK_VERSION_PATCH&quot;:&quot;3&quot;,&quot;APP_PROPERTIES_CONFIG_FILE&quot;:&quot;&lt;application_properties_config.h&gt;&quot;,&quot;NDEBUG&quot;:&quot;1&quot;,&quot;ZGM130S037HGN&quot;:&quot;1&quot;,&quot;SL_COMPONENT_CATALOG_PRESENT&quot;:&quot;1&quot;,&quot;CONFIG_MBEDTLS_USE_FREERTOS_PVCALLOC&quot;:&quot;1&quot;,&quot;SL_IOSTREAM_UART_FLUSH_TX_BUFFER&quot;:&quot;1&quot;,&quot;configPOST_SLEEP_PROCESSING&quot;:&quot;exitPowerDown&quot;,&quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;:&quot;0&quot;,&quot;ZW_CONTROLLER&quot;:&quot;1&quot;,&quot;ZWAVE_SERIES_700&quot;:&quot;1&quot;,&quot;SDK_VERSION_MINOR&quot;:&quot;21&quot;,&quot;ZAF_VERSION_MINOR&quot;:&quot;21&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_924&quot;:&quot;1&quot;,&quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_868&quot;:&quot;1&quot;,&quot;ZW_VERSION_MAJOR&quot;:&quot;7&quot;,&quot;ZAF_VERSION_PATCH&quot;:&quot;3&quot;,&quot;ZAF_CONFIG_DEVICE_OPTION_MASK&quot;:&quot;APPLICATION_NODEINFO_LISTENING&quot;,&quot;EXT_BOARD_8029A&quot;:&quot;1&quot;,&quot;ZAF_VERSION_MAJOR&quot;:&quot;10&quot;,&quot;SL_BOARD_NAME&quot;:&quot;\&quot;BRD4207A\&quot;&quot;,&quot;ZW_VERSION_MINOR&quot;:&quot;21&quot;,&quot;HARDWARE_BOARD_SUPPORTS_3_RF_BANDS&quot;:&quot;1&quot;,&quot;ZW_VERSION_PATCH&quot;:&quot;3&quot;,&quot;NO_DEBUGPRINT&quot;:&quot;1&quot;,&quot;SL_APP_PROPERTIES&quot;:&quot;1&quot;},&quot;builtinLibraryPathsStr&quot;:&quot;&quot;,&quot;builtinLibraryFilesStr&quot;:&quot;&quot;,&quot;builtinLibraryNames&quot;:[&quot;gcc&quot;,&quot;c&quot;,&quot;m&quot;,&quot;nosys&quot;],&quot;builtinLibraryObjectsStr&quot;:&quot;&quot;,&quot;id&quot;:&quot;&quot;,&quot;builtinIncludesStr&quot;:&quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/CMSIS/RTOS2/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/radio/rail_lib/plugin/fem_util/ studio:/sdk/util/third_party/freertos/cmsis/Include/ studio:/sdk/util/third_party/freertos/kernel/include/ studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/ studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/ studio:/sdk/protocol/z-wave/ZWave/API/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/ studio:/sdk/protocol/z-wave/AppsHw/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/ studio:/sdk/protocol/z-wave/PAL/inc/ studio:/sdk/protocol/z-wave/Components/SwTimer/ studio:/sdk/protocol/z-wave/Components/Utils/ studio:/sdk/protocol/z-wave/Components/QueueNotifying/ studio:/sdk/protocol/z-wave/Components/NodeMask/ studio:/sdk/protocol/z-wave/Components/DebugPrint/ studio:/sdk/protocol/z-wave/Components/Assert/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/ studio:/sdk/platform/halconfig/inc/hal-config/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ studio:/sdk/protocol/z-wave/Components/CRC/ studio:/sdk/protocol/z-wave/Components/EventDistributor/ studio:/sdk/protocol/z-wave/Components/SyncEvent/ studio:/sdk/protocol/z-wave/Components/MfgTokens/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/CMSIS/RTOS2/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/radio/rail_lib/plugin/fem_util/ studio:/sdk/util/third_party/freertos/cmsis/Include/ studio:/sdk/util/third_party/freertos/kernel/include/ studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/ studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/ studio:/sdk/protocol/z-wave/ZWave/API/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/ studio:/sdk/protocol/z-wave/AppsHw/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/ studio:/sdk/protocol/z-wave/PAL/inc/ studio:/sdk/protocol/z-wave/Components/SwTimer/ studio:/sdk/protocol/z-wave/Components/Utils/ studio:/sdk/protocol/z-wave/Components/QueueNotifying/ studio:/sdk/protocol/z-wave/Components/NodeMask/ studio:/sdk/protocol/z-wave/Components/DebugPrint/ studio:/sdk/protocol/z-wave/Components/Assert/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/ studio:/sdk/platform/halconfig/inc/hal-config/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ studio:/sdk/protocol/z-wave/Components/CRC/ studio:/sdk/protocol/z-wave/Components/EventDistributor/ studio:/sdk/protocol/z-wave/Components/SyncEvent/ studio:/sdk/protocol/z-wave/Components/MfgTokens/&quot;,&quot;resolvedOptionsStr&quot;:&quot;[{\&quot;listValues\&quot;:[\&quot;-Werror=unused-parameter\&quot;,\&quot;-Wextra\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-Wall\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-s\&quot;,\&quot;-Wno-implicit-function-declaration\&quot;,\&quot;-c\&quot;,\&quot;-Werror\&quot;,\&quot;-Werror=vla\&quot;,\&quot;-fmerge-all-constants\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Werror=unused-parameter\&quot;:\&quot;TRUE\&quot;,\&quot;-Wextra\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-Wall\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-s\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-implicit-function-declaration\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror=vla\&quot;:\&quot;TRUE\&quot;,\&quot;-fmerge-all-constants\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;:\&quot;TRUE\&quot;,\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Werror=unused-parameter\&quot;,\&quot;-Wextra\&quot;,\&quot;--specs=nano.specs\&quot;,\&quot;-Wall\&quot;,\&quot;-fmessage-length=0\&quot;,\&quot;-s\&quot;,\&quot;-Wno-implicit-function-declaration\&quot;,\&quot;-c\&quot;,\&quot;-Werror\&quot;,\&quot;-Werror=vla\&quot;,\&quot;-fmerge-all-constants\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Werror=unused-parameter\&quot;:\&quot;TRUE\&quot;,\&quot;-Wextra\&quot;:\&quot;TRUE\&quot;,\&quot;--specs=nano.specs\&quot;:\&quot;TRUE\&quot;,\&quot;-Wall\&quot;:\&quot;TRUE\&quot;,\&quot;-fmessage-length=0\&quot;:\&quot;TRUE\&quot;,\&quot;-s\&quot;:\&quot;TRUE\&quot;,\&quot;-Wno-implicit-function-declaration\&quot;:\&quot;TRUE\&quot;,\&quot;-c\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror\&quot;:\&quot;TRUE\&quot;,\&quot;-Werror=vla\&quot;:\&quot;TRUE\&quot;,\&quot;-fmerge-all-constants\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,\&quot;-Wl,--no-warn-rwx-segments\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;:\&quot;TRUE\&quot;,\&quot;-Wl,--no-warn-rwx-segments\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.softfp\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.softfp\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.c.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.softfp\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,\&quot;value\&quot;:\&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.softfp\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,\&quot;value\&quot;:\&quot;gnu.cpp.compiler.optimization.level.size\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;sl_gcc_preinclude.h\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;sl_gcc_preinclude.h\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,\&quot;value\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,\&quot;value\&quot;:\&quot;floatingpoint.type.softfp\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;,\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.c.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;:\&quot;TRUE\&quot;}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,\&quot;value\&quot;:\&quot;true\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,\&quot;builtin\&quot;:true,\&quot;optionId\&quot;:\&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,\&quot;value\&quot;:\&quot;false\&quot;,\&quot;listValuesMap\&quot;:{}},{\&quot;listValues\&quot;:[\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;,\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;],\&quot;toolId\&quot;:\&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,\&quot;builtin\&quot;:false,\&quot;optionId\&quot;:\&quot;gnu.cpp.link.option.userobjs\&quot;,\&quot;value\&quot;:\&quot;\&quot;,\&quot;listValuesMap\&quot;:{\&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;:\&quot;TRUE\&quot;,\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;:\&quot;TRUE\&quot;}}]&quot;}]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4207a:0.0.0 brd4001a:0.0.0.A01" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.zg13.zgm130s037hgn" projectCommon.referencedModules="[{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;config/FreeRTOSConfig.h&quot;,&quot;config/app_properties_config.h&quot;,&quot;config/btl_interface_cfg.h&quot;,&quot;config/emlib_core_debug_config.h&quot;,&quot;config/extension_board_8029a_efr32xg13.h&quot;,&quot;config/extension_board_8029a_efr32xg13_button.h&quot;,&quot;config/extension_board_8029a_efr32xg13_led.h&quot;,&quot;config/extension_board_8029a_efr32xg13_slider.h&quot;,&quot;config/nvm3_default_config.h&quot;,&quot;config/serial_api_config.h&quot;,&quot;config/sl_board_control_config.h&quot;,&quot;config/sl_debug_swo_config.h&quot;,&quot;config/sl_device_init_dcdc_config.h&quot;,&quot;config/sl_device_init_emu_config.h&quot;,&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;config/sl_fem_util_config.h&quot;,&quot;config/sl_memory_config.h&quot;,&quot;config/sl_power_manager_config.h&quot;,&quot;config/sl_rail_util_pa_config.h&quot;,&quot;config/sl_rail_util_power_manager_init_config.h&quot;,&quot;config/sl_rail_util_sequencer_config.h&quot;,&quot;config/sl_sleeptimer_config.h&quot;,&quot;config/zaf_appname_config.h&quot;,&quot;config/zaf_config.h&quot;,&quot;config/zaf_event_distributor_core_config.h&quot;,&quot;config/zpal_zwave_nvm_instance_config.h&quot;,&quot;config/zw_build_no.h&quot;,&quot;config/zw_config_rf.h&quot;,&quot;config/zw_region_config.h&quot;,&quot;config/zw_version_config.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/RTE_Components.h&quot;,&quot;autogen/linkerfile.ld&quot;,&quot;autogen/sl_application_type.h&quot;,&quot;autogen/sl_board_default_init.c&quot;,&quot;autogen/sl_component_catalog.h&quot;,&quot;autogen/sl_device_init_clocks.c&quot;,&quot;autogen/sl_event_handler.c&quot;,&quot;autogen/sl_event_handler.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;README.md&quot;,&quot;app.c&quot;,&quot;app.h&quot;,&quot;app_node_info.c&quot;,&quot;app_node_info.h&quot;,&quot;cmd_get_capabilities.c&quot;,&quot;cmd_handlers.c&quot;,&quot;cmd_handlers.h&quot;,&quot;cmd_handlers_invoker.c&quot;,&quot;cmds_dcdc.c&quot;,&quot;cmds_management.c&quot;,&quot;cmds_management.h&quot;,&quot;cmds_power_management.c&quot;,&quot;cmds_rf.c&quot;,&quot;cmds_rf.h&quot;,&quot;cmds_security.c&quot;,&quot;cmds_security.h&quot;,&quot;comm_interface.c&quot;,&quot;comm_interface.h&quot;,&quot;controller_supported_func.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;,&quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;,&quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm4.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv7.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/RTOS2/Include/cmsis_os2.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/RTOS2/Include/os_tick.h&quot;,&quot;gecko_sdk_4.4.3/platform/CMSIS/RTOS2/Source/os_systick.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/em_device.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/system_zgm13.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm130s037hgn.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_adc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_af_pins.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_af_ports.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_cryotimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_csen.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_devinfo.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_dma_descriptor.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_dmareq.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_etm.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_fpueh.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_gpio_p.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_idac.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_ldma_ch.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense_buf.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense_ch.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense_st.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_leuart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_pcnt.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_prs_ch.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_prs_signals.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_romtable.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtc_comp.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtcc_cc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtcc_ret.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_timer_cc.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_trng.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_vdac.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_vdac_opa.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_wdog_pch.h&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Source/startup_zgm13.c&quot;,&quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Source/system_zgm13.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;,&quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_cmsis_os2_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_slist.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_slist.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;,&quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;,&quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/inc/gpiointerrupt.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;,&quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_acmp.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_adc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cryotimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_crypto.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_crypto_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_csen.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_dbg.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpcrc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_i2c.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_idac.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_lesense.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_letimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_leuart.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_opamp.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_pcnt.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_smu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_vdac.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_acmp.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_adc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_cryotimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_crypto.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_csen.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_dbg.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpcrc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_i2c.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_idac.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_lesense.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_letimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_leuart.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_opamp.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_pcnt.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_vdac.c&quot;,&quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;,&quot;gecko_sdk_4.4.3/platform/halconfig/inc/hal-config/hal-config-types.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg1x/rail_chip_specific.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/fem_util/sl_fem_util.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/fem_util/sl_fem_util.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/sl_rail_util_pa_curves.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_sequencer/sl_rail_util_sequencer.c&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;,&quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_dcdc.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_dcdc_s1.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s1.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s1.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/mpu/inc/sl_mpu.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/mpu/src/sl_mpu.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager_debug.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sli_power_manager.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_debug.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_hal_s0_s1.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sli_power_manager_private.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_kernel.h&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;,&quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_kernel.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Apps/zwave_ncp_serial_api/SerialAPI_hw.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/AppsHw/inc/app_hw.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/AppsHw/inc/board_indicator.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/AppsHw/inc/board_init.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/Assert/Assert.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/CRC/CRC.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/DebugPrint/DebugPrint.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/DebugPrint/DebugPrintConfig.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/EventDistributor/EventDistributor.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/MfgTokens/MfgTokens.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/NodeMask/NodeMask.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/QueueNotifying/QueueNotifying.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/SwTimer/SwTimer.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/SwTimer/SwTimerLiaison.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/SyncEvent/SyncEvent.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/Utils/Min2Max2.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/Components/Utils/SizeOf.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/ZW_classcmd.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_bootloader.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_entropy.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_init.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_misc.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_nvm.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_power_manager.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_radio.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_radio_utils.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_retention_register.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_status.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_uart.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_watchdog.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ZAF_Actuator.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ZAF_AppName.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ZAF_AppName_weak.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppTimer.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppTimer.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppTimerDeepSleep.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor_ncp.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor_ncp.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ZAF_TSE.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_ApplicationEvents.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_CmdPublisher.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_file_ids.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm_app.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm_app.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_retention_register.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_retention_register.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_types.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZW_TransportEndpoint.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZW_TransportSecProtocol.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZW_product_id_enum.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ZAF_Common_helper.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ZAF_Common_interface.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ZAF_Common_interface.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ev_man.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ProtocolConfig/inc/zaf_protocol_config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ProtocolConfig/src/zaf_protocol_config.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_SerialAPI.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_UserTask.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_application_transport_interface.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_basis_api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_controller_api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_security_api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_slave_api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_system_startup_api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_transport_api.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_typedefs.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/lib/libZWaveController_700s.a&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ADC.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/board.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/extension_board_8029a.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/target_boards.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/SerialAPI/SerialAPI_hw.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/ADC.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board_BRD420x.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board_indicator.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board_init.c&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/application_properties_config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/hal-config-board-700.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/hal-config.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/sl_dcdc.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/system_startup.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/zpal_uart_config_ext.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/zpal_zwave_nvm_instance.h&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a&quot;,&quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/src/zpal_zwave_nvm_instance.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/cmsis/Include/freertos_mpool.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/cmsis/Include/freertos_os2.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/cmsis/Source/cmsis_os2.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/croutine.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/event_groups.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/FreeRTOS.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/StackMacros.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/atomic.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/croutine.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/deprecated_definitions.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/event_groups.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/list.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/message_buffer.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/mpu_prototypes.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/mpu_wrappers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/portable.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/projdefs.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/queue.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/semphr.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/stack_macros.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/stream_buffer.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/task.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/timers.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/list.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/port.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/portmacro.h&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/MemMang/heap_4.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/queue.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/stream_buffer.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/tasks.c&quot;,&quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/timers.c&quot;,&quot;main.c&quot;,&quot;nvm_backup_restore.c&quot;,&quot;nvm_backup_restore.h&quot;,&quot;postbuild.sh&quot;,&quot;serialapi_file.c&quot;,&quot;serialapi_file.h&quot;,&quot;slave_supported_func.h&quot;,&quot;utils.c&quot;,&quot;utils.h&quot;,&quot;virtual_slave_node_info.c&quot;,&quot;virtual_slave_node_info.h&quot;,&quot;zaf_config_security.h&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true},{&quot;builtinExcludes&quot;:[],&quot;removed&quot;:false,&quot;builtinSources&quot;:[&quot;autogen/.crc_config.crc&quot;],&quot;module&quot;:&quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;\n  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;\n&lt;/project:MModule&gt;&quot;,&quot;builtin&quot;:true}]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;zgm130s037hgn&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+			<storageModule buildConfig.needsApplyStock="true" buildConfig.stockConfigId="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" cppBuildConfig.projectBuiltInState="[
+    {
+        &quot;builtinMacrosMap&quot;: {
+            &quot;EFR32ZG&quot;: &quot;1&quot;, 
+            &quot;SL_RAIL_UTIL_PA_CONFIG_HEADER&quot;: &quot;&lt;sl_rail_util_pa_config.h&gt;&quot;, 
+            &quot;ZW_CONTROLLER_BRIDGE&quot;: &quot;1&quot;, 
+            &quot;ZW_CONTROLLER_STATIC&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_DEFAULT_RF_BAND_868&quot;: &quot;1&quot;, 
+            &quot;SL_BOARD_REV&quot;: &quot;\&quot;A00\&quot;&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_914&quot;: &quot;1&quot;, 
+            &quot;SDK_VERSION_MAJOR&quot;: &quot;7&quot;, 
+            &quot;configPRE_SLEEP_PROCESSING&quot;: &quot;enterPowerDown&quot;, 
+            &quot;ZW_MIGRATION_FROM_7_20&quot;: &quot;1&quot;, 
+            &quot;SDK_VERSION_PATCH&quot;: &quot;3&quot;, 
+            &quot;APP_PROPERTIES_CONFIG_FILE&quot;: &quot;&lt;application_properties_config.h&gt;&quot;, 
+            &quot;NDEBUG&quot;: &quot;1&quot;, 
+            &quot;ZGM130S037HGN&quot;: &quot;1&quot;, 
+            &quot;SL_COMPONENT_CATALOG_PRESENT&quot;: &quot;1&quot;, 
+            &quot;CONFIG_MBEDTLS_USE_FREERTOS_PVCALLOC&quot;: &quot;1&quot;, 
+            &quot;SL_IOSTREAM_UART_FLUSH_TX_BUFFER&quot;: &quot;1&quot;, 
+            &quot;configPOST_SLEEP_PROCESSING&quot;: &quot;exitPowerDown&quot;, 
+            &quot;SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT&quot;: &quot;0&quot;, 
+            &quot;ZW_CONTROLLER&quot;: &quot;1&quot;, 
+            &quot;ZWAVE_SERIES_700&quot;: &quot;1&quot;, 
+            &quot;SDK_VERSION_MINOR&quot;: &quot;21&quot;, 
+            &quot;ZAF_VERSION_MINOR&quot;: &quot;21&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_924&quot;: &quot;1&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_RF_BAND_868&quot;: &quot;1&quot;, 
+            &quot;ZW_VERSION_MAJOR&quot;: &quot;7&quot;, 
+            &quot;ZAF_VERSION_PATCH&quot;: &quot;3&quot;, 
+            &quot;ZAF_CONFIG_DEVICE_OPTION_MASK&quot;: &quot;APPLICATION_NODEINFO_LISTENING&quot;, 
+            &quot;EXT_BOARD_8029A&quot;: &quot;1&quot;, 
+            &quot;ZAF_VERSION_MAJOR&quot;: &quot;10&quot;, 
+            &quot;SL_BOARD_NAME&quot;: &quot;\&quot;BRD4207A\&quot;&quot;, 
+            &quot;ZW_VERSION_MINOR&quot;: &quot;21&quot;, 
+            &quot;HARDWARE_BOARD_SUPPORTS_3_RF_BANDS&quot;: &quot;1&quot;, 
+            &quot;ZW_VERSION_PATCH&quot;: &quot;3&quot;, 
+            &quot;NO_DEBUGPRINT&quot;: &quot;1&quot;, 
+            &quot;SL_APP_PROPERTIES&quot;: &quot;1&quot;
+        }, 
+        &quot;builtinLibraryPathsStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryFilesStr&quot;: &quot;&quot;, 
+        &quot;builtinLibraryNames&quot;: [
+            &quot;gcc&quot;, 
+            &quot;c&quot;, 
+            &quot;m&quot;, 
+            &quot;nosys&quot;
+        ], 
+        &quot;builtinLibraryObjectsStr&quot;: &quot;&quot;, 
+        &quot;id&quot;: &quot;&quot;, 
+        &quot;builtinIncludesStr&quot;: &quot;studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/CMSIS/RTOS2/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/radio/rail_lib/plugin/fem_util/ studio:/sdk/util/third_party/freertos/cmsis/Include/ studio:/sdk/util/third_party/freertos/kernel/include/ studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/ studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/ studio:/sdk/protocol/z-wave/ZWave/API/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/ studio:/sdk/protocol/z-wave/AppsHw/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/ studio:/sdk/protocol/z-wave/PAL/inc/ studio:/sdk/protocol/z-wave/Components/SwTimer/ studio:/sdk/protocol/z-wave/Components/Utils/ studio:/sdk/protocol/z-wave/Components/QueueNotifying/ studio:/sdk/protocol/z-wave/Components/NodeMask/ studio:/sdk/protocol/z-wave/Components/DebugPrint/ studio:/sdk/protocol/z-wave/Components/Assert/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/ studio:/sdk/platform/halconfig/inc/hal-config/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ studio:/sdk/protocol/z-wave/Components/CRC/ studio:/sdk/protocol/z-wave/Components/EventDistributor/ studio:/sdk/protocol/z-wave/Components/SyncEvent/ studio:/sdk/protocol/z-wave/Components/MfgTokens/ studio:/project/config/ studio:/project/autogen/ studio:/project/ studio:/sdk/platform/Device/SiliconLabs/ZGM13/Include/ studio:/sdk/platform/common/inc/ studio:/sdk/hardware/board/inc/ studio:/sdk/platform/bootloader/ studio:/sdk/platform/bootloader/api/ studio:/sdk/platform/CMSIS/Core/Include/ studio:/sdk/platform/CMSIS/RTOS2/Include/ studio:/sdk/hardware/driver/configuration_over_swo/inc/ studio:/sdk/platform/driver/debug/inc/ studio:/sdk/platform/service/device_init/inc/ studio:/sdk/platform/emdrv/common/inc/ studio:/sdk/platform/emlib/inc/ studio:/sdk/platform/radio/rail_lib/plugin/fem_util/ studio:/sdk/util/third_party/freertos/cmsis/Include/ studio:/sdk/util/third_party/freertos/kernel/include/ studio:/sdk/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/ studio:/sdk/platform/emdrv/gpiointerrupt/inc/ studio:/sdk/platform/service/mpu/inc/ studio:/sdk/platform/emdrv/nvm3/inc/ studio:/sdk/platform/service/power_manager/inc/ studio:/sdk/platform/radio/rail_lib/common/ studio:/sdk/platform/radio/rail_lib/protocol/ble/ studio:/sdk/platform/radio/rail_lib/protocol/ieee802154/ studio:/sdk/platform/radio/rail_lib/protocol/wmbus/ studio:/sdk/platform/radio/rail_lib/protocol/zwave/ studio:/sdk/platform/radio/rail_lib/chip/efr32/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/protocol/sidewalk/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/ studio:/sdk/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/ studio:/sdk/platform/radio/rail_lib/plugin/rail_util_power_manager_init/ studio:/sdk/platform/common/toolchain/inc/ studio:/sdk/platform/service/system/inc/ studio:/sdk/platform/service/sleeptimer/inc/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/ studio:/sdk/protocol/z-wave/ZAF/ProtocolConfig/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/ studio:/sdk/protocol/z-wave/ZWave/API/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/ studio:/sdk/protocol/z-wave/AppsHw/inc/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ studio:/sdk/protocol/z-wave/Apps/zwave_ncp_serial_api/ studio:/sdk/protocol/z-wave/PAL/inc/ studio:/sdk/protocol/z-wave/Components/SwTimer/ studio:/sdk/protocol/z-wave/Components/Utils/ studio:/sdk/protocol/z-wave/Components/QueueNotifying/ studio:/sdk/protocol/z-wave/Components/NodeMask/ studio:/sdk/protocol/z-wave/Components/DebugPrint/ studio:/sdk/protocol/z-wave/Components/Assert/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/ studio:/sdk/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/ studio:/sdk/platform/halconfig/inc/hal-config/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ studio:/sdk/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ studio:/sdk/protocol/z-wave/Components/CRC/ studio:/sdk/protocol/z-wave/Components/EventDistributor/ studio:/sdk/protocol/z-wave/Components/SyncEvent/ studio:/sdk/protocol/z-wave/Components/MfgTokens/&quot;, 
+        &quot;resolvedOptionsStr&quot;: &quot;[\n    {\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-parameter\&quot;,
+
+\&quot;-Wextra\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-Wall\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-s\&quot;,
+
+\&quot;-Wno-implicit-function-declaration\&quot;,
+
+\&quot;-c\&quot;,
+
+\&quot;-Werror\&quot;,
+
+\&quot;-Werror=vla\&quot;,
+
+\&quot;-fmerge-all-constants\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-parameter\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wextra\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wall\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-s\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-implicit-function-declaration\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror=vla\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmerge-all-constants\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.c.link.option.ldflags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Werror=unused-parameter\&quot;,
+
+\&quot;-Wextra\&quot;,
+
+\&quot;--specs=nano.specs\&quot;,
+
+\&quot;-Wall\&quot;,
+
+\&quot;-fmessage-length=0\&quot;,
+
+\&quot;-s\&quot;,
+
+\&quot;-Wno-implicit-function-declaration\&quot;,
+
+\&quot;-c\&quot;,
+
+\&quot;-Werror\&quot;,
+
+\&quot;-Werror=vla\&quot;,
+
+\&quot;-fmerge-all-constants\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.compiler.option.misc.otherlist\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Werror=unused-parameter\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wextra\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;--specs=nano.specs\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wall\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmessage-length=0\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-s\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wno-implicit-function-declaration\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-c\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Werror=vla\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-fmerge-all-constants\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;,
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.gnu.cpp.link.option.flags\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;-Wl,--start-group -lgcc -lc -Wl,--end-group\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;-Wl,--no-warn-rwx-segments\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.archiver.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.assembler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.misc.dialect.c99\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.c.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nostdlibs\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script\&quot;,
+
+\&quot;value\&quot;: \&quot;${workspace_loc:/${ProjName}/autogen/linkerfile.ld}\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.cpp0x\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_exceptions\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.no_rtti\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.datasect\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.functionsects\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.level\&quot;,
+
+\&quot;value\&quot;: \&quot;gnu.cpp.compiler.optimization.level.size\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.optimization.omitframepointer\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;sl_gcc_preinclude.h\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.preinclude\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;sl_gcc_preinclude.h\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.circulardependency\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.clibs\&quot;,
+
+\&quot;value\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.nanospec\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.dependencies.projects\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.enable\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.floatingpoint.type\&quot;,
+
+\&quot;value\&quot;: \&quot;floatingpoint.type.softfp\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.map\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.c.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;: \&quot;TRUE\&quot;\n        }\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.allwarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.extrawarn\&quot;,
+
+\&quot;value\&quot;: \&quot;true\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.pedantic\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base\&quot;,
+
+\&quot;builtin\&quot;: true,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.compiler.option.warnings.toerrors\&quot;,
+
+\&quot;value\&quot;: \&quot;false\&quot;,
+
+\&quot;listValuesMap\&quot;: {}\n    },
+
+{\n        \&quot;listValues\&quot;: [\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;\n        ],
+
+\&quot;toolId\&quot;: \&quot;com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base\&quot;,
+
+\&quot;builtin\&quot;: false,
+
+\&quot;optionId\&quot;: \&quot;gnu.cpp.link.option.userobjs\&quot;,
+
+\&quot;value\&quot;: \&quot;\&quot;,
+
+\&quot;listValuesMap\&quot;: {\n            \&quot;${StudioSdkPath}/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a\&quot;: \&quot;TRUE\&quot;,
+
+\&quot;${StudioSdkPath}/protocol/z-wave/ZWave/lib/libZWaveController_700s.a\&quot;: \&quot;TRUE\&quot;\n        }\n    }\n]&quot;
+    }
+]" moduleId="com.silabs.ss.framework.ide.project.core.cpp" projectCommon.boardIds="brd4207a:0.0.0 brd4001a:0.0.0.A01" projectCommon.buildArtifactType="EXE" projectCommon.partId="mcu.arm.efr32.zg13.zgm130s037hgn" projectCommon.referencedModules="[
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;config/FreeRTOSConfig.h&quot;, 
+            &quot;config/app_properties_config.h&quot;, 
+            &quot;config/btl_interface_cfg.h&quot;, 
+            &quot;config/emlib_core_debug_config.h&quot;, 
+            &quot;config/extension_board_8029a_efr32xg13.h&quot;, 
+            &quot;config/extension_board_8029a_efr32xg13_button.h&quot;, 
+            &quot;config/extension_board_8029a_efr32xg13_led.h&quot;, 
+            &quot;config/extension_board_8029a_efr32xg13_slider.h&quot;, 
+            &quot;config/nvm3_default_config.h&quot;, 
+            &quot;config/serial_api_config.h&quot;, 
+            &quot;config/sl_board_control_config.h&quot;, 
+            &quot;config/sl_debug_swo_config.h&quot;, 
+            &quot;config/sl_device_init_dcdc_config.h&quot;, 
+            &quot;config/sl_device_init_emu_config.h&quot;, 
+            &quot;config/sl_device_init_hfxo_config.h&quot;, 
+            &quot;config/sl_fem_util_config.h&quot;, 
+            &quot;config/sl_memory_config.h&quot;, 
+            &quot;config/sl_power_manager_config.h&quot;, 
+            &quot;config/sl_rail_util_pa_config.h&quot;, 
+            &quot;config/sl_rail_util_power_manager_init_config.h&quot;, 
+            &quot;config/sl_rail_util_sequencer_config.h&quot;, 
+            &quot;config/sl_sleeptimer_config.h&quot;, 
+            &quot;config/zaf_appname_config.h&quot;, 
+            &quot;config/zaf_config.h&quot;, 
+            &quot;config/zaf_event_distributor_core_config.h&quot;, 
+            &quot;config/zpal_zwave_nvm_instance_config.h&quot;, 
+            &quot;config/zw_build_no.h&quot;, 
+            &quot;config/zw_config_rf.h&quot;, 
+            &quot;config/zw_region_config.h&quot;, 
+            &quot;config/zw_version_config.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucConfig.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/RTE_Components.h&quot;, 
+            &quot;autogen/linkerfile.ld&quot;, 
+            &quot;autogen/sl_application_type.h&quot;, 
+            &quot;autogen/sl_board_default_init.c&quot;, 
+            &quot;autogen/sl_component_catalog.h&quot;, 
+            &quot;autogen/sl_device_init_clocks.c&quot;, 
+            &quot;autogen/sl_event_handler.c&quot;, 
+            &quot;autogen/sl_event_handler.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucTemplate.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;README.md&quot;, 
+            &quot;app.c&quot;, 
+            &quot;app.h&quot;, 
+            &quot;app_node_info.c&quot;, 
+            &quot;app_node_info.h&quot;, 
+            &quot;cmd_get_capabilities.c&quot;, 
+            &quot;cmd_handlers.c&quot;, 
+            &quot;cmd_handlers.h&quot;, 
+            &quot;cmd_handlers_invoker.c&quot;, 
+            &quot;cmds_dcdc.c&quot;, 
+            &quot;cmds_management.c&quot;, 
+            &quot;cmds_management.h&quot;, 
+            &quot;cmds_power_management.c&quot;, 
+            &quot;cmds_rf.c&quot;, 
+            &quot;cmds_rf.h&quot;, 
+            &quot;cmds_security.c&quot;, 
+            &quot;cmds_security.h&quot;, 
+            &quot;comm_interface.c&quot;, 
+            &quot;comm_interface.h&quot;, 
+            &quot;controller_supported_func.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_control.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/inc/sl_board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_control_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/board/src/sl_board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/inc/sl_cos.h&quot;, 
+            &quot;gecko_sdk_4.4.3/hardware/driver/configuration_over_swo/src/sl_cos.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_compiler.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_gcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/cmsis_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/core_cm4.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/mpu_armv7.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/Core/Include/tz_context.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/RTOS2/Include/cmsis_os2.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/RTOS2/Include/os_tick.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/CMSIS/RTOS2/Source/os_systick.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/em_device.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/system_zgm13.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm130s037hgn.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_adc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_af_pins.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_af_ports.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_cryotimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_csen.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_devinfo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_dma_descriptor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_dmareq.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_etm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_fpueh.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_gpio_p.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_idac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_ldma_ch.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense_buf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense_ch.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_lesense_st.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_leuart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_pcnt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_prs_ch.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_prs_signals.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_romtable.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtc_comp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtcc_cc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_rtcc_ret.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_timer_cc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_trng.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_vdac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_vdac_opa.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Include/zgm13_wdog_pch.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Source/startup_zgm13.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/Device/SiliconLabs/ZGM13/Source/system_zgm13.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/application_properties.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_errorcode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_parser.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_interface_storage.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/api/btl_reset_info.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/bootloader/app_properties/app_properties.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_atomic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_cmsis_os2_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_slist.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/inc/sl_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_assert.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_slist.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/src/sl_syscalls.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_gcc_preinclude.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/inc/sl_memory_region.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/common/toolchain/src/sl_memory.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/inc/sl_debug_swo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/driver/debug/src/sl_debug_swo.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/common/inc/ecode.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/inc/gpiointerrupt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_default.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_hal_flash.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/inc/nvm3_lock.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_default_common_linker.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_hal_flash.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emdrv/nvm3/src/nvm3_lock.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_acmp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_adc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_bus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_chip.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cmu_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_common.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_core_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_cryotimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_crypto.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_crypto_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_csen.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_dbg.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpcrc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_gpio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_i2c.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_idac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ldma.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_lesense.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_letimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_leuart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_msc_compat.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_opamp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_pcnt.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_prs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_ramfunc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_rtcc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_smu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_system_generic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_timer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_usart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_vdac.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_version.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/em_wdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/inc/sli_em_cmu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_acmp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_adc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_core.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_cryotimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_crypto.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_csen.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_dbg.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_emu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpcrc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_gpio.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_i2c.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_idac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_ldma.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_lesense.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_letimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_leuart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_msc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_opamp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_pcnt.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_prs.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rmu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_system.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_usart.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_vdac.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/emlib/src/em_wdog.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/halconfig/inc/hal-config/hal-config-types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_config_zgm130s037hgn_gcc.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg13_gcc_release.a&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/chip/efr32/efr32xg1x/rail_chip_specific.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_assert_error_codes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_features.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_mfm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/common/rail_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/fem_util/sl_fem_util.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/fem_util/sl_fem_util.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/sl_rail_util_pa_curves.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curve_types_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/plugin/rail_util_sequencer/sl_rail_util_sequencer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ble/rail_ble.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/wmbus/rail_wmbus.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/radio/rail_lib/protocol/zwave/rail_zwave.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_clocks.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_dcdc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_emu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_hfxo.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/inc/sl_device_init_nvic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_dcdc_s1.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_emu_s1.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_hfxo_s1.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/device_init/src/sl_device_init_nvic.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mpu/inc/sl_mpu.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/mpu/src/sl_mpu.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sl_power_manager_debug.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/inc/sli_power_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_debug.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sl_power_manager_hal_s0_s1.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/power_manager/src/sli_power_manager_private.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sl_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/inc/sli_sleeptimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/sleeptimer/src/sli_sleeptimer_hal.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/inc/sl_system_kernel.h&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/platform/service/system/src/sl_system_kernel.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Apps/zwave_ncp_serial_api/SerialAPI_hw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/AppsHw/inc/app_hw.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/AppsHw/inc/board_indicator.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/AppsHw/inc/board_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/Assert/Assert.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/CRC/CRC.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/DebugPrint/DebugPrint.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/DebugPrint/DebugPrintConfig.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/EventDistributor/EventDistributor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/MfgTokens/MfgTokens.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/NodeMask/NodeMask.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/QueueNotifying/QueueNotifying.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/SwTimer/SwTimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/SwTimer/SwTimerLiaison.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/SyncEvent/SyncEvent.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/Utils/Min2Max2.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/Components/Utils/SizeOf.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/ZW_classcmd.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_bootloader.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_entropy.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_init.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_misc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_nvm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_power_manager.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_radio.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_radio_utils.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_retention_register.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_status.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_uart.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/PAL/inc/zpal_watchdog.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/Actuator/ZAF_Actuator.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ZAF_AppName.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppName/ZAF_AppName_weak.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppTimer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppTimer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/AppTimerDeepSleep.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor_ncp.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/EventHandling/zaf_event_distributor_ncp.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/TrueStatusEngine/ZAF_TSE.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_ApplicationEvents.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_CmdPublisher.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_file_ids.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm_app.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_nvm_app.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_retention_register.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_retention_register.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZAF_types.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZW_TransportEndpoint.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZW_TransportSecProtocol.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ZW_product_id_enum.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ZAF_Common_helper.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ZAF_Common_interface.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/_commonIF/ZAF_Common_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ApplicationUtilities/ev_man.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ProtocolConfig/inc/zaf_protocol_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZAF/ProtocolConfig/src/zaf_protocol_config.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_SerialAPI.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_UserTask.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_application_transport_interface.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_basis_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_controller_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_security_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_slave_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_system_startup_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_transport_api.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/API/ZW_typedefs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/ZWave/lib/libZWaveController_700s.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/ADC.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/board.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/extension_board_8029a.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/target_boards.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/SerialAPI/SerialAPI_hw.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/ADC.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board_BRD420x.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board_indicator.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/AppsHw/src/common/board_init.c&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/application_properties/application_properties_config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/hal-config-board-700.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/hal-config/hal-config.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/sl_dcdc.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/system_startup.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/zpal_uart_config_ext.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/inc/zpal_zwave_nvm_instance.h&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/lib/libzpal_zgm130s037hgn.a&quot;, 
+            &quot;gecko_sdk_4.4.3/protocol/z-wave/platform/SiliconLabs/PAL/src/zpal_zwave_nvm_instance.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/cmsis/Include/freertos_mpool.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/cmsis/Include/freertos_os2.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/cmsis/Source/cmsis_os2.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/croutine.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/event_groups.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/FreeRTOS.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/StackMacros.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/atomic.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/croutine.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/deprecated_definitions.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/event_groups.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/list.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/message_buffer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/mpu_prototypes.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/mpu_wrappers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/portable.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/projdefs.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/queue.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/semphr.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/stack_macros.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/stream_buffer.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/task.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/include/timers.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/list.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/port.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F/portmacro.h&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/MemMang/heap_4.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/queue.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/stream_buffer.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/tasks.c&quot;, 
+            &quot;gecko_sdk_4.4.3/util/third_party/freertos/kernel/timers.c&quot;, 
+            &quot;main.c&quot;, 
+            &quot;nvm_backup_restore.c&quot;, 
+            &quot;nvm_backup_restore.h&quot;, 
+            &quot;postbuild.sh&quot;, 
+            &quot;serialapi_file.c&quot;, 
+            &quot;serialapi_file.h&quot;, 
+            &quot;slave_supported_func.h&quot;, 
+            &quot;utils.c&quot;, 
+            &quot;utils.h&quot;, 
+            &quot;virtual_slave_node_info.c&quot;, 
+            &quot;virtual_slave_node_info.h&quot;, 
+            &quot;zaf_config_security.h&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.componentSetup.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.CommonProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.defaultSettings.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ProjectPostBuild.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }, 
+    {
+        &quot;builtinExcludes&quot;: [], 
+        &quot;removed&quot;: false, 
+        &quot;builtinSources&quot;: [
+            &quot;autogen/.crc_config.crc&quot;
+        ], 
+        &quot;module&quot;: &quot;&lt;project:MModule xmlns:project=\&quot;http://www.silabs.com/ss/Project.ecore\&quot; builtin=\&quot;true\&quot; id=\&quot;uc.module.setup.ucProject.com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205.gcc\&quot; pdm=\&quot;true\&quot;&gt;  &lt;inclusions pattern=\&quot;.*\&quot;/&gt;    \n&lt;/project:MModule&gt;&quot;, 
+        &quot;builtin&quot;: true
+    }
+]" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.3&quot;,&quot;partOpn&quot;:&quot;zgm130s037hgn&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser" id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205" name="GNU ARM v12.2.1 - Default" parent="com.silabs.ide.si32.gcc.cdt.managedbuild.config.gnu.exe" postbuildStep="../../../tools/create_gbl.py postbuild &quot;${workspace_loc:/${ProjName}}/${ProjName}.slpb&quot; --parameter build_dir:&quot;${workspace_loc:/${ProjName}/${ConfigName}}&quot; --parameter sdk_dir:&quot;${StudioSdkPath}&quot;">
 					<folderInfo id="com.silabs.ss.framework.project.toolchain.core.default#com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205." name="/" resourcePath="">
@@ -367,7 +1626,512 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
-	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="11" projectCommon.boardIds="brd4207a:0.0.0 brd4001a:0.0.0.A01" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;README.md&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1786920724},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:582300076},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1718842848},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app_node_info.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1844560522},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;app_node_info.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1506087876},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmd_get_capabilities.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1312606874},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmd_handlers.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1853470453},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmd_handlers.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1425405446},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmd_handlers_invoker.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:67372627},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_dcdc.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-575721121},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_management.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1868792266},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_management.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-16070388},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_power_management.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1034958636},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_rf.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2114228168},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_rf.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:174887379},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_security.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:614270984},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;cmds_security.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1743339162},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;comm_interface.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-2146875598},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;comm_interface.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1088288559},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;controller_supported_func.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-975601360},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;main.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1505057239},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;nvm_backup_restore.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-491694574},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;nvm_backup_restore.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:684722156},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;postbuild.sh&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1506147555},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;serialapi_file.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-722611341},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;serialapi_file.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1665181912},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;slave_supported_func.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-662020513},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;utils.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1666658052},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;utils.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1910689686},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;virtual_slave_node_info.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:748831739},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;virtual_slave_node_info.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1067958521},{&quot;generated&quot;:false,&quot;projectPath&quot;:&quot;zaf_config_security.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-803070080},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/.crc_config.crc&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1810739659},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/RTE_Components.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1143232578},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/linkerfile.ld&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1350963736},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_application_type.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:204825895},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_board_default_init.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1764316703},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_component_catalog.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1321895832},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_device_init_clocks.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-366404538},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.c&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:2117858569},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;autogen/sl_event_handler.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1450712431},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/FreeRTOSConfig.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:737458120},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/app_properties_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:464657923},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/btl_interface_cfg.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:675916386},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/emlib_core_debug_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-78822137},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/extension_board_8029a_efr32xg13.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1416823917},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/extension_board_8029a_efr32xg13_button.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1833836219},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/extension_board_8029a_efr32xg13_led.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1948486905},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/extension_board_8029a_efr32xg13_slider.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:978776255},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/nvm3_default_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1043785191},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/serial_api_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-277959132},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_board_control_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1657463363},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_debug_swo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:622022330},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_dcdc_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1016880838},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_emu_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1403800068},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_device_init_hfxo_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:246522182},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_fem_util_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-549389523},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_memory_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-465409252},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_power_manager_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:467325263},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_pa_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1645278155},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_power_manager_init_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1786126116},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_rail_util_sequencer_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:527201278},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/sl_sleeptimer_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1204146860},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zaf_appname_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1184305731},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zaf_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:814563907},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zaf_event_distributor_core_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1540890092},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zpal_zwave_nvm_instance_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:-1593432707},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zw_build_no.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:528574553},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zw_config_rf.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:305623088},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zw_region_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1342370647},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;config/zw_version_config.h&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:1134484674},{&quot;generated&quot;:true,&quot;projectPath&quot;:&quot;zwave_ncp_serial_api_controller.slpb&quot;,&quot;originalPath&quot;:&quot;&quot;,&quot;version&quot;:1,&quot;content&quot;:311857252}]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.zg13.zgm130s037hgn" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;zgm130s037hgn&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
+	<storageModule moduleId="com.silabs.ss.framework.ide.project.core.cpp" project.generation="11" projectCommon.boardIds="brd4207a:0.0.0 brd4001a:0.0.0.A01" projectCommon.buildArtifactType="EXE" projectCommon.copiedFiles="[
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;README.md&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1786920724
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 582300076
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1718842848
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app_node_info.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1844560522
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;app_node_info.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1506087876
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmd_get_capabilities.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1312606874
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmd_handlers.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1853470453
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmd_handlers.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1425405446
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmd_handlers_invoker.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 67372627
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_dcdc.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -575721121
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_management.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1868792266
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_management.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -16070388
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_power_management.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1034958636
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_rf.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2114228168
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_rf.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 174887379
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_security.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 614270984
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;cmds_security.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1743339162
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;comm_interface.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -2146875598
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;comm_interface.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1088288559
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;controller_supported_func.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -975601360
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;main.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1505057239
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;nvm_backup_restore.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -491694574
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;nvm_backup_restore.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 684722156
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;postbuild.sh&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1506147555
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;serialapi_file.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -722611341
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;serialapi_file.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1665181912
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;slave_supported_func.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -662020513
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;utils.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1666658052
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;utils.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1910689686
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;virtual_slave_node_info.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 748831739
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;virtual_slave_node_info.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1067958521
+    }, 
+    {
+        &quot;generated&quot;: false, 
+        &quot;projectPath&quot;: &quot;zaf_config_security.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -803070080
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/.crc_config.crc&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1810739659
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/RTE_Components.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1143232578
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/linkerfile.ld&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1350963736
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_application_type.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 204825895
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_board_default_init.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1764316703
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_component_catalog.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1321895832
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_device_init_clocks.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -366404538
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.c&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 2117858569
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;autogen/sl_event_handler.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1450712431
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/FreeRTOSConfig.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 737458120
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/app_properties_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 464657923
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/btl_interface_cfg.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 675916386
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/emlib_core_debug_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -78822137
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/extension_board_8029a_efr32xg13.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1416823917
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/extension_board_8029a_efr32xg13_button.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1833836219
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/extension_board_8029a_efr32xg13_led.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1948486905
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/extension_board_8029a_efr32xg13_slider.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 978776255
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/nvm3_default_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1043785191
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/serial_api_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -277959132
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_board_control_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1657463363
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_debug_swo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 622022330
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_dcdc_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1016880838
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_emu_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1403800068
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_device_init_hfxo_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 246522182
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_fem_util_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -549389523
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_memory_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -465409252
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_power_manager_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 467325263
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_pa_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1645278155
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_power_manager_init_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1786126116
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_rail_util_sequencer_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 527201278
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/sl_sleeptimer_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1204146860
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zaf_appname_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1184305731
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zaf_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 814563907
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zaf_event_distributor_core_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1540890092
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zpal_zwave_nvm_instance_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: -1593432707
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zw_build_no.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 528574553
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zw_config_rf.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 305623088
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zw_region_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1342370647
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;config/zw_version_config.h&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 1134484674
+    }, 
+    {
+        &quot;generated&quot;: true, 
+        &quot;projectPath&quot;: &quot;zwave_ncp_serial_api_controller.slpb&quot;, 
+        &quot;originalPath&quot;: &quot;&quot;, 
+        &quot;version&quot;: 1, 
+        &quot;content&quot;: 311857252
+    }
+]" projectCommon.ideId="simplicity-ide" projectCommon.importModeId="LINK_LIBRARIES" projectCommon.partId="mcu.arm.efr32.zg13.zgm130s037hgn" projectCommon.savedStockVariables="{&quot;copiedSdkLocation&quot;:&quot;gecko_sdk_4.4.0&quot;,&quot;partOpn&quot;:&quot;zgm130s037hgn&quot;}" projectCommon.sdkId="com.silabs.sdk.stack.super:4.4.3._-295637086" projectCommon.toolchainId="com.silabs.ss.tool.ide.arm.toolchain.gnu.cdt:12.2.1.20221205"/>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="zwave_ncp_serial_api_controller.com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType.680361494" name="SLS CDT Project" projectType="com.silabs.ss.framework.ide.project.core.cdt.cdtMbsProjectType"/>
 	</storageModule>

--- a/tools/normalize_cproject.py
+++ b/tools/normalize_cproject.py
@@ -5,6 +5,9 @@ import pathlib
 import xml.etree.ElementTree as ET
 
 
+NEWLINE_SENTINEL = "7200872e315d2518866d8a02e8258034"
+
+
 def json_dumps(obj: dict | list) -> str:
     """Compactly dump JSON into a string."""
     return json.dumps(obj, separators=(", ", ": "), indent=4)
@@ -39,6 +42,11 @@ for storage_module in tree.findall(".//storageModule"):
 
                 state["resolvedOptionsStr"] = json_dumps(resolved_options)
 
+            if "builtinIncludesStr" in state:
+                state["builtinIncludesStr"] = NEWLINE_SENTINEL.join(
+                    state["builtinIncludesStr"].split()
+                )
+
         storage_module.attrib["cppBuildConfig.projectBuiltInState"] = json_dumps(
             project_built_in_state
         )
@@ -55,10 +63,10 @@ for storage_module in tree.findall(".//storageModule"):
 xml_text = ET.tostring(tree, encoding="unicode", xml_declaration=False)
 xml_text = xml_text.replace(" />", "/>")
 
-# Replace newlines with literals!
+# Replace newlines with literals
 xml_text = xml_text.replace("&#10;", "\n")
-# xml_text.replace("\\n", "\n\\n")
-xml_text = re.sub(r"\s+\\n\s+", "\n\\n", xml_text, flags=re.MULTILINE)
+xml_text = xml_text.replace(NEWLINE_SENTINEL, "\n")
+xml_text = re.sub(r"\s*\\n\s*", "\n\\n", xml_text, flags=re.MULTILINE)
 
 # Only touch the filesystem if we need to
 if processing_instructions + xml_text != cproject:


### PR DESCRIPTION
This introduces newlines, which should make diffs involving `.cproject` much smaller.