### PR TITLE
Switch to new URLs for SiLabs tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 # Install Simplicity Commander (unfortunately no stable URL available, this
 # is known to be working with Commander_linux_x86_64_1v15p0b1306.tar.bz).
 RUN \
-    curl -O https://www.silabs.com/documents/login/software/SimplicityCommander-Linux.zip \
+    curl -O https://www.silabs.com/documents/public/software/SimplicityCommander-Linux.zip \
     && unzip -q SimplicityCommander-Linux.zip \
     && tar -C /opt -xjf SimplicityCommander-Linux/Commander_linux_x86_64_*.tar.bz \
     && rm -r SimplicityCommander-Linux \
@@ -41,7 +41,7 @@ ENV PATH="$PATH:/opt/commander"
 
 # Install Silicon Labs Configurator (slc)
 RUN \
-    curl -O https://www.silabs.com/documents/login/software/slc_cli_linux.zip \
+    curl -O https://www.silabs.com/documents/public/software/slc_cli_linux.zip \
     && unzip -q -d /opt slc_cli_linux.zip \
     && rm slc_cli_linux.zip
 


### PR DESCRIPTION
They swapped them out yesterday but there are new URLs (for now).