### PR TITLE
Generate changelogs for the manifest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Generate manifest
         run: |
-          /opt/venv/bin/python3 tools/create_manifest.py artifacts > artifacts/manifest.json
+          /opt/venv/bin/python3 tools/create_manifest.py artifacts src > artifacts/manifest.json
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/src/openthread_rcp/CHANGELOG.md
+++ b/src/openthread_rcp/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 2.4.6.0_GitHub-bdb394eb3
+Initial release with the new firmware builder. This firmware is identical to the firmware bundled with the OpenThread Border Router addon.

--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 7.5.0.0.0
+Beta release built with Gecko SDK 4.4.6.
+
+# 7.4.4.0
+Initial release with the new firmware builder. This release fixes minor bugs related to adapter migration and includes other improvements in the underlying SDK.

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import json
 import logging
 import hashlib
@@ -16,6 +17,23 @@ from universal_silabs_flasher.firmware import parse_firmware_image
 _LOGGER = logging.getLogger(__name__)
 
 
+def parse_markdown_changelog(text: str) -> dict[str, tuple[str, str]]:
+    changelogs = {}
+    chunks = re.split(r"^# (.*?)\n", text, flags=re.MULTILINE)[1:]
+
+    for version, raw_text in zip(chunks[::2], chunks[1::2]):
+        first_line, rest = raw_text.split("\n", 1)
+
+        if len(first_line) > 255:
+            raise ValueError(
+                "First line of every changelog must be less than 255 characters"
+            )
+
+        changelogs[version] = (first_line, rest.strip() or None)
+
+    return changelogs
+
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -24,6 +42,11 @@ def main():
         "firmware_dir",
         type=pathlib.Path,
         help="Directory containing firmware images",
+    )
+    parser.add_argument(
+        "source_dir",
+        type=pathlib.Path,
+        help="Directory containing the source tree to identify changelogs",
     )
 
     args = parser.parse_args()
@@ -57,8 +80,33 @@ def main():
                 "size": len(data),
                 "metadata": metadata,
                 "release_notes": None,
+                "release_summary": None,
             }
         )
+
+    for fw in manifest["firmwares"]:
+        if fw["metadata"] is None:
+            continue
+
+        fw_type = fw["metadata"]["fw_type"]
+        changelog_md = args.source_dir / fw_type / "CHANGELOG.md"
+
+        if not changelog_md.exists():
+            continue
+
+        changelogs = parse_markdown_changelog(changelog_md.read_text())
+
+        version_keys = {k for k in fw["metadata"] if k.endswith("_version")} - {
+            "sdk_version",
+            "metadata_version",
+        }
+        assert len(version_keys) == 1
+        version_key = list(version_keys)[0]
+
+        version = fw["metadata"][version_key]
+        release_notes, release_summary = changelogs[version]
+        fw["release_notes"] = release_notes
+        fw["release_summary"] = release_summary
 
     print(json.dumps(manifest, indent=2))
 


### PR DESCRIPTION
A `CHANGELOG.md` file is required to be present in every public firmware and any version bump requires a changelog with at least a short one-line release note.

The format is simple:

```markdown
# version 2
Up to 255 characters for the release notes.

All subsequent text is used for the release summary and can be formatted with Markdown.

# version 1
If there is no release summary, it can be omitted.
```