### PR TITLE
Add OpenThread RCP watchdog

### DIFF
--- a/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
@@ -13,9 +13,17 @@ gbl:
 sdk_patches:
   - disable_gp_rx_filter.patch
 
+sdk_extension:
+  - id: watchdog
+    version: 1.0.0
+    vendor: nabucasa
+
 add_components:
 - id: iostream_usart
   instance: [vcom]
+- id: watchdog
+  vendor: nabucasa
+  package: watchdog
 
 c_defines:
   OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE:

--- a/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
@@ -12,6 +12,8 @@ gbl:
 
 sdk_patches:
   - disable_gp_rx_filter.patch
+  - uart_tx_drop_on_timeout.patch
+  - uart_tx_bounded_wait_usart.patch
 
 sdk_extension:
   - id: watchdog

--- a/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
+++ b/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
@@ -12,6 +12,8 @@ gbl:
 
 sdk_patches:
   - disable_gp_rx_filter.patch
+  - uart_tx_drop_on_timeout.patch
+  - uart_tx_bounded_wait_usart.patch
 
 sdk_extension:
   - id: watchdog

--- a/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
+++ b/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
@@ -13,11 +13,19 @@ gbl:
 sdk_patches:
   - disable_gp_rx_filter.patch
 
+sdk_extension:
+  - id: watchdog
+    version: 1.0.0
+    vendor: nabucasa
+
 add_components:
 - id: iostream_usart
   instance: [vcom]
 - id: simple_led
   instance: [board_activity]
+- id: watchdog
+  vendor: nabucasa
+  package: watchdog
 
 # SLC validates clock settings before c_defines are patched, use `configuration`
 configuration:

--- a/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
@@ -17,6 +17,9 @@ sdk_extension:
   - id: led_effects_openthread
     version: 1.0.0
     vendor: nabucasa
+  - id: watchdog
+    version: 1.0.0
+    vendor: nabucasa
 
 sdk_patches:
   - disable_gp_rx_filter.patch
@@ -41,6 +44,9 @@ add_components:
 - id: zbt2_reset_button
   vendor: nabucasa
   package: nabucasa_hardware
+- id: watchdog
+  vendor: nabucasa
+  package: watchdog
 
 # SLC reads `configuration` during validation, before c_defines are patched
 configuration:

--- a/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
@@ -23,6 +23,8 @@ sdk_extension:
 
 sdk_patches:
   - disable_gp_rx_filter.patch
+  - uart_tx_drop_on_timeout.patch
+  - uart_tx_bounded_wait_eusart.patch
 
 add_components:
 - id: spidrv_eusart

--- a/src/openthread_rcp/extension/watchdog_extension/config/watchdog_config.h
+++ b/src/openthread_rcp/extension/watchdog_extension/config/watchdog_config.h
@@ -1,0 +1,42 @@
+/*
+ * watchdog_config.h
+ *
+ * Watchdog configuration.
+ */
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+#ifndef WATCHDOG_CONFIG_H
+#define WATCHDOG_CONFIG_H
+
+#include "em_wdog.h"
+
+// <h> Watchdog Configuration
+
+// <e WATCHDOG_ENABLE> Enable the watchdog.
+// <i> Default: 1
+#define WATCHDOG_ENABLE 1
+// </e>
+
+// <o WATCHDOG_PERIOD> Watchdog timeout period.
+// <i> Default: wdogPeriod_64k (~2s on the 32 kHz LFRCO). Warning interrupt
+// <i> fires at 75% (~1.5s); reset occurs at the full period.
+// <wdogPeriod_2k=> wdogPeriod_2k / ~64ms
+// <wdogPeriod_4k=> wdogPeriod_4k / ~125ms
+// <wdogPeriod_8k=> wdogPeriod_8k / ~250ms
+// <wdogPeriod_16k=> wdogPeriod_16k / ~500ms
+// <wdogPeriod_32k=> wdogPeriod_32k / ~1s
+// <wdogPeriod_64k=> wdogPeriod_64k / ~2s
+// <wdogPeriod_128k=> wdogPeriod_128k / ~4s
+// <wdogPeriod_256k=> wdogPeriod_256k / ~8s
+#define WATCHDOG_PERIOD wdogPeriod_64k
+
+// <q WATCHDOG_DEBUG_RUN> Keep counting during debug halt.
+// <i> Default: 0 (paused while a debugger has the core halted).
+#define WATCHDOG_DEBUG_RUN 0
+
+// </h>
+
+#endif // WATCHDOG_CONFIG_H
+
+// <<< end of configuration section >>>

--- a/src/openthread_rcp/extension/watchdog_extension/config/watchdog_config.h
+++ b/src/openthread_rcp/extension/watchdog_extension/config/watchdog_config.h
@@ -29,7 +29,7 @@
 // <wdogPeriod_64k=> wdogPeriod_64k / ~2s
 // <wdogPeriod_128k=> wdogPeriod_128k / ~4s
 // <wdogPeriod_256k=> wdogPeriod_256k / ~8s
-#define WATCHDOG_PERIOD wdogPeriod_64k
+#define WATCHDOG_PERIOD wdogPeriod_128k
 
 // <q WATCHDOG_DEBUG_RUN> Keep counting during debug halt.
 // <i> Default: 0 (paused while a debugger has the core halted).

--- a/src/openthread_rcp/extension/watchdog_extension/inc/watchdog.h
+++ b/src/openthread_rcp/extension/watchdog_extension/inc/watchdog.h
@@ -1,0 +1,17 @@
+/*
+ * watchdog.h
+ *
+ * Hardware watchdog for the bare-metal superloop, with the WDOG warning
+ * interrupt routed into the legacy-HAL crash handler for enhanced capture.
+ */
+
+#ifndef WATCHDOG_H
+#define WATCHDOG_H
+
+// Configures and enables WDOG0. Wired to the `driver_init` event.
+void watchdog_init(void);
+
+// Feeds WDOG0. Wired to the `service_process_action` event (every superloop pass).
+void watchdog_feed(void);
+
+#endif // WATCHDOG_H

--- a/src/openthread_rcp/extension/watchdog_extension/src/watchdog.c
+++ b/src/openthread_rcp/extension/watchdog_extension/src/watchdog.c
@@ -1,0 +1,75 @@
+/*
+ * watchdog.c
+ *
+ * WDOG0 driver for the bare-metal superloop.
+ *
+ * The watchdog is fed once per superloop pass (`service_process_action`). If the
+ * loop stalls, the warning interrupt fires at 75% of the timeout and is routed
+ * straight into the legacy-HAL crash collector (`fault` in faults.s). That path
+ * captures the registers/stack of the stalled code and classifies the reset as
+ * RESET_WATCHDOG_CAUGHT (see halInternalCrashHandler() in diagnostic.c), then
+ * resets the chip well before the hard timeout would expire.
+ */
+
+#include "watchdog.h"
+#include "watchdog_config.h"
+
+#include "em_device.h"
+#include "em_wdog.h"
+#include "em_rmu.h"
+#include "sl_clock_manager.h"
+
+// Defined in the legacy-HAL crash collector (faults.s). Entered with the
+// exception frame intact; saves crash data and resets via halInternalSysReset().
+extern void fault(void);
+
+void watchdog_init(void)
+{
+#if WATCHDOG_ENABLE
+  sl_clock_manager_enable_bus_clock(SL_BUS_CLOCK_WDOG0);
+
+  // Use a FULL reset (not just a core reset) on watchdog timeout.
+#if defined(_RMU_CTRL_WDOGRMODE_MASK)
+  RMU_ResetControl(rmuResetWdog, rmuResetModeFull);
+#endif
+
+  WDOG_Init_TypeDef init = WDOG_INIT_DEFAULT;
+  init.perSel   = WATCHDOG_PERIOD;
+  init.warnSel  = wdogWarnTime75pct;
+  init.debugRun = WATCHDOG_DEBUG_RUN;
+
+#if defined(_WDOG_CTRL_CLKSEL_MASK)
+  init.clkSel = wdogClkSelLFRCO;
+#endif
+
+  WDOGn_Init(DEFAULT_WDOG, &init);
+
+  // Enable the WARN interrupt so a stall is caught with enhanced crash info
+  // before the hard reset. The IRQ vector (WDOG0_IRQHandler below) branches
+  // into the crash collector; the WARN flag is intentionally left set so the
+  // collector can classify the reset as RESET_WATCHDOG_CAUGHT.
+#if defined(WDOG_IF_WARN)
+  NVIC_ClearPendingIRQ(WDOG0_IRQn);
+  WDOGn_IntClear(DEFAULT_WDOG, WDOG_IF_WARN);
+  NVIC_EnableIRQ(WDOG0_IRQn);
+  WDOGn_IntEnable(DEFAULT_WDOG, WDOG_IEN_WARN);
+#endif
+#endif // WATCHDOG_ENABLE
+}
+
+void watchdog_feed(void)
+{
+#if WATCHDOG_ENABLE
+  WDOGn_Feed(DEFAULT_WDOG);
+#endif
+}
+
+#if WATCHDOG_ENABLE && defined(WDOG_IF_WARN)
+// Route the warning interrupt into the crash collector with the exception frame
+// untouched. `naked` keeps the compiler from emitting a prologue; `used`
+// prevents LTO from discarding the vector-table override.
+__attribute__((naked, used)) void WDOG0_IRQHandler(void)
+{
+  __asm volatile ("b.w fault");
+}
+#endif

--- a/src/openthread_rcp/extension/watchdog_extension/watchdog.slcc
+++ b/src/openthread_rcp/extension/watchdog_extension/watchdog.slcc
@@ -1,0 +1,37 @@
+id: watchdog
+label: Watchdog
+package: custom
+description: >
+  Hardware watchdog (WDOG0) for the bare-metal superloop. The watchdog is fed
+  every superloop iteration; if the loop stalls, the warning interrupt fires at
+  75% of the timeout and is routed into the crash handler so the stuck PC and
+  stack are captured (RESET_WATCHDOG_CAUGHT) before the chip resets.
+category: Platform|Driver|Watchdog
+quality: production
+source:
+  - path: src/watchdog.c
+include:
+  - path: inc
+    file_list:
+    - path: watchdog.h
+config_file:
+  - path: config/watchdog_config.h
+    file_id: watchdog_config
+provides:
+  - name: watchdog
+requires:
+  - name: emlib_wdog
+  - name: emlib_rmu
+  - name: clock_manager_runtime
+  - name: ot_crash_handler
+template_contribution:
+  - name: event_handler
+    value:
+      event: driver_init
+      include: watchdog.h
+      handler: watchdog_init
+  - name: event_handler
+    value:
+      event: service_process_action
+      include: watchdog.h
+      handler: watchdog_feed

--- a/src/openthread_rcp/extension/watchdog_extension/watchdog.slce
+++ b/src/openthread_rcp/extension/watchdog_extension/watchdog.slce
@@ -1,0 +1,5 @@
+id: watchdog
+vendor: nabucasa
+version: "1.0.0"
+component_path:
+  - path: "./"

--- a/src/openthread_rcp/sdk_patches/uart_tx_bounded_wait_eusart.patch
+++ b/src/openthread_rcp/sdk_patches/uart_tx_bounded_wait_eusart.patch
@@ -1,0 +1,22 @@
+diff --git a/platform_core/platform/service/iostream/src/sl_iostream_eusart.c b/platform_core/platform/service/iostream/src/sl_iostream_eusart.c
+index 6068fbf..de2e750 100644
+--- a/platform_core/platform/service/iostream/src/sl_iostream_eusart.c
++++ b/platform_core/platform/service/iostream/src/sl_iostream_eusart.c
+@@ -591,7 +591,16 @@ static sl_status_t eusart_tx(void *context,
+ {
+   sl_iostream_eusart_context_t *eusart_context = (sl_iostream_eusart_context_t *)context;
+   EUSART_TypeDef* eusart_periph = sl_device_peripheral_eusart_get_base_addr(eusart_context->eusart);
+-  EUSART_TX(eusart_periph, c);
++
++  // `EUSART_TX` blocks indefinitely with hardware flow control and a disconnected host.
++  // Give up transmitting after a dozen milliseconds to avoid a deadlock.
++  uint32_t budget = 1000000;
++  while (!(EUSART_STATUS_GET(eusart_periph) & EUSART_STATUS_TXFL)) {
++    if (budget-- == 0) {
++      return SL_STATUS_TIMEOUT;
++    }
++  }
++  eusart_periph->TXDATA = (uint32_t)(uint8_t)c;
+ 
+ #if defined(SL_IOSTREAM_UART_FLUSH_TX_BUFFER)
+ /* Wait until transmit buffer is empty */

--- a/src/openthread_rcp/sdk_patches/uart_tx_bounded_wait_usart.patch
+++ b/src/openthread_rcp/sdk_patches/uart_tx_bounded_wait_usart.patch
@@ -1,0 +1,22 @@
+diff --git a/platform_core/platform/service/iostream/src/sl_iostream_usart.c b/platform_core/platform/service/iostream/src/sl_iostream_usart.c
+index f884996..249b2f8 100644
+--- a/platform_core/platform/service/iostream/src/sl_iostream_usart.c
++++ b/platform_core/platform/service/iostream/src/sl_iostream_usart.c
+@@ -256,7 +256,16 @@ static sl_status_t usart_tx(void *context,
+ {
+   sl_iostream_usart_context_t *usart_context = (sl_iostream_usart_context_t *)context;
+ 
+-  USART_Tx(usart_context->usart, (uint8_t)c);
++
++  // `USART_Tx` blocks indefinitely with hardware flow control and a disconnected host.
++  // Give up transmitting after a dozen milliseconds to avoid a deadlock.
++  uint32_t budget = 1000000;
++  while (!(USART_StatusGet(usart_context->usart) & USART_STATUS_TXBL)) {
++    if (budget-- == 0) {
++      return SL_STATUS_TIMEOUT;
++    }
++  }
++  usart_context->usart->TXDATA = (uint32_t)(uint8_t)c;
+ 
+ #if defined(SL_IOSTREAM_UART_FLUSH_TX_BUFFER)
+   /* Wait until transmit buffer is empty */

--- a/src/openthread_rcp/sdk_patches/uart_tx_drop_on_timeout.patch
+++ b/src/openthread_rcp/sdk_patches/uart_tx_drop_on_timeout.patch
@@ -1,0 +1,16 @@
+diff --git a/openthread/platform-abstraction/efr32/iostream_uart.c b/openthread/platform-abstraction/efr32/iostream_uart.c
+index c9643cc..935ac0b 100644
+--- a/openthread/platform-abstraction/efr32/iostream_uart.c
++++ b/openthread/platform-abstraction/efr32/iostream_uart.c
+@@ -218,8 +218,10 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+     }
+ 
+     status = sl_iostream_write(sl_iostream_vcom_handle, aBuf, aBufLength);
+-    if (status == SL_STATUS_OK)
++    if (status == SL_STATUS_OK || status == SL_STATUS_TIMEOUT)
+     {
++        // SL_STATUS_TIMEOUT means hardware flow control kept the transmitter frozen.
++        // Pretend the write succeeded, the host will recover.
+         sTransmitDone = true;
+         error         = OT_ERROR_NONE;
+     }


### PR DESCRIPTION
One isn't enabled by default and I've noticed OpenThread RCP locking up in rare circumstances.

Might help with https://github.com/home-assistant/addons/issues/4719.