### PR TITLE
Update firmware changelogs

### DIFF
--- a/src/openthread_rcp/CHANGELOG.md
+++ b/src/openthread_rcp/CHANGELOG.md
@@ -1,17 +1,23 @@
 # SL-OPENTHREAD/3.1.0.0_GitHub-fb274efe6
-This beta release is built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0.
+Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0, adding automatic recovery from firmware stalls and fixing serial link lockups.
+
+- Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0, up from Simplicity SDK 2025.6.2.
+- Added a watchdog that resets the adapter if the firmware gets stuck.
+- Fixed the serial link locking up when the host stopped reading while hardware flow control was enabled (ZBT-1 and Yellow). Transmits now give up after a short bounded wait and drop the byte, so the adapter keeps running and the host can recover.
+- Doubled the host transmit buffer from 2048 to 4096 bytes, reducing dropped frames when a burst of network traffic arrives at once.
+- Fixed a Green Power packet filter that misclassified zero-payload frames by reading past the end of the frame.
 
 # SL-OPENTHREAD/3.0.2.0_GitHub-61e43cffb
-This beta release is built with OpenThread 3.0.2 from Simplicity SDK 2025.12.3.
+Built with OpenThread 3.0.2 from Simplicity SDK 2025.12.3.
 
 # SL-OPENTHREAD/2.7.2.0_GitHub-fb0446f53
-This beta release is built with Simplicity SDK 2025.6.2.
+Built with Simplicity SDK 2025.6.2.
 
 # 2.4.7.0_GitHub-fb0446f53
-Beta release built with Gecko SDK 4.5.0.
+Built with Gecko SDK 4.5.0.
 
 # 2.4.6.0_GitHub-bdb394eb3
-Beta release built with Gecko SDK 4.4.6.
+Built with Gecko SDK 4.4.6.
 
 # SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4
 Initial release with the new firmware builder. This firmware is identical to the firmware bundled with the OpenThread Border Router addon.

--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,14 +1,20 @@
 # 9.1.0.0
-Beta release built with EmberZNet 9.1 from Simplicity SDK 2026.6.0.
+Built with EmberZNet 9.1 from Simplicity SDK 2026.6.0, migrating us from Gecko SDK to Simplicity SDK. Faster message sending, Zigbee 4.0 support, and a few increased buffers.
+
+- Built with EmberZNet 9.1 from Simplicity SDK 2026.6.0.
+- Added Zigbee 4.0 support. This is fully backwards compatible with Zigbee 3.0 and 1.2.
+- Sending a message now takes a single request instead of up to three with a new XNCP API. This reduces latency when sending requests with network coordinators.
+- Increased network table sizes. On ZBT-2 the route and source route tables hold 254 entries, the address table 128, and up to 128 messages can be in flight at once, with a larger packet buffer heap. On SkyConnect and Yellow, 64 messages can be in flight and the address table holds 32 entries.
+- Increased the serial receive buffer from 128 to 512 bytes.
 
 # 9.0.2.0
-Beta release built with EmberZNet 9.0 from Simplicity SDK 2025.12.3. This is our first release that migrates from the older Gecko SDK to the newer Simplicity SDK.
+Built with EmberZNet 9.0 from Simplicity SDK 2025.12.3.
 
 # 7.5.1.0
-Beta release built with Gecko SDK 4.5.0. This includes a new feature to restore routes on adapter startup, speeding up network responsiveness after a reset.
+Built with Gecko SDK 4.5.0. This includes a new feature to restore routes on adapter startup, speeding up network responsiveness after a reset.
 
 # 7.5.0.0
-Beta release built with Gecko SDK 4.4.6.
+Built with Gecko SDK 4.4.6.
 
 # 7.4.4.6
 For adapters that support RGB LEDs, fix the color XNCP command parsing. Allow the adapter to signal preferred TX power settings for a given regulatory domain.

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 1.3.0
-* SDK updated to Simplicity SDK 2025.12.3 (Z-Wave SDK 8.0.2)
+Updated to Simplicity SDK 2026.6.0 (Z-Wave SDK 8.1.0).
+
+* Updated to Simplicity SDK 2026.6.0 (Z-Wave SDK 8.1.0), up from Simplicity SDK 2025.12.1 (Z-Wave SDK 8.0.0).
+* Resynced the Serial API application with the new SDK reference application, including its DMA and sleep timer driver changes.
 
 # 1.2.0
 * SDK updated to Simplicity SDK 2025.12.1.

--- a/src/zwa2_controller/README.md
+++ b/src/zwa2_controller/README.md
@@ -22,14 +22,14 @@ Examples:
 | `0`  | [`2024.12.1`][sisdk-2024.12.1] | [`7.23.1`][zdk-7.23.1] |
 | `1`  | [`2024.12.2`][sisdk-2024.12.2] | [`7.23.2`][zdk-7.23.2] |
 | `2`  | [`2025.12.1`][sisdk-2025.12.1] | [`8.0.0`][zdk-8.0.0]   |
-| `3`  | [`2025.12.3`][sisdk-2025.12.3] | [`8.0.2`][zdk-8.0.2]   |
+| `3`  | [`2026.6.0`][sisdk-2026.6.0]   | [`8.1.0`][zdk-8.1.0]   |
 
 <!-- SDK links -->
 [sisdk-2024.12.1]: https://github.com/SiliconLabs/simplicity_sdk/releases/tag/v2024.12.1-0
 [sisdk-2024.12.2]: https://github.com/SiliconLabs/simplicity_sdk/releases/tag/v2024.12.2
 [sisdk-2025.12.1]: https://docs.silabs.com/sisdk-release-notes/2025.12.1/sisdk-release-notes-overview/
-[sisdk-2025.12.3]: https://docs.silabs.com/sisdk-release-notes/2025.12.3/sisdk-release-notes-overview/
+[sisdk-2026.6.0]: https://docs.silabs.com/sisdk-release-notes/2026.6.0/sisdk-release-notes-overview/
 [zdk-7.23.1]: https://www.silabs.com/documents/public/release-notes/SRN14930-7.23.1.0.pdf
 [zdk-7.23.2]: https://www.silabs.com/documents/public/release-notes/SRN14930-7.23.2.0.pdf
 [zdk-8.0.0]: https://docs.silabs.com/sisdk-release-notes/2025.12.1/sisdk-zwave-release-notes/
-[zdk-8.0.2]: https://docs.silabs.com/sisdk-release-notes/2025.12.3/sisdk-zwave-release-notes/
+[zdk-8.1.0]: https://docs.silabs.com/sisdk-release-notes/2026.6.0/sisdk-zwave-release-notes/


### PR DESCRIPTION
We haven't been keeping track of firmware changes for the upcoming beta. This PR updates all of them and expands the changelog entries properly, using the first line for the release summary and the rest as the release notes. A HA Core PR is required (WIP) to take advantage of the new release notes.