### PR TITLE
Disable "member of all groups" feature

### DIFF
--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 7.5.0.0
 Beta release built with Gecko SDK 4.4.6.
 
+# 7.4.4.1
+Re-release of 7.4.4.0 that fixes a regression with group addressing present in the previous release, affecting some devices like IKEA remotes.
+
 # 7.4.4.0
 Initial release with the new firmware builder. This release fixes minor bugs related to adapter migration and includes other improvements in the underlying SDK.

--- a/src/zigbee_ncp/app.c
+++ b/src/zigbee_ncp/app.c
@@ -39,8 +39,7 @@
 #define FEATURE_FLOW_CONTROL_TYPE     (0b00000000000000000000000000010000)
 
 #define SUPPORTED_FEATURES ( \
-      FEATURE_MEMBER_OF_ALL_GROUPS \
-    | FEATURE_MANUAL_SOURCE_ROUTE \
+      FEATURE_MANUAL_SOURCE_ROUTE \
     | FEATURE_MFG_TOKEN_OVERRIDES \
     | FEATURE_BUILD_STRING \
     | FEATURE_FLOW_CONTROL_TYPE \
@@ -158,62 +157,6 @@ void emberAfMainInitCallback(void)
   for (uint8_t i = 0; i < XNCP_MANUAL_SOURCE_ROUTE_TABLE_SIZE; i++) {
     manual_source_routes[i].active = false;
   }
-}
-
-/** @brief Incoming packet filter callback
- *
- * Filters and/or mutates incoming packets. Currently used only for wildcard multicast
- * group membership.
- */
-EmberPacketAction sli_zigbee_af_packet_handoff_incoming_callback(EmberZigbeePacketType packetType,
-                                                                 EmberMessageBuffer packetBuffer,
-                                                                 uint8_t index,
-                                                                 void *data)
-{
-  if (packetType != EMBER_ZIGBEE_PACKET_TYPE_APS_DATA) {
-    return EMBER_ACCEPT_PACKET;
-  }
-
-  uint8_t* packetData = emberMessageBufferContents(packetBuffer);
-  uint16_t packetSize = emberMessageBufferLength(packetBuffer);
-
-  // Skip over the 802.15.4 header to the payload
-  uint8_t payload_offset = sl_mac_flat_field_offset(packetData, true, EMBER_PH_FIELD_MAC_PAYLOAD);
-  packetData += payload_offset;
-  packetSize -= payload_offset;
-
-  if (packetSize < 3) {
-    return EMBER_ACCEPT_PACKET;
-  }
-
-  uint8_t deliveryMode = (packetData[0] & 0b00001100) >> 2;
-
-  // Only look at multicast packets
-  if (deliveryMode != 0x03) {
-    return EMBER_ACCEPT_PACKET;
-  }
-
-  // Take ownership over the first entry and continuously rewrite it
-  EmberMulticastTableEntry *tableEntry = &(sl_zigbee_get_multicast_table()[0]);
-
-  tableEntry->endpoint = 1;
-  tableEntry->multicastId = BUILD_UINT16(packetData[1], packetData[2]);
-  tableEntry->networkIndex = 0;
-
-  return EMBER_ACCEPT_PACKET;
-}
-
-
-/** @brief Outgoing packet filter callback
- *
- * Filters and/or mutates outgoing packets.
- */
-EmberPacketAction sli_zigbee_af_packet_handoff_outgoing_callback(EmberZigbeePacketType packetType,
-                                                                 EmberMessageBuffer packetBuffer,
-                                                                 uint8_t index,
-                                                                 void *data)
-{
-  return EMBER_ACCEPT_PACKET;
 }
 
 


### PR DESCRIPTION
It looks like something changed in a recent SDK update and this actually _interferes_ with the group packet reception in some cases. Removing for now.