### PR TITLE
Set `PCLK_DIVIDER` instead of `DEFAULT_HF_CLOCK_SOURCE` for Yellow OT-RCP config

### DIFF
--- a/manifests/nabucasa/yellow_openthread_rcp.yaml
+++ b/manifests/nabucasa/yellow_openthread_rcp.yaml
@@ -16,12 +16,11 @@ add_components:
 
 # SLC validates clock settings before c_defines are patched, use `configuration`
 configuration:
-  SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE: SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE_HFXO
+  SL_CLOCK_MANAGER_PCLK_DIVIDER: SL_CLOCK_MANAGER_PCLK_DIV_MIN
 
 c_defines:
-  # SDK bug: the default HF clock source is HFRCODPLL for the MGM210 in Simplicity SDK,
-  # it should be overridden to the normal HFXO
-  SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE: SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE_HFXO
+  # SDK bug: the PCLK divider is set to 1 for the MGM210, it is set to 2 everywhere else
+  SL_CLOCK_MANAGER_PCLK_DIVIDER: SL_CLOCK_MANAGER_PCLK_DIV_MIN
 
   SL_IOSTREAM_USART_VCOM_PERIPHERAL: USART0
   SL_IOSTREAM_USART_VCOM_PERIPHERAL_NO: 0

--- a/src/openthread_rcp/openthread_rcp.slcp
+++ b/src/openthread_rcp/openthread_rcp.slcp
@@ -34,7 +34,6 @@ include:
     - path: reset_util.h  # Originally included from `util/third_party/openthread/src/lib/platform`
 
 source:
-  - path: main.c
   - path: app.c
 
 define:


### PR DESCRIPTION
This aligns the actual HF clock speed with that of other MG21 modules. I'm waiting for SiLabs to confirm what the expected fix here should be.