### PR TITLE
Simplicity SDK 2025.12.0 for OpenThread (and Router)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ RUN set -e \
         ninja/1.12.1 \
         commander/1.22.0 \
         slc-cli/6.0.15 \
-        simplicity-sdk/2025.6.2 \
+        simplicity-sdk/2025.12.0 \
         zap/2025.12.02 \
     # Patch ZAP apack.json to add missing linux.aarch64 executable definitions
     # Remove once zap is bumped to 2026.x.x

--- a/extension/nabucasa_hardware_extension/src/zbt2_router_callbacks.c
+++ b/extension/nabucasa_hardware_extension/src/zbt2_router_callbacks.c
@@ -192,6 +192,7 @@ static void sync_light_state(uint8_t endpoint)
 // Commissioning event handler - starts network steering
 static void commissioning_retry_event_handler(sl_zigbee_af_event_t *event)
 {
+  (void)event;
   if (sl_zigbee_af_network_state() != SL_ZIGBEE_JOINED_NETWORK) {
     // Switch from white pulse (ready) to blue pulse (searching)
     led_pattern_t search_pattern = {
@@ -248,6 +249,9 @@ void sl_zigbee_af_network_steering_complete_cb(sl_status_t status,
                                                uint8_t joinAttempts,
                                                uint8_t finalState)
 {
+  (void)totalBeacons;
+  (void)joinAttempts;
+  (void)finalState;
   sl_zigbee_app_debug_println("Network steering complete: 0x%X", status);
 
   if (status != SL_STATUS_OK) {
@@ -268,6 +272,10 @@ void sl_zigbee_af_post_attribute_change_cb(uint8_t endpoint,
                                            uint8_t size,
                                            uint8_t* value)
 {
+  (void)manufacturerCode;
+  (void)type;
+  (void)size;
+  (void)value;
   if (mask != CLUSTER_MASK_SERVER) {
     return;
   }

--- a/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
@@ -2,7 +2,7 @@ name: SkyConnect OpenThread RCP
 device: EFR32MG21A020F512IM32
 base_project: src/openthread_rcp
 filename: "{manifest_name}_{ot_rcp_version.split('/')[-1]}_gsdk_{sdk_version}"
-sdk: "simplicity_sdk:2025.6.2"
+sdk: "simplicity_sdk:2025.12.0"
 toolchain: "12.2.1.20221205"
 
 gbl:

--- a/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
+++ b/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
@@ -2,7 +2,7 @@ name: Yellow OpenThread RCP
 device: MGM210PA32JIA
 base_project: src/openthread_rcp
 filename: "{manifest_name}_{ot_rcp_version.split('/')[-1]}_gsdk_{sdk_version}"
-sdk: "simplicity_sdk:2025.6.2"
+sdk: "simplicity_sdk:2025.12.0"
 toolchain: "12.2.1.20221205"
 
 gbl:

--- a/manifests/nabucasa/zbt2/config/zcl/zcl_config.zap
+++ b/manifests/nabucasa/zbt2/config/zcl/zcl_config.zap
@@ -759,6 +759,142 @@
           ]
         },
         {
+          "name": "Poll Control",
+          "code": 32,
+          "mfgCode": null,
+          "define": "POLL_CONTROL_CLUSTER",
+          "side": "client",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "CheckInResponse",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            },
+            {
+              "name": "CheckIn",
+              "code": 0,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "FastPollStop",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 0,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "cluster revision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "client",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "3",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "Keep-Alive",
+          "code": 37,
+          "mfgCode": null,
+          "define": "KEEPALIVE_CLUSTER",
+          "side": "client",
+          "enabled": 1,
+          "attributes": [
+            {
+              "name": "cluster revision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "client",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "0x0001",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "Keep-Alive",
+          "code": 37,
+          "mfgCode": null,
+          "define": "KEEPALIVE_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "attributes": [
+            {
+              "name": "Keep-Alive Base",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int8u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "Keep-Alive Jitter",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "60",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "cluster revision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "0x0001",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
           "name": "Color Control",
           "code": 768,
           "mfgCode": null,

--- a/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZBT-2 OpenThread RCP
 device: EFR32MG24A420F1536IM40
 base_project: src/openthread_rcp
 filename: "{manifest_name}_{ot_rcp_version.split('/')[-1]}_gsdk_{sdk_version}"
-sdk: "simplicity_sdk:2025.6.2"
+sdk: "simplicity_sdk:2025.12.0"
 toolchain: "12.2.1.20221205"
 
 gbl:

--- a/manifests/nabucasa/zbt2/zbt2_router.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_router.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZBT-2 Zigbee Router
 device: EFR32MG24A420F1536IM40
 base_project: src/zigbee_router
 filename: "{manifest_name}_{sdk_version}"
-sdk: "simplicity_sdk:2025.6.2"
+sdk: "simplicity_sdk:2025.12.0"
 toolchain: "12.2.1.20221205"
 
 gbl:

--- a/src/openthread_rcp/CHANGELOG.md
+++ b/src/openthread_rcp/CHANGELOG.md
@@ -1,3 +1,6 @@
+# SL-OPENTHREAD/3.0.0.0_GitHub-61e43cffb
+This beta release is built with Simplicity SDK 2025.12.0.
+
 # SL-OPENTHREAD/2.7.2.0_GitHub-fb0446f53
 This beta release is built with Simplicity SDK 2025.6.2.
 

--- a/src/zigbee_router/zigbee_router.slcp
+++ b/src/zigbee_router/zigbee_router.slcp
@@ -53,7 +53,14 @@ component:
   - id: zigbee_basic
   - id: zigbee_scan_dispatch
   - id: zigbee_update_tc_link_key
+  - id: zigbee_update_app_link_key
+  - id: zigbee_security_link_keys
   - id: clock_manager
+  - id: zigbee_dynamic_commissioning
+  - id: zigbee_trust_center_keepalive
+  - id: zigbee_poll_control_client
+  - id: zigbee_bdb_3dot1_rejoin_algorithm
+  - id: zigbee_bdb_3dot1_trust_center_extension
   - id: zigbee_application_bootloader
   # Platform - enable LTO for gcc
   - id: toolchain_gcc_lto
@@ -87,7 +94,7 @@ configuration:
   - name: SLI_ZIGBEE_PRIMARY_NETWORK_DEVICE_TYPE
     value: SLI_ZIGBEE_NETWORK_DEVICE_TYPE_ROUTER
   - name: SLI_ZIGBEE_PRIMARY_NETWORK_SECURITY_TYPE
-    value: SLI_ZIGBEE_NETWORK_SECURITY_TYPE_3_0
+    value: SLI_ZIGBEE_NETWORK_SECURITY_TYPE_4_0
   - name: SL_CLI_PROMPT_STRING
     value: "\"zigbee_router>\""
   - name: NVM3_DEFAULT_NVM_SIZE
@@ -165,6 +172,12 @@ configuration:
     value: 2000
     condition:
       - device_series_3
+  - name: SL_ZIGBEE_AF_PLUGIN_NETWORK_STEERING_ENABLE_AUTOSTART
+    value: 0
+  - name: SL_ZIGBEE_AF_PLUGIN_TRUST_CENTER_KEEPALIVE_DEFAULT_BASE_PERIOD_MINUTES
+    value: 1
+  - name: SL_ZIGBEE_AF_PLUGIN_TRUST_CENTER_KEEPALIVE_DEFAULT_JITTER_PERIOD_SECONDS
+    value: 30
 
 source:
   - path: main.c

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -704,6 +704,8 @@ def main():
         "-Wextra",
         "-Werror",
         "-Wno-error=maybe-uninitialized",  # Linking fails due to a few SDK bugs
+        # simplicity_sdk_2025.12.0/security_mbedtls_source/library/ssl_tls.c:2801:13: error: 'mbedtls_ssl_get_hostname_pointer' defined but not used
+        "-Wno-error=unused-function",
     ]
     build_flags["CXX_FLAGS"] = build_flags["C_FLAGS"]
 

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -690,6 +690,7 @@ def main():
         args.build_dir.absolute(): "/src",
         f"{cmake_dir.absolute()}/..": "/src",
         "/home/buildengineer/jenkins/workspace/Gecko_Workspace/gsdk": f"/src/{sdk_name}_{sdk_version}",
+        "/__w/zigbee": f"/src/{sdk_name}_{sdk_version}",
     }
     build_flags["C_FLAGS"] += [
         f"-ffile-prefix-map={src}={dst}" for src, dst in remapped_paths.items()

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -287,9 +287,7 @@ def main():
         gbl_dynamic.remove("ot_rcp_version")
 
         ot_proj_path = project_root / "config/sl_openthread_generic_config.h"
-        ot_sdk_path = (
-            gsdk_path / "protocol/openthread/include/sl_openthread_package_info.h"
-        )
+        ot_sdk_path = gsdk_path / "openthread/include/sl_openthread_package_info.h"
 
         if ot_proj_path.exists():
             openthread_config_h = parse_c_header_defines(ot_proj_path.read_text())


### PR DESCRIPTION
The bulk of the work for this migration was done in #178, this PR just bumps a few version strings. Theoretically the Zigbee side works with the new SDK as well because the code has `#ifdef`s allowing for compilation with both Gecko SDK and Simplicity SDK. For now, we're going to just test OpenThread. I didn't notice a single protocol-level change between the two SDK releases so we don't need to change anything in bellows to support this SDK.

I've also bumped the ZBT-2 router firmware and enabled the Zigbee 4.0 firmware flags, since it's basically in alpha testing at the moment. It features an improved rejoin algorithm, some new clusters by default (`PollControl` and `KeepAlive`), and some better link key encryption. These optional features require a compatible coordinator firmware, we'll release a Zigbee 4.0 coordinator firmware for beta testing after the current beta is promoted to stable, likely this week.

Fixes https://github.com/NabuCasa/silabs-firmware-builder/issues/177.