### PR TITLE
Fix Zigbee XNCP manual source route bounds check

### DIFF
--- a/src/zigbee_ncp/extension/xncp_common_extension/src/xncp_common_commands.c
+++ b/src/zigbee_ncp/extension/xncp_common_extension/src/xncp_common_commands.c
@@ -181,7 +181,7 @@ static bool handle_set_source_route(xncp_context_t *ctx)
 
     uint8_t num_relays = (ctx->payload_length - 2) / 2;
 
-    if (num_relays > EMBER_MAX_SOURCE_ROUTE_RELAY_COUNT + 1) {
+    if (num_relays > EMBER_MAX_SOURCE_ROUTE_RELAY_COUNT) {
         *ctx->status = EMBER_BAD_ARGUMENT;
         return true;
     }


### PR DESCRIPTION
## Proposed change

This fixes a check in Zigbee NCP firmware for the experimental manual source routing firmware extension, where the number of relays being passed in could exceed `EMBER_MAX_SOURCE_ROUTE_RELAY_COUNT=11` by one, writing to the next slot.

In reality, this isn't really an issue, but still something to fix.

Note: This is untested.

## AI summary

The bounds check in `handle_set_source_route` accepted one more relay than the destination buffer can hold, allowing a write one element past the end of `ManualSourceRoute.relays[]` and corrupting the next entry in the static `manual_source_routes` table.

Tighten the bound from `> EMBER_MAX_SOURCE_ROUTE_RELAY_COUNT + 1` to `> EMBER_MAX_SOURCE_ROUTE_RELAY_COUNT` so it matches the buffer size.

### How it got introduced

The original implementation (7d779e9, "Implement manual source routing") stored each route as a 2D array sized `[1 + EMBER_MAX_SOURCE_ROUTE_RELAY_COUNT + 1]` — a destination slot, N relay slots, and a NULL-terminator slot. Under that layout, accepting up to N+1 relays was safe because of the trailing slack slot.

The 2024 refactor that moved XNCP commands into modular components (eb5f597, "Move all XNCP commands into components", merged in aa67fd1) replaced the 2D array with the struct above, which is sized at exactly N with no terminator. The accompanying bounds check was carried over unchanged, so it became off by one when the buffer shrank.
