### PR TITLE
Increase routing table size

### DIFF
--- a/manifests/nabucasa/skyconnect_zigbee_ncp.yaml
+++ b/manifests/nabucasa/skyconnect_zigbee_ncp.yaml
@@ -23,6 +23,10 @@ c_defines:
     type: c_flag
     value: 32
 
+  EMBER_ROUTE_TABLE_SIZE:
+    type: c_flag
+    value: 250
+
   SL_IOSTREAM_USART_VCOM_BAUDRATE: 115200
   SL_IOSTREAM_USART_VCOM_FLOW_CONTROL_TYPE: usartHwFlowControlCtsAndRts
 

--- a/manifests/nabucasa/yellow_zigbee_ncp.yaml
+++ b/manifests/nabucasa/yellow_zigbee_ncp.yaml
@@ -27,6 +27,10 @@ c_defines:
     type: c_flag
     value: 32
 
+  EMBER_ROUTE_TABLE_SIZE:
+    type: c_flag
+    value: 250
+
   SL_IOSTREAM_USART_VCOM_BAUDRATE: 115200
   SL_IOSTREAM_USART_VCOM_FLOW_CONTROL_TYPE: usartHwFlowControlCtsAndRts
 


### PR DESCRIPTION
The current size is 16 entries.

How this impacts real networks is TBD. Conceptually this would help but I'm not sure if EmberZNet will waste resources checking and maintaining old routes.