### PR TITLE
Create factory HEX files out of GBL files

### DIFF
--- a/tools/create_factory_hex.py
+++ b/tools/create_factory_hex.py
@@ -203,6 +203,9 @@ class IntelHex:
         else:
             raise ValueError("No end-of-file record found")
 
+        if self.records[index + 1 :]:
+            raise ValueError("Records found after end-of-file record")
+
         # Validate that the flashed regions do not overlap
         contiguous_extents = []
 


### PR DESCRIPTION
This modifies the `tools.create_factory_hex` script to work with GBL files instead of HEX files, to allow combined factory firmware images to be created from publicly available artifacts. I've modified the tool to more thoroughly validate the resulting HEX file (no overlapping writes, end of file is present, etc.) and to always use extended linear segments when writing to flash, for consistency.

Sample run:

```console
$ python -m tools.create_factory_hex \
    --bootloader zbt2_bootloader_2.4.3.gbl \
    --application zbt2_zigbee_ncp_7.4.4.6.gbl \
    --tokens zbt2_flash_tokens.json \
    --output zbt2_mg24_combined_20251124.hex
Flashed regions:
  0x08000000-0x08002D50  ( 11,600 bytes)
    08000000  08 10 00 20 71 01 00 08 e5 27 00 08 0b 25 00 08   |... q....'...%..|
    08000010  e5 27 00 08 e5 27 00 08 e5 27 00 08 e5 27 00 08   |.'...'...'...'..|
    08000020  e5 27 00 08 e5 27 00 08 94 2b 00 08 e5 27 00 08   |.'...'...+...'..|
    08000030  e5 27 00 08 44 2b 00 08 e5 27 00 08 e5 27 00 08   |.'..D+...'...'..|
    08000040  e5 27 00 08 e5 27 00 08 e5 27 00 08 e5 27 00 08   |.'...'...'...'..|
    08000050  e5 27 00 08 e5 27 00 08 e5 27 00 08 e5 27 00 08   |.'...'...'...'..|
    08000060  e5 27 00 08 e5 27 00 08 e5 27 00 08 e5 27 00 08   |.'...'...'...'..|
    08000070  e5 27 00 08 e5 27 00 08 e5 27 00 08 e5 27 00 08   |.'...'...'...'..|
    ...
    08002CD0  51 0e 52 7f 9b 05 68 8c 1f 83 d9 ab 5b e0 cd 19   |Q.R...h.....[...|
    08002CE0  ec 2c 00 08 10 10 00 20 18 00 00 00 f0 0f 10 03   |.,..... ........|
    08002CF0  00 00 00 00 42 11 00 20 13 00 00 00 09 00 00 00   |....B.. ........|
    08002D00  00 01 00 00 02 02 00 00 13 00 00 00 f0 0f 10 03   |................|
    08002D10  00 00 00 00 42 12 00 20 13 00 00 00 09 00 00 00   |....B.. ........|
    08002D20  00 02 00 00 01 01 00 00 d3 ff ff ff f0 7f 10 30   |...............0|
    08002D30  c2 10 00 20 00 00 00 00 00 00 00 00 00 c0 05 40   |... ...........@|
    08002D40  29 00 00 00 1d 02 00 08 f5 01 00 08 e4 64 d9 3b   |)............d.;|


  0x08006000-0x0804624C  (262,732 bytes)
    08006000  00 10 00 20 59 6e 00 08 11 c6 00 08 15 c6 00 08   |... Yn..........|
    08006010  e5 59 03 08 19 c6 00 08 21 c6 00 08 e5 59 03 08   |.Y......!....Y..|
    08006020  e5 59 03 08 e5 59 03 08 e5 59 03 08 e5 59 03 08   |.Y...Y...Y...Y..|
    08006030  25 c6 00 08 80 eb 03 08 e5 59 03 08 e5 59 03 08   |%........Y...Y..|
    08006040  a1 6d 00 08 e5 59 03 08 e5 59 03 08 e5 59 03 08   |.m...Y...Y...Y..|
    08006050  e5 59 03 08 e5 59 03 08 e5 59 03 08 e5 59 03 08   |.Y...Y...Y...Y..|
    08006060  e5 59 03 08 29 1b 01 08 b7 88 03 08 e5 59 03 08   |.Y..)........Y..|
    08006070  e5 59 03 08 e5 59 03 08 e5 59 03 08 e5 59 03 08   |.Y...Y...Y...Y..|
    ...
    080461CC  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    080461DC  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    080461EC  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    080461FC  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    0804620C  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    0804621C  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    0804622C  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|
    0804623C  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |................|


  0x0FE00010-0x0FE00030  (     32 bytes)
    0FE00010  4e 61 62 75 20 43 61 73 61 00 ff ff ff ff ff ff   |Nabu Casa.......|
    0FE00020  43 6f 6e 6e 65 63 74 20 5a 42 54 2d 32 00 ff ff   |Connect ZBT-2...|
```