### PR TITLE
Remove unnecessary build flags redefinition

### DIFF
--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -568,12 +568,6 @@ def main():
             )
         )
 
-    build_flags = {
-        "C_FLAGS": [],
-        "CXX_FLAGS": [],
-        "LD_FLAGS": [],
-    }
-
     # Remove absolute paths from the build for reproducibility
     build_flags["C_FLAGS"] += [
         f"-ffile-prefix-map={str(src.absolute())}={dst}"


### PR DESCRIPTION
`build_flags` should not be redefined a second time like this.