### PR TITLE
Add container-based build workflow and improve build tooling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,48 +127,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install SDK extensions
-        run: |
-          # XXX: slc-cli does not actually work when the extensions aren't in the SDK!
-          for sdk in /*_sdk_*; do
-            slc signature trust --sdk "$sdk"
-
-            ln -s $PWD/gecko_sdk_extensions "$sdk"/extension
-
-            for ext in "$sdk"/extension/*/; do
-              slc signature trust --sdk "$sdk" --extension-path "$ext"
-            done
-          done
-
       - name: Build firmware
         id: build-firmware
         run: |
-          # Fix `fatal: detected dubious ownership in repository at`
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-          # Pass all SDKs as consecutive `--sdk ...` arguments
-          sdk_args=""
-          for sdk_dir in /*_sdk*; do
-            sdk_args="$sdk_args --sdk $sdk_dir"
-          done
-
-          # Pass all toolchains as consecutive `--toolchain ...` arguments
-          toolchain_args=""
-          for toolchain_dir in /opt/*arm-none-eabi*; do
-            toolchain_args="$toolchain_args --toolchain $toolchain_dir"
-          done
-
-          # Build it
-          /opt/venv/bin/python3 tools/build_project.py \
-            $sdk_args \
-            $toolchain_args \
-            --manifest "${{ matrix.manifest }}" \
-            --build-dir build \
-            --build-system makefile \
-            --output-dir outputs \
-            --output gbl \
-            --output hex \
-            --output out
+          build_firmware.sh \
+            --work-dir "$GITHUB_WORKSPACE" \
+            --manifest "${{ matrix.manifest }}"
 
           # Get the basename of the GBL in `outputs`
           output_basename=$(basename -- $(basename -- $(ls -1 outputs/*.gbl | head -n 1)) .gbl)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,34 @@
+name: reviewdog / shellscripts
+
+on:
+    push:
+        paths:
+            - tools/build_firmware.sh
+
+    pull_request:
+        paths:
+            - tools/build_firmware.sh
+
+jobs:
+
+  shellcheck:
+    name: Check shell scripts with shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          reporter: github-pr-review
+          path: tools
+          pattern: "*.sh"
+
+  shfmt:
+    name: Check shell scripts with shfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-shfmt@v1
+        with:
+          level: warning
+          shfmt_flags: '-i 0 '

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ autogen/
 *.project.mak
 *.Makefile
 build/
+outputs/
+build_dir/
 artifact/
 artifacts/
 trashed_modified_files/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
        xz-utils
 
 COPY requirements.txt /tmp/
+COPY tools/build_firmware.sh /usr/bin/build_firmware.sh
 
 RUN \
     virtualenv /opt/venv \
@@ -81,9 +82,12 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 
+RUN mkdir -p /build_dir /outputs
 RUN chown $USERNAME:$USERNAME \
     /gecko_sdk_* \
-    /simplicity_sdk_*
+    /simplicity_sdk_* \
+    /build_dir \
+    /outputs
 
 USER $USERNAME
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,5 +81,9 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 
+RUN chown $USERNAME:$USERNAME \
+    /gecko_sdk_* \
+    /simplicity_sdk_*
+
 USER $USERNAME
 WORKDIR /build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+TOPDIR = $(shell pwd)
+DOCKER_CHECK := $(shell command -v docker 2> /dev/null)
+PODMAN_CHECK := $(shell command -v podman 2> /dev/null)
+
+ifdef PODMAN_CHECK
+    CONTAINER_ENGINE ?= podman
+else ifdef DOCKER_CHECK
+    CONTAINER_ENGINE ?= docker
+endif
+
+CONTAINER_NAME ?= silabs-firmware-builder
+CONTAINER_USER_GROUP ?= $(shell id -u):$(shell id -g)
+
+ifeq ($(CONTAINER_ENGINE),docker)
+    VOLUME_OPTS=
+else
+    VOLUME_OPTS=:z
+endif
+
+define run_in_container
+	$(CONTAINER_ENGINE) \
+		run --rm -it \
+		--user $(CONTAINER_USER_GROUP) \
+		-v $(TOPDIR):/build$(VOLUME_OPTS) \
+		-v $(TOPDIR)/outputs:/outputs$(VOLUME_OPTS) \
+		-v $(TOPDIR)/build_dir:/build_dir$(VOLUME_OPTS) \
+		$(CONTAINER_NAME)
+endef
+
+MANIFESTS ?= $(shell find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print)
+
+all: build_container build_firmware
+
+help:
+	@echo "Usage: make [all|build_container|build_firmware]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all             Build container and firmware"
+	@echo "  build_container Build container"
+	@echo "  build_firmware  Build firmware"
+	@echo "  help            Show this help message"
+	@echo ""
+	@echo "Options:"
+	@echo "  build_firmware MANIFESTS=<path>  Override default manifest files (default: all .yaml/.yml files in manifests/)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  # Build the container image"
+	@echo "  make build_container"
+	@echo ""
+	@echo "  # Build all firmware manifests"
+	@echo "  make build_firmware"
+	@echo ""
+	@echo "  # Build a specific firmware manifest"
+	@echo "  make build_firmware MANIFESTS=manifests/nabucasa/yellow_bootloader.yaml"
+	@echo ""
+
+./outputs ./build_dir:
+	mkdir -p $@
+ifneq ($(CONTAINER_ENGINE),docker)
+	$(CONTAINER_ENGINE) unshare chown -R $(shell id -u):$(shell id -g) $@
+endif
+
+build_container:
+	$(CONTAINER_ENGINE) build -t $(CONTAINER_NAME) .
+
+build_firmware: ./outputs ./build_dir
+	$(run_in_container) \
+		bash -c " \
+			build_firmware.sh \
+			--build-dir /build_dir \
+			--output-dir /outputs \
+			$(foreach manifest,$(MANIFESTS),--manifest $(manifest)) \
+		"

--- a/README.md
+++ b/README.md
@@ -90,3 +90,117 @@ python tools/build_project.py \
 ```
 
 Once the build is complete, the firmwares will be in the `output` directory.
+
+## Building with a container (for development)
+
+This is a convenience GNU Make  based wrapper around the build process that is being used on the GitHub Actions CI pipeline, but can also be used for local development.
+
+### Prerequisites
+
+- [GNU Make](https://www.gnu.org/software/make/)
+- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman-desktop.io/)
+
+| Prerequisite | macOS | Windows | Debian/Ubuntu | Fedora |
+|-------------|--------|---------|---------------|---------|
+| GNU Make | `brew install make` | Via [Chocolatey](https://chocolatey.org/): `choco install make` | `sudo apt install make` | `sudo dnf install make` |
+| Docker | Download [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Download [Docker Desktop](https://www.docker.com/products/docker-desktop/) | `sudo apt install docker.io` | `sudo dnf install docker-ce docker-ce-cli containerd.io` |
+| Podman | `brew install podman` | Download [Podman Desktop](https://podman-desktop.io/downloads) | `sudo apt install podman` | `sudo dnf install podman` |
+
+### Usage
+
+#### Help
+
+Provides a list of commands and options.
+
+```bash
+make help
+
+Usage: make [all|build_container|build_firmware]
+
+Targets:
+  all             Build container and firmware
+  build_container Build container
+  build_firmware  Build firmware
+  help            Show this help message
+
+Options:
+  build_firmware MANIFESTS=<path>  Override default manifest files (default: all .yaml/.yml files in manifests/)
+
+Examples:
+  # Build the container image
+  make build_container
+
+  # Build all firmware manifests
+  make build_firmware
+
+  # Build a specific firmware manifest
+  make build_firmware MANIFESTS=manifests/nabucasa/yellow_bootloader.yaml
+```
+
+#### Build everything
+
+Builds the container image and all available firmware manifests.
+
+```bash
+make
+```
+
+Once this command completes, the firmwares will be in the `outputs` directory.
+
+```bash
+ls -w 80 outputs | head -3
+skyconnect_bootloader_2.4.2.gbl
+skyconnect_bootloader_2.4.2.hex
+skyconnect_bootloader_2.4.2.out
+```
+
+#### Build the container
+
+Builds only the container image.
+
+```bash
+make build_container
+```
+
+#### Build all available firmware manifests
+
+Builds all available firmware manifests in the `manifests` directory.
+
+```bash
+make build_firmware
+```
+
+#### Build a specific firmware manifest
+
+Builds a specific firmware manifest by providing the path to the manifest file.
+
+```bash
+make build_firmware MANIFESTS=manifests/nabucasa/yellow_openthread_ncp.yaml
+```
+
+Once this command completes, the firmwares will be in the `outputs` directory.
+
+```bash
+ls -w 80 outputs
+yellow_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl
+yellow_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.hex
+yellow_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.out
+```
+
+#### Build with a custom container image
+
+Builds the firmware with a custom container image by providing the container image name.
+
+```bash
+make build_firmware CONTAINER_NAME=ghcr.io/nabucasa/silabs-firmware-builder
+```
+
+### Makefile variables
+
+The following variables can be customized when running make commands:
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| CONTAINER_NAME | silabs-firmware-builder | Name of the container image to build/use |
+| CONTAINER_ENGINE | docker | Container engine to use (docker or podman) |
+| MANIFESTS | every file in `manifests`  directory| Which firmware manifests to build |

--- a/tools/build_firmware.sh
+++ b/tools/build_firmware.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -euo pipefail
+
+build_dir="build_dir"
+output_dir="outputs"
+work_dir="/build"
+manifest_files=()
+python_interpreter="/opt/venv/bin/python3"
+
+# Show help message
+show_help() {
+	echo "Usage: $0 [OPTIONS]"
+	echo
+	echo "Build firmware images from manifest files"
+	echo
+	echo "Options:"
+	echo "  -h, --help                 Show this help message"
+	echo "  -m, --manifest FILE        YAML manifest file describing the firmware to build"
+	echo "                             (can be specified multiple times)"
+	echo "  -b, --build-dir DIR        Directory for build files (default: ${build_dir})"
+	echo "  -o, --output-dir DIR       Directory for output files (default: ${output_dir})"
+	echo "  -w, --work-dir DIR         Working directory for build process (default: ${work_dir})"
+	echo "  -p, --python PATH          Python interpreter path (default: ${python_interpreter})"
+	exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+	case $1 in
+	-h | --help)
+		show_help
+		;;
+	-m | --manifest)
+		if [ -z "${2:-}" ]; then
+			echo "Error: --manifest requires a file argument"
+			exit 1
+		fi
+		manifest_files+=("$2")
+		shift
+		;;
+	-b | --build-dir)
+		if [ -z "${2:-}" ]; then
+			echo "Error: --build-dir requires a directory argument"
+			exit 1
+		fi
+		build_dir="$2"
+		shift
+		;;
+	-o | --output-dir)
+		if [ -z "${2:-}" ]; then
+			echo "Error: --output-dir requires a directory argument"
+			exit 1
+		fi
+		output_dir="$2"
+		shift
+		;;
+	-w | --work-dir)
+		if [ -z "${2:-}" ]; then
+			echo "Error: --work-dir requires a directory argument"
+			exit 1
+		fi
+		work_dir="$2"
+		shift
+		;;
+	-p | --python)
+		if [ -z "${2:-}" ]; then
+			echo "Error: --python requires a path argument"
+			exit 1
+		fi
+		python_interpreter="$2"
+		shift
+		;;
+	*)
+		echo "Error: Unknown argument: $1"
+		echo "Use -h or --help for usage information"
+		exit 1
+		;;
+	esac
+	shift
+done
+
+# Check that Python3 with ruamel.yaml is available
+if ! "$python_interpreter" -c "import ruamel.yaml" &>/dev/null; then
+	echo "Error: Python3 with ruamel.yaml is not available at $python_interpreter"
+	echo "Install ruamel.yaml with 'pip install ruamel.yaml'"
+	exit 1
+fi
+
+# Check if any manifest files were provided
+if [ ${#manifest_files[@]} -eq 0 ]; then
+	echo "Error: No manifest files provided"
+	echo "Use -h or --help for usage information"
+	exit 1
+fi
+
+git config --global --add safe.directory "$work_dir"
+
+# Install SDK extensions
+for sdk in /*_sdk_*; do
+	slc signature trust --sdk "$sdk"
+	ln -s "$(pwd)"/gecko_sdk_extensions "$sdk"/extension
+	for ext in "$sdk"/extension/*/; do
+		slc signature trust --sdk "$sdk" --extension-path "$ext"
+	done
+done
+
+# Build SDK arguments
+sdk_args=()
+for sdk_dir in /*_sdk*; do
+	sdk_args+=(--sdk "$sdk_dir")
+done
+
+# Build toolchain arguments
+toolchain_args=()
+for toolchain_dir in /opt/*arm-none-eabi*; do
+	toolchain_args+=(--toolchain "$toolchain_dir")
+done
+
+# Determine if we should keep the SLC daemon running
+keep_daemon=""
+if [ ${#manifest_files[@]} -gt 1 ]; then
+	keep_daemon="--keep-slc-daemon"
+fi
+
+# Build firmware
+for manifest_file in "${manifest_files[@]}"; do
+	echo "Building firmware manifest $manifest_file, using build directory $build_dir and output directory $output_dir"
+
+	"$python_interpreter" tools/build_project.py \
+		"${sdk_args[@]}" \
+		"${toolchain_args[@]}" \
+		$keep_daemon \
+		--manifest "$manifest_file" \
+		--build-dir "$build_dir" \
+		--output-dir "$output_dir" \
+		--build-system makefile \
+		--output gbl \
+		--output hex \
+		--output out
+done

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -103,13 +103,18 @@ def get_git_commit_id(repo: pathlib.Path) -> str:
     """Get a commit hash for the current git repository."""
 
     def git(*args: str) -> str:
-        result = subprocess.run(
-            ["git", "-C", str(repo)] + list(args),
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        return result.stdout.strip()
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo)] + list(args),
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return result.stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"Git command `git -C {repo} {' '.join(args)}` failed: {exc.stderr.strip()}"
+            ) from exc
 
     # Get the current commit ID
     commit_id = git("rev-parse", "HEAD")[:8]


### PR DESCRIPTION
This PR introduces a new container-based build workflow and several improvements to the build system:

### Major Changes
- Added a new Makefile for streamlined container-based builds
- Created `tools/build_firmware.sh` script to standardize build steps
- Updated CI to use the new build script
- Added QA checks for shell scripts using reviewdog
- Fixed various build-related issues

### New Build Workflow Features
- Simple `make`-based commands for building firmware
- Support for both Docker and Podman
- Flexible firmware manifest selection
- Shared build steps between local and CI environments

### Technical Improvements
- Fixed permission issues with extension symlinks under rootless podman
- Improved error reporting in build_project.py
- Added shellcheck and shfmt QA checks
- Standardized build steps between local and CI environments

### Usage Example
#### Build all firmware
```bash
make
```

#### Build specific manifest
```bash
make build_firmware MANIFESTS=manifests/nabucasa/yellow_bootloader.yaml
````

### Documentation
Added comprehensive documentation in README.md covering:
- Prerequisites installation
- Build workflow usage
- Available make targets
- Customization options

Fixes:
- Permission issues with rootless podman
- Git commit ID error reporting
- Build step standardization