### PR TITLE
Fix latest OpenThread changelog entry

### DIFF
--- a/src/openthread_rcp/CHANGELOG.md
+++ b/src/openthread_rcp/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 2.7.2.0_GitHub-fb0446f53
-This release is built using Simplicity SDK 2025.6.2.
+# SL-OPENTHREAD/2.7.2.0_GitHub-fb0446f53
+This beta release is built with Simplicity SDK 2025.6.2.
 
 # 2.4.7.0_GitHub-fb0446f53
 Beta release built with Gecko SDK 4.5.0.


### PR DESCRIPTION
The latest changelog was missing the `SL-OPENTHREAD` prefix, causing manifest generation to fail.