### PR TITLE
Release manifests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,7 +159,7 @@ jobs:
           done
 
           # Build it
-          python3 tools/build_project.py \
+          /opt/venv/bin/python3 tools/build_project.py \
             $sdk_args \
             $toolchain_args \
             --manifest "${{ matrix.manifest }}" \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,6 +174,11 @@ jobs:
           output_basename=$(basename -- $(basename -- $(ls -1 outputs/*.gbl | head -n 1)) .gbl)
           echo "output_basename=$output_basename" >> $GITHUB_OUTPUT
 
+      - name: Generate manifest
+        id: build-firmware
+        run: |
+          /opt/venv/bin/python3 tools/create_manifest.py outputs > outputs/manifest.json
+
       - name: Install node within container (act)
         if: ${{ env.ACT }}
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,11 +174,6 @@ jobs:
           output_basename=$(basename -- $(basename -- $(ls -1 outputs/*.gbl | head -n 1)) .gbl)
           echo "output_basename=$output_basename" >> $GITHUB_OUTPUT
 
-      - name: Generate manifest
-        id: build-firmware
-        run: |
-          /opt/venv/bin/python3 tools/create_manifest.py outputs > outputs/manifest.json
-
       - name: Install node within container (act)
         if: ${{ env.ACT }}
         run: |
@@ -193,14 +188,48 @@ jobs:
           compression-level: 9
           if-no-files-found: error
 
+  generate-manifest:
+    name: Generate manifest
+    needs: [build-firmwares]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-container.outputs.container_name }}
+      options: --user root
+    steps:
+      - name: Download all workflow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+          pattern: firmware-build-*
+
+      - name: Generate manifest
+        run: |
+          /opt/venv/bin/python3 tools/create_manifest.py artifacts > artifacts/manifest.json
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest
+          path: artifacts/manifest.json
+          compression-level: 9
+          if-no-files-found: error
+
   release-assets:
     name: Upload release assets
-    needs: [build-firmwares]
+    needs: [generate-manifest]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+          pattern: manifest
+
       - name: Download all workflow artifacts
         uses: actions/download-artifact@v4
         with:
@@ -211,4 +240,6 @@ jobs:
       - name: Upload artifacts
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/*.gbl
+          files: |
+            artifacts/*.gbl
+            artifacts/manifest.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,12 +190,14 @@ jobs:
 
   generate-manifest:
     name: Generate manifest
-    needs: [build-firmwares]
+    needs: [build-container, build-firmwares]
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-container.outputs.container_name }}
       options: --user root
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all workflow artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.7.3
     hooks:
       - id: ruff
         args: [--fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,17 @@ RUN \
        default-jre-headless \
        patch \
        python3 \
-       python3-ruamel.yaml \
+       python3-pip \
+       python3-virtualenv \
        unzip \
        xz-utils
+
+COPY requirements.txt /tmp/
+
+RUN \
+    virtualenv /opt/venv \
+    && /opt/venv/bin/pip install -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
 
 # Install Simplicity Commander (unfortunately no stable URL available, this
 # is known to be working with Commander_linux_x86_64_1v15p0b1306.tar.bz).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ tool will automatically determine which SDK and toolchain to use.
 > automatically found so these flags can be omitted.
 
 ```bash
-pip install ruamel.yaml  # Only dependency
+pip install -r requirements.txt
 
 python tools/build_project.py \
     # The following SDK and toolchain flags can be omitted on macOS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ruamel.yaml
+universal-silabs-flasher>=0.0.25

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import ast
 import sys
@@ -169,9 +170,9 @@ def load_toolchains(paths: list[pathlib.Path]) -> dict[pathlib.Path, str]:
     return toolchains
 
 
-def subprocess_run_verbose(command: list[str], prefix: str) -> None:
+def subprocess_run_verbose(command: list[str], prefix: str, **kwargs) -> None:
     with subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs
     ) as proc:
         for line in proc.stdout:
             LOGGER.info("[%s] %r", prefix, line.decode("utf-8").strip())
@@ -543,7 +544,10 @@ def main():
             f"POST_BUILD_EXE={args.postbuild}",
             "VERBOSE=1",
         ],
-        "make"
+        "make",
+        env={
+            "PATH": f"{pathlib.Path(sys.executable).parent}:{os.environ['PATH']}"
+        }
     )
     # fmt: on
 

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import hashlib
 import pathlib
 import argparse
+
 from datetime import datetime, timezone
-import logging
 
 from universal_silabs_flasher.firmware import parse_firmware_image
 

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -7,6 +7,7 @@ import json
 import hashlib
 import pathlib
 import argparse
+from datetime import datetime, timezone
 import logging
 
 from universal_silabs_flasher.firmware import parse_firmware_image
@@ -26,7 +27,9 @@ def main():
 
     args = parser.parse_args()
     manifest = {
-        "metadata": {},
+        "metadata": {
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
         "firmwares": [],
     }
 

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Tool to create a JSON manifest file for a collection of firmwares."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import pathlib
+import argparse
+import logging
+
+from universal_silabs_flasher.firmware import parse_firmware_image
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "firmware_dir",
+        type=pathlib.Path,
+        help="Directory containing firmware images",
+    )
+
+    args = parser.parse_args()
+    manifest = {
+        "metadata": {},
+        "firmwares": [],
+    }
+
+    for firmware_file in args.firmware_dir.glob("*.gbl"):
+        data = firmware_file.read_bytes()
+
+        try:
+            firmware = parse_firmware_image(data)
+        except ValueError:
+            _LOGGER.warning("Ignoring invalid firmware file: %s", firmware_file)
+            continue
+
+        try:
+            gbl_metadata = firmware.get_nabucasa_metadata()
+        except (KeyError, ValueError):
+            metadata = None
+        else:
+            metadata = gbl_metadata.original_json
+
+        manifest["firmwares"].append(
+            {
+                "filename": firmware_file.name,
+                "checksum": f"sha3-256:{hashlib.sha3_256(data).hexdigest()}",
+                "size": len(data),
+                "metadata": metadata,
+                "release_notes": None,
+            }
+        )
+
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently, GitHub releases do not include any information about the actual firmware files beyond the filename.

A new `manifest.json` file will be included in the release to describe the firmwares and allow for programmatic access to the information in the GBL files:

```json
{
  "metadata": {
    "created_at": "2024-11-11T18:28:51.450197+00:00"
  },
  "firmwares": [
    {
      "filename": "bootloader-uart-xmodem-chip.gbl",
      "checksum": "sha3-256:237c8c1c6971172bf7565270edfbf5e82c251d6b3a78efa4b5f7733d64bcc4e3",
      "size": 11244,
      "metadata": {
        "baudrate": 115200,
        "fw_type": "gecko-bootloader",
        "gecko_bootloader_version": "2.4.2",
        "metadata_version": 1,
        "sdk_version": "4.4.2"
      },
      "release_notes": null
    },
    {
      "filename": "skyconnect_zigbee_ncp_7.4.4.0.gbl",
      "checksum": "sha3-256:46e6d7d16060e666a8e57941c7a575dcdcf9d01e9819fd46150f9f7c2798c631",
      "size": 240492,
      "metadata": {
        "baudrate": 115200,
        "ezsp_version": "7.4.4.0",
        "fw_type": "zigbee_ncp",
        "fw_variant": null,
        "metadata_version": 2,
        "sdk_version": "4.4.4"
      },
      "release_notes": null
    }
  ]
}