### PR TITLE
Clean up Dockerfile and and slim down image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -210,9 +210,6 @@ jobs:
           # image build (HOME=/root). Restore it for this step.
           export HOME=/root
 
-          # Fix `fatal: detected dubious ownership in repository at`
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
           /opt/venv/bin/python3 tools/build_project.py \
             --manifest "${{ matrix.manifest }}" \
             --build-dir build \
@@ -224,12 +221,6 @@ jobs:
           # Get the basename of the GBL in `outputs`
           output_basename=$(basename -- $(basename -- $(ls -1 outputs/*.gbl | head -n 1)) .gbl)
           echo "output_basename=$output_basename" >> $GITHUB_OUTPUT
-
-      - name: Install node within container (act)
-        if: ${{ env.ACT }}
-        run: |
-          curl -fsSL https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s 20
-          apt-get install -y nodejs
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -205,6 +205,11 @@ jobs:
       - name: Build firmware
         id: build-firmware
         run: |
+          # GHA's `container:` sets HOME=/github/home, but slc-cli's adapter-pack
+          # discovery scans $HOME/.silabs/... where slt put everything during the
+          # image build (HOME=/root). Restore it for this step.
+          export HOME=/root
+
           # Fix `fatal: detected dubious ownership in repository at`
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -178,54 +178,45 @@ jobs:
 
 
 
-  list-manifests:
-    name: List firmware manifests
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: set-matrix
-        run: |
-          echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
-
   build-firmwares:
     name: Firmware builder
-    needs: [list-manifests, merge-container]
+    needs: [merge-container]
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.merge-container.outputs.container_name }}
       options: --user root
-    strategy:
-      matrix:
-        manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build firmware
-        id: build-firmware
+      - name: Build all firmwares
         run: |
           # GHA's `container:` sets HOME=/github/home, but slc-cli's adapter-pack
           # discovery scans $HOME/.silabs/... where slt put everything during the
           # image build (HOME=/root). Restore it for this step.
           export HOME=/root
 
-          /opt/venv/bin/python3 tools/build_project.py \
-            --manifest "${{ matrix.manifest }}" \
-            --build-dir build \
-            --output-dir outputs \
-            --output gbl \
-            --output hex \
-            --output out
+          manifests=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) | sort)
 
-          # Get the basename of the GBL in `outputs`
-          output_basename=$(basename -- $(basename -- $(ls -1 outputs/*.gbl | head -n 1)) .gbl)
-          echo "output_basename=$output_basename" >> $GITHUB_OUTPUT
+          for manifest in $manifests; do
+            echo "::group::Building $manifest"
+            /opt/venv/bin/python3 tools/build_project.py \
+              --manifest "$manifest" \
+              --build-dir "build/$(basename "$manifest" | sed 's/\.[^.]*$//')" \
+              --output-dir outputs \
+              --output gbl \
+              --output hex \
+              --output out \
+              --slc-daemon \
+              --keep-slc-daemon
+            echo "::endgroup::"
+          done
+
+          slc --daemon --daemon-timeout 1 daemon-shutdown || true
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-build-${{ steps.build-firmware.outputs.output_basename }}
+          name: firmware-builds
           path: outputs/*
           compression-level: 9
           if-no-files-found: error
@@ -245,7 +236,7 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-          pattern: firmware-build-*
+          pattern: firmware-builds
 
       - name: Generate manifest
         run: |
@@ -279,7 +270,7 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-          pattern: firmware-build-*
+          pattern: firmware-builds
 
       - name: Upload artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -178,45 +178,54 @@ jobs:
 
 
 
+  list-manifests:
+    name: List firmware manifests
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        run: |
+          echo "matrix=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) -print | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
   build-firmwares:
     name: Firmware builder
-    needs: [merge-container]
+    needs: [list-manifests, merge-container]
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.merge-container.outputs.container_name }}
       options: --user root
+    strategy:
+      matrix:
+        manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build all firmwares
+      - name: Build firmware
+        id: build-firmware
         run: |
           # GHA's `container:` sets HOME=/github/home, but slc-cli's adapter-pack
           # discovery scans $HOME/.silabs/... where slt put everything during the
           # image build (HOME=/root). Restore it for this step.
           export HOME=/root
 
-          manifests=$(find manifests -type f \( -name "*.yaml" -o -name "*.yml" \) | sort)
+          /opt/venv/bin/python3 tools/build_project.py \
+            --manifest "${{ matrix.manifest }}" \
+            --build-dir build \
+            --output-dir outputs \
+            --output gbl \
+            --output hex \
+            --output out
 
-          for manifest in $manifests; do
-            echo "::group::Building $manifest"
-            /opt/venv/bin/python3 tools/build_project.py \
-              --manifest "$manifest" \
-              --build-dir "build/$(basename "$manifest" | sed 's/\.[^.]*$//')" \
-              --output-dir outputs \
-              --output gbl \
-              --output hex \
-              --output out \
-              --slc-daemon \
-              --keep-slc-daemon
-            echo "::endgroup::"
-          done
-
-          slc --daemon --daemon-timeout 1 daemon-shutdown || true
+          # Get the basename of the GBL in `outputs`
+          output_basename=$(basename -- $(basename -- $(ls -1 outputs/*.gbl | head -n 1)) .gbl)
+          echo "output_basename=$output_basename" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-builds
+          name: firmware-build-${{ steps.build-firmware.outputs.output_basename }}
           path: outputs/*
           compression-level: 9
           if-no-files-found: error
@@ -236,7 +245,7 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-          pattern: firmware-builds
+          pattern: firmware-build-*
 
       - name: Generate manifest
         run: |
@@ -270,7 +279,7 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-          pattern: firmware-builds
+          pattern: firmware-build-*
 
       - name: Upload artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,7 +197,6 @@ jobs:
       image: ${{ needs.merge-container.outputs.container_name }}
       options: --user root
     strategy:
-      max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,7 +137,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ needs.check-container.outputs.image_name }}:${{ needs.check-container.outputs.tag_name }}-${{ matrix.arch }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.check-container.outputs.image_name }}:cache-${{ matrix.arch }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.check-container.outputs.image_name }}:cache-${{ matrix.arch }},mode=max
-          push: true
+          outputs: type=image,compression=zstd,compression-level=19,force-compression=true,push=true
 
   merge-container:
     name: Create multi-arch manifest
@@ -197,6 +197,7 @@ jobs:
       image: ${{ needs.merge-container.outputs.container_name }}
       options: --user root
     strategy:
+      max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,8 +90,8 @@ RUN set -e \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     # slt-cli is x64 only but runs fine with QEMU
-    && aria2c --checksum=sha-256=8c2dd5091c15d5dd7b8fc978a512c49d9b9c5da83d4d0b820cfe983b38ef3612 -o slt.zip \
-        https://www.silabs.com/documents/public/software/slt-cli-1.1.0-linux-x64.zip \
+    && aria2c --checksum=sha-256=2b9941216a3549aea6c5cc76565e2bc91ebfd9f41bec1e026341ce47c3aca1d0 -o slt.zip \
+        https://www.silabs.com/documents/public/software/slt-cli-1.1.2-linux-x64.zip \
     && bsdtar -xf slt.zip -C /usr/bin && rm slt.zip \
     && chmod +x /usr/bin/slt \
     && if [ "$TARGETARCH" = "arm64" ]; then \
@@ -100,17 +100,18 @@ RUN set -e \
         && apt-get install -y --no-install-recommends libc6:amd64 zlib1g:amd64 \
         && rm -rf /var/lib/apt/lists/* \
         # slt needs to be emulated. It executes conan_wrapper during installation so we need to use --execve to make it work
-        # -R limits address space to 47 bits, fixing Go binaries that assume 48-bit sign-extended addresses
         && mv /usr/bin/slt /usr/bin/slt-bin \
-        && printf '#!/bin/sh\nexec /usr/bin/qemu-x86_64-static -R 0x800000000000 --execve /usr/bin/qemu-x86_64-static /usr/bin/slt-bin "$@"\n' > /usr/bin/slt \
+        && printf '#!/bin/sh\nexec /usr/bin/qemu-x86_64-static --execve /usr/bin/qemu-x86_64-static /usr/bin/slt-bin "$@"\n' > /usr/bin/slt \
         && chmod +x /usr/bin/slt \
         # Install conan
         && slt --non-interactive install conan \
         && mv /root/.silabs/slt/engines/conan/conan_engine /root/.silabs/slt/engines/conan/conan_engine-bin \
+        # -R limits address space to 47 bits, fixing Go binaries that assume 48-bit sign-extended addresses
+        # This can be removed once conan_engine is recompiled with a newer Go toolchain
         && printf '#!/bin/sh\nexec /usr/bin/qemu-x86_64-static -R 0x800000000000 /root/.silabs/slt/engines/conan/conan_engine-bin "$@"\n' > /root/.silabs/slt/engines/conan/conan_engine \
         && chmod +x /root/.silabs/slt/engines/conan/conan_engine \
         # Remove --execve from slt wrapper once we install conan, so native tools (tar, etc.) run without QEMU
-        && printf '#!/bin/sh\nexec /usr/bin/qemu-x86_64-static -R 0x800000000000 /usr/bin/slt-bin "$@"\n' > /usr/bin/slt \
+        && printf '#!/bin/sh\nexec /usr/bin/qemu-x86_64-static /usr/bin/slt-bin "$@"\n' > /usr/bin/slt \
         # Patch slt to select ARM64 packages for subsequent installs
         && sed -i 's/amd6/arm6/g' /usr/bin/slt-bin \
         # Force conan to use the ARM64 profile for downloading packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,15 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
             ca-certificates \
             git \
         && rm -rf /var/lib/apt/lists/* \
-        # Download QEMU 10.2.0 source
-        && aria2c --checksum=sha-256=6d7046777ce992e5ce88c413ebe3d1f57b1833e7d8200724097c9b74507e196e -o qemu.tar.gz \
-            https://gitlab.com/qemu-project/qemu/-/archive/v10.2.0/qemu-v10.2.0.tar.gz \
+        # Download QEMU 11.0.0 source
+        && aria2c --checksum=sha-256=253fb688815c7ba4bf1a3ecb582bd4476cfa485deb759f5f641efcde0d4bfabd -o qemu.tar.gz \
+            https://gitlab.com/qemu-project/qemu/-/archive/v11.0.0/qemu-v11.0.0.tar.gz \
         && tar xzf qemu.tar.gz && rm qemu.tar.gz \
-        && mv qemu-v10.2.0 qemu \
+        && mv qemu-v11.0.0 qemu \
         && cd qemu \
         # Apply execve interception patch from conda-forge
         && aria2c -o execve.patch \
-            https://raw.githubusercontent.com/conda-forge/qemu-execve-feedstock/7d9a37bb5498831e0eb9a1cff5c0c6f3d49cb1f7/recipe/patches/apply-execve-JH.patch \
+            https://raw.githubusercontent.com/conda-forge/qemu-execve-feedstock/eaea9abfa56f859c98fb3938535a961465a58ae6/recipe/patches/execve/apply-execve-JH.patch \
         && patch -p1 < execve.patch && rm execve.patch \
         # Skip vsyscall page setup when reserved_va is enabled
         && sed -i '/Cannot allocate vsyscall page/{s/.*/        return true;/;n;d}' linux-user/x86_64/elfload.c \

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,24 +128,17 @@ RUN set -e \
 
 # Install toolchain via slt
 RUN set -e \
-    && apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/* \
     && slt --non-interactive install \
         cmake/3.30.2 \
         ninja/1.12.1 \
         commander/1.22.0 \
         slc-cli/6.0.15 \
         simplicity-sdk/2025.6.2 \
-        zap/2025.12.02 \
+        zap/2026.02.26 \
     # conan cannot resolve two copies of the same package
     # even with different versions in a single command
     && slt --non-interactive install \
         simplicity-sdk/2025.12.1 \
-    # Patch ZAP apack.json to add missing linux.aarch64 executable definitions
-    # Remove once zap is bumped to 2026.x.x
-    && ZAP_PATH="$(slt where zap)" \
-    && jq '.executable["zap:linux.aarch64"]     = {"exe": "zap",     "optional": true} \
-         | .executable["zap-cli:linux.aarch64"] = {"exe": "zap-cli", "optional": true}' \
-        "$ZAP_PATH/apack.json" > /tmp/apack.json && mv /tmp/apack.json "$ZAP_PATH/apack.json" \
     # Clean up download caches to reduce image size
     && rm -rf /root/.silabs/slt/installs/archive/*.zip \
               /root/.silabs/slt/installs/archive/*.tar.* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,7 @@ RUN set -e \
     && rm -rf /root/.silabs/slt/installs/archive/*.zip \
               /root/.silabs/slt/installs/archive/*.tar.* \
               /root/.silabs/slt/installs/conan/p/*/d/ \
+              /root/.silabs/slt/installs/conan/download_cache \
     # Create stable symlinks and wrappers to make the tools available in PATH
     && mkdir -p /root/.silabs/slt/bin \
     && ln -s "$(slt where java21)/jre/bin/java" /root/.silabs/slt/bin/java \

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,8 +136,8 @@ RUN set -e \
         slc-cli/6.0.17 \
         simplicity-sdk/2025.6.2 \
         zap/2026.02.26 \
-    # conan cannot resolve two copies of the same package
-    # even with different versions in a single command
+    # conan cannot resolve two copies of the same package, even with different versions,
+    # in a single command
     && slt --non-interactive install \
         simplicity-sdk/2025.12.1 \
     # Clean up download caches to reduce image size

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,8 +132,8 @@ RUN set -e \
     && slt --non-interactive install \
         cmake/3.30.2 \
         ninja/1.12.1 \
-        commander/1.22.0 \
-        slc-cli/6.0.15 \
+        commander/1.23.1 \
+        slc-cli/6.0.17 \
         simplicity-sdk/2025.6.2 \
         zap/2026.02.26 \
     # conan cannot resolve two copies of the same package


### PR DESCRIPTION
A few small tweaks:
- Use zstd compression
- Bump all Dockerfile dependencies, including SiLabs tooling
  - https://github.com/project-chip/zap/pull/1677 has been released so we can remove the `apack.json` hack we use for ARM64.
  - `slt-cli` has been recompiled with a newer version of Go so we can drop the `-R 0x800000000000` workaround.
- Delete `/root/.silabs/slt/installs/conan/download_cache`, which reduces the image size by over a gigabyte 😅.

Overall, the total compressed size reduces from 5.3GB to 2.1GB, shaving off 60%!

---

| # | Layer | `latest` (gzip) | this PR (zstd) | Δ |
|---|---|---:|---:|---:|
| 1 | Debian trixie-slim base | 29.78 MB | 23.01 MB | −6.77 MB |
| 2 | Runtime apt packages (git, libgl1, libglib2.0-0, …) | 108.45 MB | 81.41 MB | −27.04 MB |
| 3 | Gecko SDK 4.5.0 | 1207.86 MB | 593.20 MB | **−614.66 MB** |
| 4 | Python 3.13 interpreter | 35.15 MB | 31.70 MB | −3.45 MB |
| 5 | Python venv (firmware-builder deps) | 9.45 MB | 8.38 MB | −1.07 MB |
| 6 | QEMU x86_64-static (execve-patched, ARM64 only) | 164 B | 137 B | −27 B |
| 7 | `slt` CLI binary | 11.42 MB | 12.56 MB | +1.14 MB |
| 8 | Silabs toolchain (Simplicity SDK, commander, slc-cli, zap, cmake, ninja, conan, JDK) | 3898.02 MB | 1397.17 MB | **−2500.85 MB** |
| 9 | Image metadata (WORKDIR/ENV/ENTRYPOINT) | 94 B | 78 B | −16 B |
| | **Total (compressed)** | **5300.12 MB** | **2147.42 MB** | **−3152.70 MB** |