### PR TITLE
Ensure manifest generation runs even when cached containers are used

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,6 +218,7 @@ jobs:
   generate-manifest:
     name: Generate manifest
     needs: [check-container, build-firmwares]
+    if: ${{ !cancelled() && needs.build-firmwares.result == 'success' }}
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.check-container.outputs.container_name }}


### PR DESCRIPTION
We ran into some fun GitHub Actions quirks:
- https://github.com/actions/runner/issues/2205
- https://github.com/orgs/community/discussions/26945
- https://github.com/orgs/community/discussions/45058

We cache Docker containers more aggressively now but skipping a step apparently causes _some_ future steps to also be skipped. This should resolve it.