### PR TITLE
Bump all manifests to Simplicity SDK 2026.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,8 +155,11 @@ RUN set -e \
         ninja/1.12.1 \
         commander/1.24.1 \
         slc-cli/6.0.22 \
-        simplicity-sdk/2026.6.1 \
+        simplicity-sdk/2026.6.0 \
         zap/2026.06.17 \
+    # conan's dependency graph rejects two versions of the same package in a
+    # single `install` invocation, so the other SDK version needs its own.
+    && slt --non-interactive install simplicity-sdk/2026.6.1 \
     # We don't currently use the LLVM toolchain that is pulled in as a default
     # dependency. Uninstall it to save space.
     && slt --non-interactive uninstall --force llvm-arm-toolchain-for-embedded \

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,11 +155,8 @@ RUN set -e \
         ninja/1.12.1 \
         commander/1.24.1 \
         slc-cli/6.0.22 \
-        simplicity-sdk/2026.6.0 \
+        simplicity-sdk/2026.6.1 \
         zap/2026.06.17 \
-    # conan's dependency graph rejects two versions of the same package in a
-    # single `install` invocation, so the other SDK version needs its own.
-    && slt --non-interactive install simplicity-sdk/2026.6.1 \
     # We don't currently use the LLVM toolchain that is pulled in as a default
     # dependency. Uninstall it to save space.
     && slt --non-interactive uninstall --force llvm-arm-toolchain-for-embedded \

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN set -e \
         ninja/1.12.1 \
         commander/1.24.1 \
         slc-cli/6.0.22 \
-        simplicity-sdk/2026.6.0 \
+        simplicity-sdk/2026.6.1 \
         zap/2026.06.17 \
     # We don't currently use the LLVM toolchain that is pulled in as a default
     # dependency. Uninstall it to save space.

--- a/manifests/nabucasa/skyconnect/skyconnect_bootloader.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_bootloader.yaml
@@ -2,7 +2,7 @@ name: SkyConnect Bootloader
 device: EFR32MG21A020F512IM32
 base_project: src/bootloader
 filename: "{manifest_name}_{gecko_bootloader_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_openthread_rcp.yaml
@@ -2,7 +2,7 @@ name: SkyConnect OpenThread RCP
 device: EFR32MG21A020F512IM32
 base_project: src/openthread_rcp
 filename: "{manifest_name}_{ot_rcp_version.split('/')[-1]}_gsdk_{sdk_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/skyconnect/skyconnect_zigbee_ncp.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_zigbee_ncp.yaml
@@ -2,7 +2,7 @@ name: SkyConnect Zigbee
 device: EFR32MG21A020F512IM32
 base_project: src/zigbee_ncp
 filename: "{manifest_name}_{ezsp_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/yellow/yellow_bootloader.yaml
+++ b/manifests/nabucasa/yellow/yellow_bootloader.yaml
@@ -2,7 +2,7 @@ name: Yellow Bootloader
 device: MGM210PA32JIA
 base_project: src/bootloader
 filename: "{manifest_name}_{gecko_bootloader_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
+++ b/manifests/nabucasa/yellow/yellow_openthread_rcp.yaml
@@ -2,7 +2,7 @@ name: Yellow OpenThread RCP
 device: MGM210PA32JIA
 base_project: src/openthread_rcp
 filename: "{manifest_name}_{ot_rcp_version.split('/')[-1]}_gsdk_{sdk_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/yellow/yellow_zigbee_ncp.yaml
+++ b/manifests/nabucasa/yellow/yellow_zigbee_ncp.yaml
@@ -2,7 +2,7 @@ name: Yellow Zigbee
 device: MGM210PA32JIA
 base_project: src/zigbee_ncp
 filename: "{manifest_name}_{ezsp_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/zbt2/zbt2_bootloader.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_bootloader.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZBT-2 Bootloader
 device: EFR32MG24A420F1536IM40
 base_project: src/bootloader
 filename: "{manifest_name}_{gecko_bootloader_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZBT-2 OpenThread RCP
 device: EFR32MG24A420F1536IM40
 base_project: src/openthread_rcp
 filename: "{manifest_name}_{ot_rcp_version.split('/')[-1]}_gsdk_{sdk_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "gcc:14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/zbt2/zbt2_router.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_router.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZBT-2 Zigbee Router
 device: EFR32MG24A420F1536IM40
 base_project: src/zigbee_router
 filename: "{manifest_name}_{sdk_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "gcc:14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/zbt2/zbt2_zigbee_ncp.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_zigbee_ncp.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZBT-2 Zigbee
 device: EFR32MG24A420F1536IM40
 base_project: src/zigbee_ncp
 filename: "{manifest_name}_{ezsp_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "gcc:14.2.1.20241119"
 
 gbl:

--- a/manifests/nabucasa/zwa2/zwa2_controller.yaml
+++ b/manifests/nabucasa/zwa2/zwa2_controller.yaml
@@ -2,7 +2,7 @@ name: Home Assistant Connect ZWA-2 Z-Wave Controller
 device: EFR32ZG23A020F512GM40
 base_project: src/zwa2_controller
 filename: "{manifest_name}_{zwave_version}"
-sdk: "simplicity_sdk:2026.6.0"
+sdk: "simplicity_sdk:2026.6.1"
 toolchain: "gcc:14.2.1.20241119"
 gbl:
   fw_type: zwave_ncp

--- a/src/openthread_rcp/CHANGELOG.md
+++ b/src/openthread_rcp/CHANGELOG.md
@@ -1,3 +1,6 @@
+# SL-OPENTHREAD/3.1.1.0_GitHub-fb274efe6
+Built with Simplicity SDK 2026.6.1, up from Simplicity SDK 2026.6.0.
+
 # SL-OPENTHREAD/3.1.0.0_GitHub-fb274efe6
 Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0, adding automatic recovery from firmware stalls and fixing serial link lockups.
 

--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.1.1.0
+Built with Simplicity SDK 2026.6.1, up from Simplicity SDK 2026.6.0.
+
 # 9.1.0.0
 Built with EmberZNet 9.1 from Simplicity SDK 2026.6.0, migrating us from Gecko SDK to Simplicity SDK. Faster message sending, Zigbee 4.0 support, and a few increased buffers.
 

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.
 
-* Updated to Simplicity SDK 2026.6.0 (Z-Wave SDK 8.1.0), up from Simplicity SDK 2025.12.1 (Z-Wave SDK 8.0.0).
+* Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), up from Simplicity SDK 2025.12.1 (Z-Wave SDK 8.0.0).
 * Resynced the Serial API application with the new SDK reference application, including its DMA and sleep timer driver changes.
-* Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration.
+* Restored runtime Image Rejection calibration.
 * Fixed a transmission stall that could occur under LBT/CSMA.
 * Fixed fragmented-beam handling for the Japanese region.
 

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -5,7 +5,6 @@ Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image R
 * Resynced the Serial API application with the new SDK reference application, including its DMA and sleep timer driver changes.
 * Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration.
 * Fixed a transmission stall that could occur under LBT/CSMA.
-* Fixed an EFR32ZG28 radio calibration issue affecting RSSI and CCA measurements.
 * Fixed fragmented-beam handling for the Japanese region.
 
 # 1.2.0

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,8 +1,12 @@
 # 1.3.0
-Updated to Simplicity SDK 2026.6.0 (Z-Wave SDK 8.1.0).
+Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.
 
 * Updated to Simplicity SDK 2026.6.0 (Z-Wave SDK 8.1.0), up from Simplicity SDK 2025.12.1 (Z-Wave SDK 8.0.0).
 * Resynced the Serial API application with the new SDK reference application, including its DMA and sleep timer driver changes.
+* Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration.
+* Fixed a transmission stall that could occur under LBT/CSMA.
+* Fixed an EFR32ZG28 radio calibration issue affecting RSSI and CCA measurements.
+* Fixed fragmented-beam handling for the Japanese region.
 
 # 1.2.0
 * SDK updated to Simplicity SDK 2025.12.1.

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -769,6 +769,8 @@ def main():
         # The Z-Wave libraries were packaged against their own conan hashes
         "/home/buildengineer/.silabs/slt/installs/conan/p/cmsis4dea3e6cbb6ce/p": "/src/vendor/cmsis",
         "/home/buildengineer/.silabs/slt/installs/conan/p/platf6edd0cd4d4914/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        # Z-Wave's platform_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1
+        "/home/buildengineer/.silabs/slt/installs/conan/p/platf0f636d352884d/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
         # The zigbee stack libraries reference the silabs_core package they were built against
         "/github/home/.silabs/slt/installs/conan/p/commo8335073ce327e/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
         # silabs_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -771,6 +771,8 @@ def main():
         "/home/buildengineer/.silabs/slt/installs/conan/p/platf6edd0cd4d4914/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
         # The zigbee stack libraries reference the silabs_core package they were built against
         "/github/home/.silabs/slt/installs/conan/p/commo8335073ce327e/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        # silabs_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1
+        "/github/home/.silabs/slt/installs/conan/p/commo6146391826d06/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
         # The Z-Wave SDK isn't part of the Simplicity SDK but is still referenced. If we
         # ever decide to compile it as part of CI, we can change this remap.
         "/opt/github/runner/_work/z-wave/z-wave": "/src/vendor/zwave",


### PR DESCRIPTION
## Summary
- Bump the `sdk` field to `simplicity_sdk:2026.6.1` in all manifests (skyconnect, yellow, zbt2, zwa2)
- Bump the baked `simplicity-sdk` version installed in the build container (Dockerfile) to match
- Now that every manifest targets the same SDK version, simplify the Dockerfile back to a single `slt install` call, removing the temporary dual-version workaround
- Fix two conan package hashes hardcoded in `tools/build_project.py`'s ELF path-reproducibility remap (`silabs_core` and the Z-Wave variant of `platform_core`), which changed when Silicon Labs repackaged them for 2026.6.1
- Add changelog entries for the firmware versions produced by the SDK bump (OpenThread RCP `3.1.1.0`, Zigbee NCP `9.1.1.0`) — no source changes on our side, just the version bump reflected by the new SDK

## Test plan
- [x] Rebuilt the Docker build container locally with `simplicity-sdk/2026.6.1`
- [x] Built `manifests/nabucasa/zbt2/zbt2_openthread_rcp.yaml` locally against the rebuilt container; build succeeded and produced `zbt2_openthread_rcp_3.1.1.0_GitHub-fb274efe6_gsdk_2026.6.1.gbl` with no errors
- [x] CI builds all 11 manifests and generates the release manifest successfully (https://github.com/lboue/silabs-firmware-builder/actions/runs/30552253024)