### PR TITLE
Include all known changelog entries in `manifest.json`

### DIFF
--- a/src/openthread_rcp/CHANGELOG.md
+++ b/src/openthread_rcp/CHANGELOG.md
@@ -1,14 +1,14 @@
 # SL-OPENTHREAD/3.1.1.0_GitHub-fb274efe6
-Built with Simplicity SDK 2026.6.1, up from Simplicity SDK 2026.6.0.
-
-# SL-OPENTHREAD/3.1.0.0_GitHub-fb274efe6
-Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0, adding automatic recovery from firmware stalls and fixing serial link lockups.
+Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.1, adding automatic recovery from firmware stalls and fixing serial link lockups.
 
 - Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0, up from Simplicity SDK 2025.6.2.
 - Added a watchdog that resets the adapter if the firmware gets stuck.
 - Fixed the serial link locking up when the host stopped reading while hardware flow control was enabled (ZBT-1 and Yellow). Transmits now give up after a short bounded wait and drop the byte, so the adapter keeps running and the host can recover.
 - Doubled the host transmit buffer from 2048 to 4096 bytes, reducing dropped frames when a burst of network traffic arrives at once.
 - Fixed a Green Power packet filter that misclassified zero-payload frames by reading past the end of the frame.
+
+# SL-OPENTHREAD/3.1.0.0_GitHub-fb274efe6
+Built with OpenThread 3.1.0 from Simplicity SDK 2026.6.0, adding automatic recovery from firmware stalls and fixing serial link lockups.
 
 # SL-OPENTHREAD/3.0.2.0_GitHub-61e43cffb
 Built with OpenThread 3.0.2 from Simplicity SDK 2025.12.3.

--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,14 +1,14 @@
 # 9.1.1.0
-Built with Simplicity SDK 2026.6.1, up from Simplicity SDK 2026.6.0.
+Built with EmberZNet 9.1 from Simplicity SDK 2026.6.1, migrating us from Gecko SDK to Simplicity SDK. Faster message sending, Zigbee 4.0 support, and a few increased buffers.
 
-# 9.1.0.0
-Built with EmberZNet 9.1 from Simplicity SDK 2026.6.0, migrating us from Gecko SDK to Simplicity SDK. Faster message sending, Zigbee 4.0 support, and a few increased buffers.
-
-- Built with EmberZNet 9.1 from Simplicity SDK 2026.6.0.
+- Built with EmberZNet 9.1 from Simplicity SDK 2026.6.1.
 - Added Zigbee 4.0 support. This is fully backwards compatible with Zigbee 3.0 and 1.2.
 - Sending a message now takes a single request instead of up to three with a new XNCP API. This reduces latency when sending requests with network coordinators.
 - Increased network table sizes. On ZBT-2 the route and source route tables hold 254 entries, the address table 128, and up to 128 messages can be in flight at once, with a larger packet buffer heap. On SkyConnect and Yellow, 64 messages can be in flight and the address table holds 32 entries.
 - Increased the serial receive buffer from 128 to 512 bytes.
+
+# 9.1.0.0
+Built with EmberZNet 9.1 from Simplicity SDK 2026.6.0, migrating us from Gecko SDK to Simplicity SDK.
 
 # 9.0.2.0
 Built with EmberZNet 9.0 from Simplicity SDK 2025.12.3.

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -17,8 +17,9 @@ from universal_silabs_flasher.firmware import parse_firmware_image
 _LOGGER = logging.getLogger(__name__)
 
 
-def parse_markdown_changelog(text: str) -> dict[str, tuple[str, str]]:
-    changelogs = {}
+def parse_markdown_changelog(text: str) -> list[dict[str, str | None]]:
+    """Parse a changelog into an ordered list of entries, newest first."""
+    entries = []
     chunks = re.split(r"^# (.*?)\n", text, flags=re.MULTILINE)[1:]
 
     for version, raw_text in zip(chunks[::2], chunks[1::2]):
@@ -29,9 +30,31 @@ def parse_markdown_changelog(text: str) -> dict[str, tuple[str, str]]:
                 "First line of every changelog must be less than 255 characters"
             )
 
-        changelogs[version] = (first_line, rest.strip() or None)
+        entries.append(
+            {
+                "version": version,
+                "summary": first_line,
+                "notes": rest.strip() or None,
+            }
+        )
 
-    return changelogs
+    return entries
+
+
+def get_firmware_version(metadata: dict) -> str | None:
+    """Extract the firmware version from its metadata, if it is versioned at all."""
+    version_keys = {k for k in metadata if k.endswith("_version")} - {
+        "sdk_version",
+        "metadata_version",
+    }
+
+    # Some firmwares, such as the Zigbee router, carry no version of their own
+    if not version_keys:
+        return None
+
+    (version_key,) = version_keys
+
+    return metadata[version_key]
 
 
 def main():
@@ -54,10 +77,11 @@ def main():
         "metadata": {
             "created_at": datetime.now(UTC).isoformat(),
         },
+        "changelogs": {},
         "firmwares": [],
     }
 
-    for firmware_file in args.firmware_dir.glob("*.gbl"):
+    for firmware_file in sorted(args.firmware_dir.glob("*.gbl")):
         data = firmware_file.read_bytes()
 
         try:
@@ -76,6 +100,7 @@ def main():
         manifest["firmwares"].append(
             {
                 "filename": firmware_file.name,
+                "version": get_firmware_version(metadata) if metadata else None,
                 "checksum": f"sha3-256:{hashlib.sha3_256(data).hexdigest()}",
                 "size": len(data),
                 "metadata": metadata,
@@ -85,6 +110,7 @@ def main():
         )
 
     missing_changelogs = False
+    changelogs: dict[str, list[dict[str, str | None]]] = {}
 
     for fw in manifest["firmwares"]:
         if fw["metadata"] is None:
@@ -93,33 +119,36 @@ def main():
         fw_type = fw["metadata"]["fw_type"]
         changelog_md = args.source_dir / fw_type / "CHANGELOG.md"
 
-        if not changelog_md.exists():
+        if fw_type not in changelogs:
+            if changelog_md.exists():
+                changelogs[fw_type] = parse_markdown_changelog(changelog_md.read_text())
+            else:
+                changelogs[fw_type] = []
+
+        if not changelogs[fw_type]:
             continue
 
-        changelogs = parse_markdown_changelog(changelog_md.read_text())
+        entry = next(
+            (e for e in changelogs[fw_type] if e["version"] == fw["version"]), None
+        )
 
-        version_keys = {k for k in fw["metadata"] if k.endswith("_version")} - {
-            "sdk_version",
-            "metadata_version",
-        }
-        assert len(version_keys) == 1
-        version_key = next(iter(version_keys))
-
-        version = fw["metadata"][version_key]
-
-        if version not in changelogs:
+        if entry is None:
             _LOGGER.error(
                 "Firmware %s version %s has no changelog entry in %s",
                 fw["filename"],
-                version,
+                fw["version"],
                 changelog_md,
             )
             missing_changelogs = True
             continue
 
-        release_notes, release_summary = changelogs[version]
-        fw["release_notes"] = release_notes
-        fw["release_summary"] = release_summary
+        # These two fields are kept for backwards compatibility with older clients that
+        # predate `changelogs`. Their names are inverted: `release_notes` holds the
+        # one-line summary and `release_summary` holds the detailed body.
+        fw["release_notes"] = entry["summary"]
+        fw["release_summary"] = entry["notes"]
+
+    manifest["changelogs"] = {t: e for t, e in changelogs.items() if e}
 
     if missing_changelogs:
         sys.exit(1)


### PR DESCRIPTION
Required for https://github.com/home-assistant-libs/ha-silabs-firmware-client/pull/4.

This will allow HA Core to show more detailed changelog entries for firmware update entities.