### PR TITLE
Consolidated unicast sending API

### DIFF
--- a/src/zigbee_ncp/extension/xncp_common_extension/src/xncp_common_commands.c
+++ b/src/zigbee_ncp/extension/xncp_common_extension/src/xncp_common_commands.c
@@ -11,6 +11,7 @@
 #include "ezsp-enum.h"
 #include "em_usart.h"
 #include "random.h"
+#include "stack/include/stack-info.h"
 
 #if defined(SL_CATALOG_IOSTREAM_EUSART_PRESENT)
 #include "sl_iostream_eusart.h"
@@ -22,6 +23,9 @@
 #include <string.h>
 
 #define BUILD_UINT16(low, high) (((uint16_t)(low)) | ((uint16_t)(high) << 8))
+
+#define XNCP_SEND_UNICAST_FLAG_EXTENDED_TIMEOUT (1 << 0)
+#define XNCP_SEND_UNICAST_FLAG_SOURCE_ROUTE     (1 << 1)
 
 typedef enum {
   XNCP_FLOW_CONTROL_TYPE_SOFTWARE = 0x00,
@@ -44,9 +48,10 @@ typedef struct ManualSourceRoute {
 
 static ManualSourceRoute manual_source_routes[XNCP_MANUAL_SOURCE_ROUTE_TABLE_SIZE];
 
-// External references to EmberZNet route table
+// External references to EmberZNet internal tables
 extern sli_zigbee_route_table_entry_t sli_zigbee_route_table[];
 extern uint8_t sli_zigbee_route_table_size;
+extern uint8_t sli_zigbee_address_table_size;
 
 //------------------------------------------------------------------------------
 // Forward declarations
@@ -60,6 +65,7 @@ static bool handle_get_chip_info(xncp_context_t *ctx);
 static bool handle_set_route_table_entry(xncp_context_t *ctx);
 static bool handle_get_route_table_entry(xncp_context_t *ctx);
 static bool handle_get_tx_power_info(xncp_context_t *ctx);
+static bool handle_send_unicast(xncp_context_t *ctx);
 
 //------------------------------------------------------------------------------
 // Command table
@@ -74,6 +80,7 @@ const xncp_command_def_t xncp_common_commands[] = {
     {0x0006, handle_set_route_table_entry},
     {0x0007, handle_get_route_table_entry},
     {0x0008, handle_get_tx_power_info},
+    {0x0009, handle_send_unicast},
     {0, NULL}  // sentinel
 };
 
@@ -178,22 +185,11 @@ void nc_zigbee_override_append_source_route(uint16_t destination,
     }
 }
 
-static bool handle_set_source_route(xncp_context_t *ctx)
+static void install_manual_source_route(uint16_t node_id,
+                                        const uint8_t *relay_bytes,
+                                        uint8_t num_relays)
 {
-    if ((ctx->payload_length < 2) || (ctx->payload_length % 2 != 0)) {
-        *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
-        return true;
-    }
-
-    uint8_t num_relays = (ctx->payload_length - 2) / 2;
-
-    if (num_relays > XNCP_MAX_SOURCE_ROUTE_RELAY_COUNT) {
-        *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
-        return true;
-    }
-
     uint8_t insertion_index = xncp_get_pseudo_random_number() % XNCP_MANUAL_SOURCE_ROUTE_TABLE_SIZE;
-    uint16_t node_id = BUILD_UINT16(ctx->payload[0], ctx->payload[1]);
 
     for (uint8_t i = 0; i < XNCP_MANUAL_SOURCE_ROUTE_TABLE_SIZE; i++) {
         ManualSourceRoute *route = &manual_source_routes[i];
@@ -209,13 +205,30 @@ static bool handle_set_source_route(xncp_context_t *ctx)
     ManualSourceRoute *route = &manual_source_routes[insertion_index];
 
     for (uint8_t i = 0; i < num_relays; i++) {
-        uint16_t relay = BUILD_UINT16(ctx->payload[2 + 2 * i + 0], ctx->payload[2 + 2 * i + 1]);
-        route->relays[i] = relay;
+        route->relays[i] = BUILD_UINT16(relay_bytes[2 * i + 0], relay_bytes[2 * i + 1]);
     }
 
     route->destination = node_id;
     route->num_relays = num_relays;
     route->active = true;
+}
+
+static bool handle_set_source_route(xncp_context_t *ctx)
+{
+    if ((ctx->payload_length < 2) || (ctx->payload_length % 2 != 0)) {
+        *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
+        return true;
+    }
+
+    uint8_t num_relays = (ctx->payload_length - 2) / 2;
+
+    if (num_relays > XNCP_MAX_SOURCE_ROUTE_RELAY_COUNT) {
+        *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
+        return true;
+    }
+
+    uint16_t node_id = BUILD_UINT16(ctx->payload[0], ctx->payload[1]);
+    install_manual_source_route(node_id, ctx->payload + 2, num_relays);
 
     *ctx->status = XNCP_STATUS_OK;
     return true;
@@ -378,5 +391,102 @@ static bool handle_get_tx_power_info(xncp_context_t *ctx)
     ctx->reply[(*ctx->reply_length)++] = (uint8_t)result.recommended_power_dbm;
     ctx->reply[(*ctx->reply_length)++] = (uint8_t)result.max_power_dbm;
 
+    return true;
+}
+
+//------------------------------------------------------------------------------
+// Combined send (XNCP_FEATURE_COMBINED_SEND)
+//------------------------------------------------------------------------------
+
+// Mirrors the host `set_extended_timeout` logic locally: skip if already set,
+// otherwise set it, creating an address table entry first if none exists.
+static void apply_extended_timeout(uint8_t *eui64, uint16_t node_id, bool extended_timeout)
+{
+    bool current = (sl_zigbee_get_extended_timeout(eui64) == SL_STATUS_OK);
+    if (current == extended_timeout) {
+        return;
+    }
+
+    sl_802154_short_addr_t existing_node_id;
+    if ((sl_zigbee_lookup_node_id_by_eui64(eui64, &existing_node_id) == SL_STATUS_OK)
+        && (existing_node_id != SL_ZIGBEE_TABLE_ENTRY_UNUSED_NODE_ID)) {
+        sl_zigbee_set_extended_timeout(eui64, extended_timeout);
+        return;
+    }
+
+    // No address table entry exists; replace a random one so the timeout sticks
+    uint8_t index = xncp_get_pseudo_random_number() % sli_zigbee_address_table_size;
+    sl_zigbee_set_address_table_info(index, eui64, node_id);
+    sl_zigbee_set_extended_timeout(eui64, extended_timeout);
+}
+
+static bool handle_send_unicast(xncp_context_t *ctx)
+{
+    uint8_t *p = ctx->payload;
+    uint8_t *end = ctx->payload + ctx->payload_length;
+
+    // flags(1) + destination(2) + aps_frame(11) + message_tag(1)
+    if ((end - p) < 15) {
+        *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
+        return true;
+    }
+
+    uint8_t flags = *p++;
+
+    sl_802154_short_addr_t destination = BUILD_UINT16(p[0], p[1]);
+    p += 2;
+
+    sl_zigbee_aps_frame_t aps_frame;
+    aps_frame.profileId = BUILD_UINT16(p[0], p[1]); p += 2;
+    aps_frame.clusterId = BUILD_UINT16(p[0], p[1]); p += 2;
+    aps_frame.sourceEndpoint = *p++;
+    aps_frame.destinationEndpoint = *p++;
+    aps_frame.options = BUILD_UINT16(p[0], p[1]); p += 2;
+    aps_frame.groupId = BUILD_UINT16(p[0], p[1]); p += 2;
+    aps_frame.sequence = *p++;
+    aps_frame.radius = 0;
+
+    uint8_t message_tag = *p++;
+
+    if (flags & XNCP_SEND_UNICAST_FLAG_EXTENDED_TIMEOUT) {
+        if ((end - p) < 9) {
+            *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
+            return true;
+        }
+        uint8_t *eui64 = p;
+        p += 8;
+        bool extended_timeout = (*p++ != 0);
+        apply_extended_timeout(eui64, destination, extended_timeout);
+    }
+
+    if (flags & XNCP_SEND_UNICAST_FLAG_SOURCE_ROUTE) {
+        if ((end - p) < 1) {
+            *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
+            return true;
+        }
+        uint8_t num_relays = *p++;
+        if ((num_relays > XNCP_MAX_SOURCE_ROUTE_RELAY_COUNT)
+            || ((end - p) < (num_relays * 2))) {
+            *ctx->status = XNCP_STATUS_BAD_ARGUMENT;
+            return true;
+        }
+        install_manual_source_route(destination, p, num_relays);
+        p += num_relays * 2;
+    }
+
+    uint8_t message_length = (uint8_t)(end - p);
+
+    uint8_t aps_sequence = 0;
+    sl_status_t status = sl_zigbee_send_unicast(SL_ZIGBEE_OUTGOING_DIRECT,
+                                                destination, &aps_frame, message_tag,
+                                                message_length, p, &aps_sequence);
+
+    ctx->reply[(*ctx->reply_length)++] = (uint8_t)((status >>  0) & 0xFF);
+    ctx->reply[(*ctx->reply_length)++] = (uint8_t)((status >>  8) & 0xFF);
+    ctx->reply[(*ctx->reply_length)++] = (uint8_t)((status >> 16) & 0xFF);
+    ctx->reply[(*ctx->reply_length)++] = (uint8_t)((status >> 24) & 0xFF);
+    ctx->reply[(*ctx->reply_length)++] = aps_sequence;
+
+    *ctx->status = XNCP_STATUS_OK;
     return true;
 }

--- a/src/zigbee_ncp/extension/xncp_common_extension/xncp_common_commands.slcc
+++ b/src/zigbee_ncp/extension/xncp_common_extension/xncp_common_commands.slcc
@@ -40,6 +40,8 @@ template_contribution:
     value: XNCP_FEATURE_CHIP_INFO
   - name: xncp_feature
     value: XNCP_FEATURE_RESTORE_ROUTE_TABLE
+  - name: xncp_feature
+    value: XNCP_FEATURE_COMBINED_SEND
   - name: zigbee_af_callback
     value:
       callback_type: event_init

--- a/src/zigbee_ncp/extension/xncp_extension/inc/xncp_types.h
+++ b/src/zigbee_ncp/extension/xncp_extension/inc/xncp_types.h
@@ -64,6 +64,7 @@ typedef EmberMessageBuffer xncp_message_buffer_t;
 #define XNCP_FEATURE_CHIP_INFO             (1UL << 5)
 #define XNCP_FEATURE_RESTORE_ROUTE_TABLE   (1UL << 6)
 #define XNCP_FEATURE_TX_POWER_INFO         (1UL << 7)
+#define XNCP_FEATURE_COMBINED_SEND         (1UL << 8)
 #define XNCP_FEATURE_LED_CONTROL           (1UL << 31)
 
 // Base command IDs (extensions define their own in separate headers)


### PR DESCRIPTION
Bellows currently sends a few commands back-to-back when sending a unicast request:
- Setting an extended timeout:
  - Breaks early if `getExtendedTimeout` is already correct.
  - If not, uses `lookupNodeIdByEui64` and optionally `setExtendedTimeout` + `replaceAddressTableEntry`.
- `xncp_set_manual_source_route` (if manual source routing is enabled)
- `send_unicast`

This PR replaces them all with a single XNCP command that performs the above logic in firmware to reduce serial round trips.