### PR TITLE
slsdk file for extension and debian image bump for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -12,6 +12,7 @@ RUN \
        jq \
        yq \
        libgl1 \
+       libglib2.0-0 \
        make \
        default-jre-headless \
        patch \

--- a/gecko_sdk_extensions/nc_efr32_watchdog_extension/nc_efr32_watchdog.slsdk
+++ b/gecko_sdk_extensions/nc_efr32_watchdog_extension/nc_efr32_watchdog.slsdk
@@ -1,0 +1,7 @@
+﻿# Properties file for Simplicity Studio metadata
+id=uc.extension.nc_erf32_watchdog
+
+version=1.0.0
+
+label=EFR32 Watchdog
+description=EFR32 Watchdog.


### PR DESCRIPTION
Simplicity Studio SV5.11.1.1 needs slsdk file for proper import of extension. Also new SLC CLI needs JRE newer then one available in bookworm and an additional library.