### PR TITLE
Add an intermediate CI step that removes buggy status propagation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,6 +137,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    outputs:
+      container_name: ${{ needs.check-container.outputs.container_name }}
     steps:
       - name: Log in to the GitHub container registry
         if: needs.check-container.outputs.build_image == 'true'
@@ -181,10 +183,10 @@ jobs:
 
   build-firmwares:
     name: Firmware builder
-    needs: [list-manifests, check-container, merge-container]
+    needs: [list-manifests, merge-container]
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.check-container.outputs.container_name }}
+      image: ${{ needs.merge-container.outputs.container_name }}
       options: --user root
     strategy:
       matrix:
@@ -226,10 +228,10 @@ jobs:
 
   generate-manifest:
     name: Generate manifest
-    needs: [check-container, build-firmwares]
+    needs: [merge-container, build-firmwares]
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.check-container.outputs.container_name }}
+      image: ${{ needs.merge-container.outputs.container_name }}
       options: --user root
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It looks like the buggy CI status propagation fixed in https://github.com/NabuCasa/silabs-firmware-builder/pull/171 propagates _further_ and affects release asset uploading.

To fix this, I think a better solution is to just create a "status-stripping" step that always runs.