### PR TITLE
Improve subprocess run logging

### DIFF
--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -170,16 +170,14 @@ def load_toolchains(paths: list[pathlib.Path]) -> dict[pathlib.Path, str]:
 
 
 def subprocess_run_verbose(command: list[str], prefix: str) -> None:
-    result = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
-    with result.stdout:
-        for line in iter(result.stdout.readline, b""):
+    with subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    ) as proc:
+        for line in proc.stdout:
             LOGGER.info("[%s] %r", prefix, line.decode("utf-8").strip())
 
-    result_returncode = result.wait()
-
-    if result_returncode != 0:
-        LOGGER.error("[%s] Error: %s", prefix, result_returncode)
+    if proc.returncode != 0:
+        LOGGER.error("[%s] Error: %s", prefix, proc.returncode)
         sys.exit(1)
 
 

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -173,7 +173,7 @@ def subprocess_run_verbose(command: list[str], prefix: str) -> None:
     result = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     with result.stdout:
-        for line in iter(result.stdout, b""):
+        for line in iter(result.stdout.readline, b""):
             LOGGER.info("[%s] %r", prefix, line.decode("utf-8").strip())
 
     result_returncode = result.wait()


### PR DESCRIPTION
Allows the logs from `slc generate` to show up in the Actions logs.
I think worth having, especially useful when making changes and `slc` doesn't like it... 😅

Note: This is mostly for the "error" scenario, where previously logs wouldn't show up, and only meaningless errors were thrown.