### PR TITLE
Allow overriding the EZSP version patch number

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ruamel.yaml
 universal-silabs-flasher>=0.0.25
+pyelftools

--- a/src/zigbee_ncp/config/xncp_config.h
+++ b/src/zigbee_ncp/config/xncp_config.h
@@ -17,4 +17,8 @@
 // Specify a build string that can be read by the host, augmenting its version info
 #define XNCP_BUILD_STRING  ("")
 
+
+// Override the EZSP patch number. The default (0xFF) disables this.
+#define XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE  (0xFF)
+
 #endif /* CONFIG_XNCP_CONFIG_H_ */


### PR DESCRIPTION
This PR allows the EmberZNet patch number to be overridden at build time. Currently, we have no control over any portion of the version number returned my EmberZNet.