### PR TITLE
Add a way to mutate JSON within manifests

### DIFF
--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -470,6 +470,20 @@ def main():
         LOGGER.error("Defines were unused, aborting: %s", unused_defines)
         sys.exit(1)
 
+    # JSON config
+    for json_config in manifest.get("json_config", []):
+        json_path = args.build_dir / json_config["file"]
+
+        subprocess.run(
+            [
+                "jq",
+                json_config["jq"],
+                json_path,
+                json_path,
+            ],
+            check=True,
+        )
+
     # Fix Gecko SDK bugs
     sl_rail_util_pti_config_h = args.build_dir / "config/sl_rail_util_pti_config.h"
 


### PR DESCRIPTION
See https://github.com/NabuCasa/silabs-firmware-builder/pull/84.

Example:

```yaml
json_config:
  - file: "config/zcl/zcl_config.zap"
    jq: |
      .endpointTypes[].clusters[].attributes[] | select(.name == "model name") 
      | .defaultValue = "some model"'

  - file: "config/zcl/zcl_config.zap"
    jq: |
      .endpointTypes[].clusters[].attributes[] | select(.name == "manufacturer name") 
      | .defaultValue = "some manufacturer"'
```