### PR TITLE
Add zap tooling to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,14 @@ RUN \
     && unzip -q -d gecko_sdk_4.4.4 gecko_sdk_4.4.4.zip \
     && rm gecko_sdk_4.4.4.zip
 
+# ZCL Advanced Platform (ZAP) v2024.09.27
+RUN \
+    curl -o zap_2024.09.27.zip -L https://github.com/project-chip/zap/releases/download/v2024.09.27/zap-linux-x64.zip \
+    && unzip -q -d /opt/zap zap_2024.09.27.zip \
+    && rm zap_2024.09.27.zip
+
+ENV STUDIO_ADAPTER_PACK_PATH="/opt/zap"
+
 ARG USERNAME=builder
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
Add  ZAP tooling to docker container which allows for Zigbee apps that require ZCL clusters to be built (such as any of the example apps like Z3Light and Z3Switch). `slc` will automatically generate all required files from `config/zcl/zcl_config.zap` saved under the project src folder.


Snippet from .slcp file
```
config_file:
- path: config/zcl/zcl_config.zap
  directory: zcl
```