### PR TITLE
Parallel download stages with checksumming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ ARG TARGETARCH
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
-RUN apk add --no-cache aria2 bzip2 ca-certificates libarchive-tools xz
+RUN apk add --no-cache \
+    aria2 \
+    bzip2 \
+    ca-certificates \
+    libarchive-tools \
+    xz
 
 # ============ Parallel download stages ============
 


### PR DESCRIPTION
Supersedes #99 and #93.

This PR migrates from a sequential Dockerfile to parallel download layers and `COPY --from` to construct the final image. This doesn't impact clean build times much (they hover at around 2 minutes +  8 minutes to export) but allows us to:
1. Validate checksums in intermediate layers. Each parallel download layer is isolated and its output is cached. Unless we change one, the result will be loaded from cache, where we know the checksum has been validated. This is compatible with SiLabs release URLs (which do not contain version info) because the download layer will not re-run unless something changes. Local builds may fail due to checksum mis-match but this will be rare due to caching and can be updated via a PR.
2. More quickly rebuild after changing the Dockerfile. Unless an individual downloader layer or the base downloader itself are modified, we do not rebuild them until the cache expires. At worst, we perform an unnecessary `COPY`.