### PR TITLE
Replace `commander` with pygbl and clean up `build_project.py`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -241,7 +241,7 @@ jobs:
       - name: Build firmware
         id: build-firmware
         run: |
-          /opt/venv/bin/python3 tools/build_project.py \
+          /opt/venv/bin/python3 -m tools.build_project \
             --manifest "${MATRIX_MANIFEST}" \
             --build-dir build \
             --output-dir outputs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,15 @@ RUN set -eux \
         > /etc/apt/apt.conf.d/80snapshot \
     && apt-get update
 
-# Simplicity Commander, slc-cli, ZAP, a JRE and a Python interpreter are published on
-# Silicon Labs' update site as native builds for both architectures. Fetching them directly
-# avoids `slt`, which is x86_64-only and would otherwise have to be emulated on ARM64.
+# slc-cli, ZAP, a JRE and a Python interpreter are published on Silicon Labs' update
+# site as native builds for both architectures. Fetching them directly avoids `slt`,
+# which is x86_64-only and would otherwise have to be emulated on ARM64.
 FROM trixie-stable AS silabs-tools
 ARG TARGETARCH
 RUN set -eux \
     && apt-get install -y --no-install-recommends \
         aria2 ca-certificates libarchive-tools \
-    && mkdir -p /opt/silabs/commander /opt/silabs/slc-cli /opt/silabs/zap \
-                /opt/silabs/java21 /opt/silabs/python \
+    && mkdir -p /opt/silabs/slc-cli /opt/silabs/zap /opt/silabs/java21 /opt/silabs/python \
     && if [ "$TARGETARCH" = "arm64" ]; then \
         aria2c -q -o python.zip --checksum=sha-256=0bd0334fead1e3c2647b6c09b9801b214ab3b999e9e6a9d13553ff57c1e04bb2 \
             https://updates.silabs.com/studio/v6/updates/update_site/archives/python/3.10.3/python.3.10.gtk.linux.aarch64.zip \
@@ -36,9 +35,7 @@ RUN set -eux \
         && aria2c -q -o zap.zip --checksum=sha-256=15c5263ea98a1162e655ad5fb154a4f0e62047b6382a889f9e986f570c30c45b \
             https://updates.silabs.com/studio/v6/updates/update_site/archives/zap/2026.06.17/zap-linux-arm64.zip \
         && aria2c -q -o jre.zip --checksum=sha-256=61b4be111fe14d7a9138de920047489c679c7a697320cf69d28b23046edbaf73 \
-            https://updates.silabs.com/studio/v6/updates/update_site/archives/java21/21.0.6/linux.aarch64_21.0.6.zip \
-        && aria2c -q -o commander.tar.bz --checksum=sha-256=99fd45e5064b00ace957b4d12c00bb3c3b33845b4e65793fde99d4960004e091 \
-            https://updates.silabs.com/studio/v6/updates/update_site/archives/commander/1.24.1/Commander_linux_aarch64_1v24p1b1980.tar.bz; \
+            https://updates.silabs.com/studio/v6/updates/update_site/archives/java21/21.0.6/linux.aarch64_21.0.6.zip; \
        else \
         aria2c -q -o python.zip --checksum=sha-256=26f56b1cfa05b2b3b7dafb2c2a5e3c19498389c34dfe68be800f71f476c86363 \
             https://updates.silabs.com/studio/v6/updates/update_site/archives/python/3.10.3/python.3.10.3.gtk.linux.x86_64.zip \
@@ -47,9 +44,7 @@ RUN set -eux \
         && aria2c -q -o zap.zip --checksum=sha-256=45537226973fb892894f7110288dd4a7db627728af8cd9fc7c27b658530e2b88 \
             https://updates.silabs.com/studio/v6/updates/update_site/archives/zap/2026.06.17/zap-linux-x64.zip \
         && aria2c -q -o jre.zip --checksum=sha-256=5382fa98bcc66fc3aef48792a3e84328eca16afa9bf97517527e92812516ee50 \
-            https://updates.silabs.com/studio/v6/updates/update_site/archives/java21/21.0.6/linux.x86_64_21.0.6.zip \
-        && aria2c -q -o commander.tar.bz --checksum=sha-256=3ba24eeaeb560e9db306a4d070e2bbe40b456701b4b87c53643a93ab1101b2c4 \
-            https://updates.silabs.com/studio/v6/updates/update_site/archives/commander/1.24.1/Commander_linux_x86_64_1v24p1b1980.tar.bz; \
+            https://updates.silabs.com/studio/v6/updates/update_site/archives/java21/21.0.6/linux.x86_64_21.0.6.zip; \
        fi \
     # slc runs the SDK's template generators with this Python, which it finds as an adapter
     # pack rather than on PATH
@@ -57,8 +52,7 @@ RUN set -eux \
     && bsdtar -xf slc.zip --strip-components=1 -C /opt/silabs/slc-cli \
     && bsdtar -xf zap.zip -C /opt/silabs/zap \
     && bsdtar -xf jre.zip --strip-components=1 -C /opt/silabs/java21 \
-    && bsdtar -xf commander.tar.bz --strip-components=1 -C /opt/silabs/commander \
-    && rm python.zip slc.zip zap.zip jre.zip commander.tar.bz
+    && rm python.zip slc.zip zap.zip jre.zip
 
 # The SDK is a conan package, but conan is not needed to fetch one: the recipe revision,
 # package id and package revision are all discoverable over its REST API. Those revisions
@@ -187,7 +181,6 @@ COPY --from=zstd-gcc-builder /opt/zstd-gcc /tmp/zstd-gcc
 RUN set -eux \
     && mkdir -p /opt/silabs/bin \
     && ln -s /opt/silabs/java21/jre/bin/java /opt/silabs/bin/java \
-    && ln -s /opt/silabs/commander/commander /opt/silabs/bin/commander \
     && ln -s /opt/silabs/zap/zap /opt/silabs/bin/zap \
     # slc uses $(dirname "$0") to find slc.jar, so it needs a wrapper rather than a symlink
     && printf '#!/bin/sh\nexec /opt/silabs/slc-cli/slc "$@"\n' > /opt/silabs/bin/slc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -197,4 +197,4 @@ ENV PATH="$PATH:/opt/silabs/bin"
 
 WORKDIR /repo
 
-ENTRYPOINT ["/opt/venv/bin/python3", "tools/build_project.py"]
+ENTRYPOINT ["/opt/venv/bin/python3", "-m", "tools.build_project"]

--- a/extension/board_activity_extension/board_activity_led.slcc
+++ b/extension/board_activity_extension/board_activity_led.slcc
@@ -18,3 +18,5 @@ requires:
 toolchain_settings:
   - option: gcc_linker_option
     value: "-Wl,--wrap=halStackIndicateActivity"
+  - option: llvm_linker_option
+    value: "-Wl,--wrap=halStackIndicateActivity"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.14"
 dependencies = [
     "ruamel.yaml",
     "pyelftools",
-    "pygbl[all]>=1.0.1",
+    "pygbl[all]>=1.1.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 requires-python = ">=3.14"
 dependencies = [
     "ruamel.yaml",
-    "universal-silabs-flasher>=0.0.25",
     "pyelftools",
+    "pygbl[all]>=1.0.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.14"
 dependencies = [
     "ruamel.yaml",
     "pyelftools",
-    "pygbl[all]>=1.0.0",
+    "pygbl[all]>=1.0.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.14"
 dependencies = [
     "ruamel.yaml",
     "pyelftools",
-    "pygbl[all]>=1.1.0",
+    "pygbl[all]>=1.2.0",
 ]
 
 [tool.uv]

--- a/src/zigbee_ncp/extension/xncp_common_extension/xncp_common_commands.slcc
+++ b/src/zigbee_ncp/extension/xncp_common_extension/xncp_common_commands.slcc
@@ -22,6 +22,8 @@ requires:
 toolchain_settings:
   - option: gcc_linker_option
     value: "-Wl,--wrap=sli_zigbee_am_multicast_member"
+  - option: llvm_linker_option
+    value: "-Wl,--wrap=sli_zigbee_am_multicast_member"
 template_contribution:
   - name: xncp_command_table
     value:

--- a/src/zigbee_router/extension/router_beacon_filter_extension/router_beacon_filter.slcc
+++ b/src/zigbee_router/extension/router_beacon_filter_extension/router_beacon_filter.slcc
@@ -14,3 +14,10 @@ requires:
 toolchain_settings:
   - option: gcc_linker_option
     value: "-Wl,--wrap=sli_zigbee_stack_get_stored_beacon"
+  - option: llvm_linker_option
+    value: "-Wl,--wrap=sli_zigbee_stack_get_stored_beacon"
+
+metadata:
+  nabucasa:
+    wrap_definitions:
+      sli_zigbee_stack_get_stored_beacon: "libzigbee-pro-stack.a:beacon-handling.c.obj"

--- a/src/zigbee_router/extension/router_eui64_unique_extension/router_eui64_unique.slcc
+++ b/src/zigbee_router/extension/router_eui64_unique_extension/router_eui64_unique.slcc
@@ -13,3 +13,10 @@ requires:
 toolchain_settings:
   - option: gcc_linker_option
     value: "-Wl,--wrap=sl_token_manager_get_data"
+  - option: llvm_linker_option
+    value: "-Wl,--wrap=sl_token_manager_get_data"
+
+metadata:
+  nabucasa:
+    wrap_definitions:
+      sl_token_manager_get_data: "sl_token_manager_api.c"

--- a/src/zwa2_controller/extension/nabucasa_zwa2_extension/zwave_dmadrv_compat.slcc
+++ b/src/zwa2_controller/extension/nabucasa_zwa2_extension/zwave_dmadrv_compat.slcc
@@ -33,3 +33,7 @@ toolchain_settings:
     value: "-Wl,--wrap=LDMA_IRQHandler"
   - option: gcc_linker_option
     value: "-Wl,--wrap=zpal_uart_utils_tx_transfer_start"
+  - option: llvm_linker_option
+    value: "-Wl,--wrap=LDMA_IRQHandler"
+  - option: llvm_linker_option
+    value: "-Wl,--wrap=zpal_uart_utils_tx_transfer_start"

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import ast
 import contextlib
+import dataclasses
+import enum
 import hashlib
 import json
 import logging
@@ -29,7 +31,12 @@ LOGGER = logging.getLogger(__name__)
 yaml = YAML(typ="safe")
 
 
-def evaulate_f_string(f_string: str, variables: dict[str, typing.Any]) -> str:
+class Toolchain(enum.StrEnum):
+    LLVM = "llvm"
+    GCC = "gcc"
+
+
+def evaluate_f_string(f_string: str, variables: dict[str, typing.Any]) -> str:
     """Evaluates an `f`-string with the given locals."""
 
     return eval("f" + repr(f_string), variables)
@@ -154,7 +161,8 @@ def load_toolchains(paths: list[pathlib.Path]) -> dict[pathlib.Path, str]:
                 if "define _LIBCPP_VERSION " in line:
                     version = int(line.split()[-1])
                     toolchains[toolchain] = (
-                        f"llvm:{version // 10000}.{version // 100 % 100}.{version % 100}"
+                        f"{Toolchain.LLVM}:"
+                        f"{version // 10000}.{version // 100 % 100}.{version % 100}"
                     )
                     break
             continue
@@ -172,7 +180,7 @@ def load_toolchains(paths: list[pathlib.Path]) -> dict[pathlib.Path, str]:
                 version_info[name] = value
 
         toolchains[toolchain] = (
-            f"gcc:{version_info['basever']}.{version_info['datestamp']}"
+            f"{Toolchain.GCC}:{version_info['basever']}.{version_info['datestamp']}"
         )
 
     return toolchains
@@ -283,7 +291,41 @@ def remap_debug_build_paths(elf_path: pathlib.Path, prefix_map: dict[str, str]) 
             f.write(data)
 
 
-def main():
+@dataclasses.dataclass(frozen=True)
+class ResolvedBuild:
+    """Everything about a build that is resolved up front and never changes."""
+
+    manifest: dict[str, typing.Any]
+    manifest_path: pathlib.Path
+    build_dir: pathlib.Path
+    projects_root: pathlib.Path
+    base_project_path: pathlib.Path
+    base_project_name: str
+    sdk: pathlib.Path
+    sdk_name: str
+    sdk_version: str
+    toolchain: Toolchain
+    toolchain_path: pathlib.Path
+    build_timestamp: datetime
+
+    @property
+    def manifest_dir(self) -> pathlib.Path:
+        return self.manifest_path.parent
+
+    @property
+    def build_template_path(self) -> pathlib.Path:
+        return self.build_dir / "template"
+
+    @property
+    def base_project_slcp(self) -> pathlib.Path:
+        return self.build_template_path / f"{self.base_project_name}.slcp"
+
+    @property
+    def cmake_dir(self) -> pathlib.Path:
+        return self.build_dir / f"cmake_{self.toolchain}"
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
@@ -378,36 +420,16 @@ def main():
         help="Build timestamp for reproducible builds (YYYYMMDDHHmmss format)",
     )
 
-    args = parser.parse_args()
+    return parser
 
-    if args.build_timestamp is not None:
-        args.build_timestamp = datetime.strptime(
-            args.build_timestamp, "%Y%m%d%H%M%S"
-        ).replace(tzinfo=UTC)
-    else:
-        args.build_timestamp = datetime.now(UTC)
 
-    if args.slc_daemon:
-        SLC = ["slc", "--daemon", "--daemon-timeout", "1"]
-    else:
-        SLC = ["slc"]
-
-    if args.build_dir is None:
-        args.build_dir = pathlib.Path(f"build/{time.time():.0f}_{args.manifest.stem}")
-
-    # argparse defaults should be replaced, not extended
-    if args.sdks != get_sdk_default_paths():
-        args.sdks = args.sdks[len(get_sdk_default_paths()) :]
-
-    if args.toolchains != get_toolchain_default_paths():
-        args.toolchains = args.toolchains[len(get_toolchain_default_paths()) :]
-
+def resolve_build(args: argparse.Namespace) -> ResolvedBuild:
+    """Load the manifest and pin down the SDK, toolchain, and build paths."""
     manifest = yaml.load(args.manifest.read_text())
 
     for key, override in args.overrides:
         manifest[key] = override
 
-    # Ensure we can load the correct SDK and toolchain
     sdks = load_sdks(args.sdks)
     sdk, sdk_and_version = next(
         (path, version) for path, version in sdks.items() if version == manifest["sdk"]
@@ -415,29 +437,41 @@ def main():
     sdk_name, sdk_version = sdk_and_version.split(":", 1)
 
     toolchains = load_toolchains(args.toolchains)
-    toolchain = next(
+    toolchain_path = next(
         path
         for path, name in toolchains.items()
         if manifest["toolchain"] in (name, name.split(":", 1)[1])
     )
-    is_llvm = toolchains[toolchain].startswith("llvm:")
+    toolchain = Toolchain(toolchains[toolchain_path].split(":", 1)[0])
 
-    # First, copy the base project into the build dir, under `template/`
     projects_root = pathlib.Path(__file__).parent.parent
     base_project_path = projects_root / manifest["base_project"]
     assert base_project_path.is_relative_to(projects_root)
 
-    build_template_path = args.build_dir / "template"
+    # The template copy preserves `.slcp` files, so the source project names the build
+    (base_project_slcp,) = base_project_path.glob("*.slcp")
 
-    LOGGER.info("Building in %s", args.build_dir.resolve())
+    return ResolvedBuild(
+        manifest=manifest,
+        manifest_path=args.manifest,
+        build_dir=args.build_dir,
+        projects_root=projects_root,
+        base_project_path=base_project_path,
+        base_project_name=base_project_slcp.stem,
+        sdk=sdk,
+        sdk_name=sdk_name,
+        sdk_version=sdk_version,
+        toolchain=toolchain,
+        toolchain_path=toolchain_path,
+        build_timestamp=args.build_timestamp,
+    )
 
-    if args.clean_build_dir:
-        with contextlib.suppress(OSError):
-            shutil.rmtree(args.build_dir)
 
+def copy_base_project(build: ResolvedBuild) -> None:
+    """Copy the base project into the build dir, then overlay SDK sources onto it."""
     shutil.copytree(
-        base_project_path,
-        build_template_path,
+        build.base_project_path,
+        build.build_template_path,
         dirs_exist_ok=True,
         ignore=lambda dir, contents: [
             "autogen",
@@ -453,9 +487,9 @@ def main():
 
     # Copy SDK files into the build template (e.g. unmodified sample app sources).
     # Files already present in the project (customized) are not overwritten.
-    for sdk_file in manifest.get("copy_sdk_files", []):
-        src = sdk / sdk_file["source"]
-        dst = build_template_path / sdk_file["path"]
+    for sdk_file in build.manifest.get("copy_sdk_files", []):
+        src = build.sdk / sdk_file["source"]
+        dst = build.build_template_path / sdk_file["path"]
 
         if dst.exists():
             LOGGER.info("Skipping SDK file (already in project): %s", sdk_file["path"])
@@ -465,29 +499,22 @@ def main():
         shutil.copy(src, dst)
         LOGGER.info("Copied SDK file: %s -> %s", sdk_file["source"], sdk_file["path"])
 
-    # We extend the base project with the manifest, since added components could have
-    # extra dependencies
-    (base_project_slcp,) = build_template_path.glob("*.slcp")
-    base_project_name = base_project_slcp.stem
-    base_project = yaml.load(base_project_slcp.read_text())
 
-    # Add new components
+def merge_manifest_into_slcp(
+    base_project: dict[str, typing.Any], manifest: dict[str, typing.Any]
+) -> dict[str, typing.Any]:
+    """Extend the base project with the manifest's additions and removals."""
     base_project["component"].extend(manifest.get("add_components", []))
     base_project.setdefault("toolchain_settings", []).extend(
         manifest.get("toolchain_settings", [])
     )
-
-    # Add SDK extensions
     base_project.setdefault("sdk_extension", []).extend(
         manifest.get("sdk_extension", [])
     )
-
-    # Add template contributions
     base_project.setdefault("template_contribution", []).extend(
         manifest.get("template_contribution", [])
     )
 
-    # Remove components
     for component in manifest.get("remove_components", []):
         try:
             base_project["component"].remove(component)
@@ -497,19 +524,8 @@ def main():
             )
             sys.exit(1)
 
-    # Add new sources
     base_project.setdefault("source", []).extend(manifest.get("add_sources", []))
     base_project.setdefault("include", []).extend(manifest.get("add_includes", []))
-
-    # Add config files (e.g., ZAP files)
-    manifest_dir = args.manifest.parent
-    for config_file in manifest.get("config_file", []):
-        src_path = manifest_dir / config_file["path"]
-        dst_path = build_template_path / config_file["path"]
-        dst_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(src_path, dst_path)
-        LOGGER.info("Copied config file: %s", config_file["path"])
-
     base_project.setdefault("config_file", []).extend(manifest.get("config_file", []))
 
     # Extend configuration and C defines
@@ -536,32 +552,54 @@ def main():
                 # Otherwise, append it
                 output_config.append({"name": name, "value": value})
 
-    # Finally, write out the modified base project
-    with base_project_slcp.open("w") as f:
+    return base_project
+
+
+def prepare_project_slcp(build: ResolvedBuild) -> dict[str, typing.Any]:
+    """Merge the manifest into the copied project and write it back out."""
+    # Config files (e.g. ZAP files) live next to the manifest, not in the base project
+    for config_file in build.manifest.get("config_file", []):
+        src_path = build.manifest_dir / config_file["path"]
+        dst_path = build.build_template_path / config_file["path"]
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src_path, dst_path)
+        LOGGER.info("Copied config file: %s", config_file["path"])
+
+    base_project = merge_manifest_into_slcp(
+        yaml.load(build.base_project_slcp.read_text()), build.manifest
+    )
+
+    with build.base_project_slcp.open("w") as f:
         yaml.dump(base_project, f)
 
-    # Next, generate a chip-specific project from the modified base project
-    LOGGER.info(f"Generating project for {manifest['device']}")
+    return base_project
+
+
+def run_slc_generate(
+    build: ResolvedBuild, slc: list[str], tool_paths: list[pathlib.Path]
+) -> None:
+    """Generate a chip-specific project from the modified base project."""
+    LOGGER.info(f"Generating project for {build.manifest['device']}")
 
     # fmt: off
     subprocess_run_verbose(
-        SLC
+        slc
         + [
             "generate",
             "--verbose", "DEBUG",
             "--trust-totality",
-            "--with", manifest["device"],
-            "--project-file", base_project_slcp.resolve(),
-            "--export-destination", args.build_dir.resolve(),
+            "--with", build.manifest["device"],
+            "--project-file", build.base_project_slcp.resolve(),
+            "--export-destination", build.build_dir.resolve(),
             "--copy-proj-sources",
             "--copy-sdk-sources",
             "--new-project",
-            "--toolchain", "toolchain_llvm" if is_llvm else "toolchain_gcc",
-            "--sdk", sdk,
+            "--toolchain", f"toolchain_{build.toolchain}",
+            "--sdk", build.sdk,
             "--output-type", "vscode",
         ]
-        + [f"--tool-path={p}" for p in args.tool_paths]
-        + [f"--toolchain-locations={'llvm' if is_llvm else 'gcc'}:{toolchain}"],
+        + [f"--tool-path={p}" for p in tool_paths]
+        + [f"--toolchain-locations={build.toolchain}:{build.toolchain_path}"],
         "slc generate",
         env={
             **os.environ,
@@ -569,30 +607,37 @@ def main():
     )
     # fmt: on
 
-    # Apply SDK patches if specified. These should be a last resort, we prefer to use
-    # SDK extensions wherever possible!
-    if manifest.get("sdk_patches"):
-        copied_sdk_dir = next(args.build_dir.glob(f"{sdk_name}_*"))
 
-        for patch_path in manifest["sdk_patches"]:
-            patch_file = base_project_path / "sdk_patches" / patch_path
-            LOGGER.info("Applying SDK patch: %s", patch_file.name)
-            subprocess.run(
-                [
-                    "git",
-                    "apply",
-                    f"--directory={copied_sdk_dir.resolve().relative_to(projects_root.resolve())}",
-                    str(patch_file.resolve()),
-                ],
-                check=True,
-                cwd=projects_root,
-            )
+def apply_sdk_patches(build: ResolvedBuild) -> None:
+    """Patch the copied SDK. A last resort, prefer SDK extensions wherever possible!"""
+    if not build.manifest.get("sdk_patches"):
+        return
 
-    # Make sure all extensions are valid (check both SDK and project extensions)
+    copied_sdk_dir = next(build.build_dir.glob(f"{build.sdk_name}_*"))
+
+    for patch_path in build.manifest["sdk_patches"]:
+        patch_file = build.base_project_path / "sdk_patches" / patch_path
+        LOGGER.info("Applying SDK patch: %s", patch_file.name)
+        subprocess.run(
+            [
+                "git",
+                "apply",
+                f"--directory={copied_sdk_dir.resolve().relative_to(build.projects_root.resolve())}",
+                str(patch_file.resolve()),
+            ],
+            check=True,
+            cwd=build.projects_root,
+        )
+
+
+def validate_sdk_extensions(
+    build: ResolvedBuild, base_project: dict[str, typing.Any]
+) -> None:
+    """Make sure all referenced extensions exist in the SDK or the project."""
     for sdk_extension in base_project.get("sdk_extension", []):
-        sdk_ext_dir = sdk / f"extension/{sdk_extension['id']}_extension"
+        sdk_ext_dir = build.sdk / f"extension/{sdk_extension['id']}_extension"
         project_ext_dir = (
-            build_template_path / f"extension/{sdk_extension['id']}_extension"
+            build.build_template_path / f"extension/{sdk_extension['id']}_extension"
         )
 
         if not sdk_ext_dir.is_dir() and not project_ext_dir.is_dir():
@@ -603,67 +648,60 @@ def main():
             )
             sys.exit(1)
 
-    # Template variables for C defines
-    value_template_env = {
-        "git_repo_hash": get_git_commit_id(repo=pathlib.Path(__file__).parent.parent),
-        "manifest_name": args.manifest.stem,
-        "now": args.build_timestamp,
-    }
 
-    # Actually search for C defines within config
-    unused_defines = set(manifest.get("c_defines", {}).keys())
-
-    # First, populate build flags
-    build_flags = {
-        "C_FLAGS": [],
-        "CXX_FLAGS": [],
-        "LD_FLAGS": [],
-    }
+def normalize_c_defines(manifest: dict[str, typing.Any]) -> dict[str, dict]:
+    """Expand the shorthand form of `c_defines` entries into full dicts."""
+    normalized = {}
 
     for define, config in manifest.get("c_defines", {}).items():
         if not isinstance(config, dict):
-            config = manifest["c_defines"][define] = {
-                "type": "config",
-                "value": config,
-                "error_on_duplicate": True,
-            }
-        elif isinstance(config, dict) and "error_on_duplicate" not in config:
-            config["error_on_duplicate"] = True
+            config = {"type": "config", "value": config}
 
-        if config["type"] == "config":
-            continue
-        elif config["type"] != "c_flag":
+        config = {"error_on_duplicate": True, **config}
+
+        if config["type"] not in ("config", "c_flag"):
             raise ValueError(f"Invalid config type: {config['type']}")
 
-        build_flags["C_FLAGS"].append(f"-D{define}={config['value']}")
-        build_flags["CXX_FLAGS"].append(f"-D{define}={config['value']}")
-        unused_defines.remove(define)
+        normalized[define] = config
 
-    for config_root in [args.build_dir / "autogen", args.build_dir / "config"]:
+    return normalized
+
+
+def patch_config_headers(
+    config_roots: list[pathlib.Path],
+    c_defines: dict[str, dict],
+    base_project: dict[str, typing.Any],
+    template_env: dict[str, typing.Any],
+) -> set[str]:
+    """Rewrite `#define`s in the generated config headers, returning the ones applied."""
+    written = set()
+
+    for config_root in config_roots:
         for config_f in config_root.glob("*.h"):
             config_h_lines = config_f.read_text().split("\n")
             written_config = {}
             new_config_h_lines = []
 
             for index, line in enumerate(config_h_lines):
-                for define, config in manifest.get("c_defines", {}).items():
+                # The two lists stay in lockstep, so `index` is valid in both
+                assert len(new_config_h_lines) == index
+
+                for define, config in c_defines.items():
                     if config["type"] == "c_flag":
                         continue
-
-                    value_template = config["value"]
 
                     if f"#define {define} " not in line:
                         continue
 
-                    if define not in unused_defines:
-                        if manifest["c_defines"][define]["error_on_duplicate"]:
+                    if define in written:
+                        if config["error_on_duplicate"]:
                             LOGGER.error("Define %r used twice!", define)
                             sys.exit(1)
-                        else:
-                            LOGGER.warning(
-                                "Define %r used twice but this is allowed", define
-                            )
-                            continue
+
+                        LOGGER.warning(
+                            "Define %r used twice but this is allowed", define
+                        )
+                        continue
 
                     define_with_whitespace = line.split(f"#define {define}", 1)[1]
                     alignment = define_with_whitespace[
@@ -686,19 +724,18 @@ def main():
                         assert re.match(r'#warning ".*? not configured"', prev_line)
                         new_config_h_lines[index - 1] = f"//{prev_line}"
 
-                    value_template = str(value_template)
+                    value_template = str(config["value"])
 
                     if value_template.startswith("template:"):
                         value = value_template.replace("template:", "", 1).format(
-                            **value_template_env
+                            **template_env
                         )
                     else:
                         value = value_template
 
                     new_config_h_lines.append(f"#define {define}{alignment}{value}")
                     written_config[define] = value
-
-                    unused_defines.remove(define)
+                    written.add(define)
                     break
                 else:
                     new_config_h_lines.append(line)
@@ -707,15 +744,13 @@ def main():
                 LOGGER.info("Patching %s with %s", config_f, written_config)
                 config_f.write_text("\n".join(new_config_h_lines))
 
-    if unused_defines:
-        LOGGER.error("Defines were unused, aborting: %s", unused_defines)
-        sys.exit(1)
+    return written
 
-    # Fix Gecko SDK bugs
-    sl_rail_util_pti_config_h = args.build_dir / "config/sl_rail_util_pti_config.h"
 
-    # PTI seemingly cannot be excluded, even if it is disabled.
-    # This causes builds to fail when `-Werror` is enabled.
+def fix_pti_config_warning(build: ResolvedBuild) -> None:
+    """PTI seemingly cannot be excluded, even if it is disabled, breaking `-Werror`."""
+    sl_rail_util_pti_config_h = build.build_dir / "config/sl_rail_util_pti_config.h"
+
     if sl_rail_util_pti_config_h.exists():
         sl_rail_util_pti_config_h.write_text(
             sl_rail_util_pti_config_h.read_text().replace(
@@ -724,64 +759,93 @@ def main():
             )
         )
 
-    cmake_dir = args.build_dir / ("cmake_llvm" if is_llvm else "cmake_gcc")
 
-    remapped_paths = {
-        args.build_dir.absolute(): "/src",
-        f"{cmake_dir.absolute()}/..": "/src",
+def sdk_path_remaps(build: ResolvedBuild) -> dict[str, str]:
+    """Absolute paths baked into the SDK and its prebuilt libraries, and their remaps."""
+    sdk_src = f"/src/{build.sdk_name}_{build.sdk_version}"
+
+    return {
+        str(build.build_dir.absolute()): "/src",
+        f"{build.cmake_dir.absolute()}/..": "/src",
         # The toolchain's own resource/runtime headers (e.g. clang's builtin and newlib
         # include dirs) are recorded in debug info under a machine-specific conan path
-        str(toolchain): "/src/vendor/toolchain",
-        "/home/buildengineer/jenkins/workspace/Gecko_Workspace/gsdk": f"/src/{sdk_name}_{sdk_version}",
+        str(build.toolchain_path): "/src/vendor/toolchain",
+        "/home/buildengineer/jenkins/workspace/Gecko_Workspace/gsdk": sdk_src,
         # Zigbee sources reference the GitHub Actions workspace they were packaged in
-        "/__w/zigbee/zigbee": f"/src/{sdk_name}_{sdk_version}/zigbee",
+        "/__w/zigbee/zigbee": f"{sdk_src}/zigbee",
         "/home/buildengineer/.silabs/slt/installs/conan/p/cmsisfb920dbb6ad42/p": "/src/vendor/cmsis",
-        "/home/buildengineer/.silabs/slt/installs/conan/p/platf85e95225bc406/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
-        "/home/buildengineer/.silabs/slt/installs/conan/p/platfe548addd6aec0/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        "/home/buildengineer/.silabs/slt/installs/conan/p/platf85e95225bc406/p": f"{sdk_src}/platform_core",
+        "/home/buildengineer/.silabs/slt/installs/conan/p/platfe548addd6aec0/p": f"{sdk_src}/platform_core",
         # The Z-Wave libraries were packaged against their own conan hashes
         "/home/buildengineer/.silabs/slt/installs/conan/p/cmsis4dea3e6cbb6ce/p": "/src/vendor/cmsis",
-        "/home/buildengineer/.silabs/slt/installs/conan/p/platf6edd0cd4d4914/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        "/home/buildengineer/.silabs/slt/installs/conan/p/platf6edd0cd4d4914/p": f"{sdk_src}/platform_core",
         # Z-Wave's platform_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1
-        "/home/buildengineer/.silabs/slt/installs/conan/p/platf0f636d352884d/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        "/home/buildengineer/.silabs/slt/installs/conan/p/platf0f636d352884d/p": f"{sdk_src}/platform_core",
         # The zigbee stack libraries reference the silabs_core package they were built against
-        "/github/home/.silabs/slt/installs/conan/p/commo8335073ce327e/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        "/github/home/.silabs/slt/installs/conan/p/commo8335073ce327e/p": f"{sdk_src}/platform_core",
         # silabs_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1
-        "/github/home/.silabs/slt/installs/conan/p/commo6146391826d06/p": f"/src/{sdk_name}_{sdk_version}/platform_core",
+        "/github/home/.silabs/slt/installs/conan/p/commo6146391826d06/p": f"{sdk_src}/platform_core",
         # The Z-Wave SDK isn't part of the Simplicity SDK but is still referenced. If we
         # ever decide to compile it as part of CI, we can change this remap.
         "/opt/github/runner/_work/z-wave/z-wave": "/src/vendor/zwave",
     }
-    build_flags["C_FLAGS"] += [
-        f"-ffile-prefix-map={src}={dst}" for src, dst in remapped_paths.items()
-    ]
 
-    # Ensure deterministic linking order
-    build_flags["LD_FLAGS"] += ["-Wl,--sort-section=name"]
 
-    # Enable errors
-    build_flags["C_FLAGS"] += ["-Wall", "-Wextra", "-Werror"]
+def warning_flags(toolchain: Toolchain) -> list[str]:
+    """Warnings that are errors, minus the ones the SDK cannot currently satisfy."""
+    flags = ["-Wall", "-Wextra", "-Werror"]
 
-    if is_llvm:
-        build_flags["C_FLAGS"] += [
-            "-Wno-unknown-warning-option",  # ignore GCC-only warning names
-            "-Wno-error=format-security",  # SDK `diagnostic.c` uses a non-literal format string
-            "-Wno-error=unknown-pragmas",  # our `ws2812.c` uses `#pragma GCC optimize`
-            "-Wno-error=unused-function",  # unused statics in SDK/OpenThread sources
-            "-Wno-error=c23-extensions",  # our `cmds_proprietary.c` has a label before a declaration
-            "-Wno-error=unterminated-string-initialization",  # char arrays in zigbee router sources
-        ]
-    else:
-        build_flags["C_FLAGS"] += [
+    if toolchain is Toolchain.LLVM:
+        return (
+            flags
+            + [
+                "-Wno-unknown-warning-option",  # ignore GCC-only warning names
+                "-Wno-error=format-security",  # SDK `diagnostic.c` uses a non-literal format string
+                "-Wno-error=unknown-pragmas",  # our `ws2812.c` uses `#pragma GCC optimize`
+                "-Wno-error=unused-function",  # unused statics in SDK/OpenThread sources
+                "-Wno-error=c23-extensions",  # our `cmds_proprietary.c` has a label before a declaration
+                "-Wno-error=unterminated-string-initialization",  # char arrays in zigbee router sources
+            ]
+        )
+
+    return (
+        flags
+        + [
             "-Wno-error=maybe-uninitialized",  # Linking fails due to a few SDK bugs
             "-Wno-error=uninitialized",  # False positive in zigbee `core-cli.c` under LTO
             "-Wno-error=unused-function",  # mbedTLS `ssl_tls.c` with X.509 hostname verification disabled
         ]
+    )
 
-    build_flags["CXX_FLAGS"] = build_flags["C_FLAGS"]
 
+def assemble_build_flags(
+    build: ResolvedBuild, c_flag_defines: list[str]
+) -> dict[str, list[str]]:
+    c_flags = (
+        c_flag_defines
+        + [
+            f"-ffile-prefix-map={src}={dst}"
+            for src, dst in sdk_path_remaps(build).items()
+        ]
+        + warning_flags(build.toolchain)
+    )
+
+    return {
+        "C_FLAGS": c_flags,
+        "CXX_FLAGS": c_flags,
+        # Ensure deterministic linking order
+        "LD_FLAGS": ["-Wl,--sort-section=name"],
+    }
+
+
+def cmake_configure_and_build(
+    build: ResolvedBuild, build_flags: dict[str, list[str]]
+) -> None:
     # The GBL is built in-process after the link, so neutralize the SDK's post-build
     # hook. CMake expects a semicolon-separated list for the command.
     cmake_post_build_command = ";".join([shutil.which("cmake"), "-E", "true"])
+
+    source_date_epoch = str(int(build.build_timestamp.timestamp()))
 
     # fmt: off
     subprocess_run_verbose(
@@ -799,52 +863,40 @@ def main():
         env={
             "HOME": os.environ["HOME"],
             "PATH": f"{pathlib.Path(sys.executable).parent}:{os.environ['PATH']}",
-            ("ARM_LLVM_DIR" if is_llvm else "ARM_GCC_DIR"): toolchain,
+            f"ARM_{build.toolchain.upper()}_DIR": build.toolchain_path,
             "NINJA_EXE_PATH": shutil.which("ninja"),
             # Unused, `post_build_command` replaces it. The SDK's toolchain.cmake still
             # requires it to be non-empty, otherwise it errors out.
             "POST_BUILD_EXE": shutil.which("cmake"),
-            "SOURCE_DATE_EPOCH": str(int(args.build_timestamp.timestamp())),
+            "SOURCE_DATE_EPOCH": source_date_epoch,
         },
-        cwd=cmake_dir,
+        cwd=build.cmake_dir,
     )
     # fmt: on
 
     subprocess_run_verbose(
         ["cmake", "--build", "."],
         "cmake --build",
-        cwd=cmake_dir,
+        cwd=build.cmake_dir,
         env={
             "HOME": os.environ["HOME"],
             "PATH": f"{pathlib.Path(sys.executable).parent}:{os.environ['PATH']}",
-            "SOURCE_DATE_EPOCH": str(int(args.build_timestamp.timestamp())),
+            "SOURCE_DATE_EPOCH": source_date_epoch,
         },
     )
 
-    # Extract the metadata from the source and build trees, patch the ELF, and build the
-    # GBL. This runs before the debug paths below are rewritten, as the GBL contains only
-    # loadable segments and is unaffected by them.
-    extracted_gbl_metadata = create_gbl(
-        build_dir=cmake_dir,
-        project_root=args.build_dir,
-        gsdk_path=sdk,
-        project_name=base_project_name,
-        sdk_version=sdk_version,
-        gbl_metadata=manifest["gbl"],
-    )
 
-    output_artifact = (cmake_dir / base_project_name).with_suffix(".gbl")
-
-    # Verify that --wrap linker flags don't wrap weak stubs
+def verify_build_reproducibility(
+    build: ResolvedBuild, output_artifact: pathlib.Path
+) -> None:
+    """Check the linker wraps and scrub absolute build paths out of the ELF's DWARF."""
     validate_linker_wrap_symbols(map_file=output_artifact.with_suffix(".map"))
 
-    # Rewrite absolute build paths in the ELF's DWARF for reproducibility, then verify
-    # none leaked
     out_elf = output_artifact.with_suffix(".out")
     remap_debug_build_paths(
         out_elf,
         {
-            str(args.build_dir.resolve()): "/src",
+            str(build.build_dir.resolve()): "/src",
             "/home/buildengineer": "/src/vendor",  # Silicon Labs build machines
             "/github/home": "/src/vendor",  # Silicon Labs Zigbee CI
             "/opt/github": "/src/vendor",  # Silicon Labs Z-Wave CI
@@ -863,9 +915,97 @@ def main():
             + "\n - ".join(map(str, unreproducible_paths))
         )
 
-    base_filename = evaulate_f_string(
-        manifest.get("filename", "{manifest_name}"),
-        {**value_template_env, **extracted_gbl_metadata},
+
+def main() -> None:
+    args = build_argument_parser().parse_args()
+
+    if args.build_timestamp is not None:
+        args.build_timestamp = datetime.strptime(
+            args.build_timestamp, "%Y%m%d%H%M%S"
+        ).replace(tzinfo=UTC)
+    else:
+        args.build_timestamp = datetime.now(UTC)
+
+    if args.slc_daemon:
+        slc = ["slc", "--daemon", "--daemon-timeout", "1"]
+    else:
+        slc = ["slc"]
+
+    if args.build_dir is None:
+        args.build_dir = pathlib.Path(f"build/{time.time():.0f}_{args.manifest.stem}")
+
+    # argparse defaults should be replaced, not extended
+    if args.sdks != get_sdk_default_paths():
+        args.sdks = args.sdks[len(get_sdk_default_paths()) :]
+
+    if args.toolchains != get_toolchain_default_paths():
+        args.toolchains = args.toolchains[len(get_toolchain_default_paths()) :]
+
+    build = resolve_build(args)
+    LOGGER.info("Building in %s", build.build_dir.resolve())
+
+    if args.clean_build_dir:
+        with contextlib.suppress(OSError):
+            shutil.rmtree(build.build_dir)
+
+    copy_base_project(build)
+    base_project = prepare_project_slcp(build)
+
+    run_slc_generate(build, slc=slc, tool_paths=args.tool_paths)
+    apply_sdk_patches(build)
+    validate_sdk_extensions(build, base_project)
+
+    # Template variables for C defines and the output filename
+    template_env = {
+        "git_repo_hash": get_git_commit_id(repo=build.projects_root),
+        "manifest_name": build.manifest_path.stem,
+        "now": build.build_timestamp,
+    }
+
+    c_defines = normalize_c_defines(build.manifest)
+    c_flag_defines = [
+        f"-D{define}={config['value']}"
+        for define, config in c_defines.items()
+        if config["type"] == "c_flag"
+    ]
+    written_defines = patch_config_headers(
+        config_roots=[build.build_dir / "autogen", build.build_dir / "config"],
+        c_defines=c_defines,
+        base_project=base_project,
+        template_env=template_env,
+    )
+
+    unused_defines = (
+        set(c_defines)
+        - written_defines
+        - {define for define, config in c_defines.items() if config["type"] == "c_flag"}
+    )
+    if unused_defines:
+        LOGGER.error("Defines were unused, aborting: %s", unused_defines)
+        sys.exit(1)
+
+    fix_pti_config_warning(build)
+
+    cmake_configure_and_build(build, assemble_build_flags(build, c_flag_defines))
+
+    # Extract the metadata from the source and build trees, patch the ELF, and build the
+    # GBL. This runs before the debug paths below are rewritten, as the GBL contains only
+    # loadable segments and is unaffected by them.
+    extracted_gbl_metadata = create_gbl(
+        build_dir=build.cmake_dir,
+        project_root=build.build_dir,
+        gsdk_path=build.sdk,
+        project_name=build.base_project_name,
+        sdk_version=build.sdk_version,
+        gbl_metadata=build.manifest["gbl"],
+    )
+
+    output_artifact = (build.cmake_dir / build.base_project_name).with_suffix(".gbl")
+    verify_build_reproducibility(build, output_artifact)
+
+    base_filename = evaluate_f_string(
+        build.manifest.get("filename", "{manifest_name}"),
+        {**template_env, **extracted_gbl_metadata},
     )
 
     args.output_dir.mkdir(exist_ok=True)
@@ -882,10 +1022,10 @@ def main():
 
     if args.clean_build_dir:
         with contextlib.suppress(OSError):
-            shutil.rmtree(args.build_dir)
+            shutil.rmtree(build.build_dir)
 
     if args.slc_daemon and not args.keep_slc_daemon:
-        subprocess.run(SLC + ["daemon-shutdown"], check=True)
+        subprocess.run(slc + ["daemon-shutdown"], check=True)
 
 
 if __name__ == "__main__":

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -193,38 +193,145 @@ def subprocess_run_verbose(command: list[str], prefix: str, **kwargs) -> None:
         sys.exit(1)
 
 
-def validate_linker_wrap_symbols(map_file: pathlib.Path) -> None:
-    """
-    Check that all --wrap linker flags wrap non-stub symbols.
+def validate_wrap_declarations(project_path: pathlib.Path) -> dict[str, str | None]:
+    """Map each wrapped symbol to where its definition lives, or `None` if unspecified."""
+    declarations: dict[str, str | None] = {}
 
-    When using GCC's --wrap=X, the linker creates __real_X pointing to the original.
-    If these __real functions are stubs, LTO will usually combine them and reuse the
-    same address.
-    """
-    map_content = map_file.read_text()
+    # Shared extensions are symlinked in from the repo root, and `rglob` does not
+    # descend into symlinked directories on its own
+    for slcc in sorted(project_path.rglob("*.slcc", recurse_symlinks=True)):
+        component = yaml.load(slcc.read_text())
+        declared: dict[str, set[str]] = {}
 
-    # Build address -> [symbols] and symbol -> address mappings
-    addr_to_symbols: dict[str, list[str]] = {}
-    symbol_to_addr: dict[str, str] = {}
+        for setting in component.get("toolchain_settings", []):
+            targets = set(re.findall(r"--wrap=(\w+)", str(setting["value"])))
 
-    for match in re.finditer(r"^\s+(0x[0-9a-f]+)\s+(\w+)$", map_content):
-        addr, name = match.groups()
-        addr_to_symbols.setdefault(addr, []).append(name)
-        symbol_to_addr[name] = addr
+            if targets:
+                declared.setdefault(setting["option"], set()).update(targets)
 
-    # Check if original symbols share addresses with unrelated symbols
-    for name in re.findall(r"__wrap_(\w+)", map_content):
-        if name not in symbol_to_addr:
+        if not declared:
             continue
 
-        addr = symbol_to_addr[name]
-        symbols_at_addr = addr_to_symbols[addr]
+        gcc = declared.get("gcc_linker_option", set())
+        llvm = declared.get("llvm_linker_option", set())
 
-        if len(symbols_at_addr) > 1:
-            raise RuntimeError(
-                f"Linker --wrap={name} appears to wrap an empty stub "
-                f"(shares address {addr} with: {symbols_at_addr}"
+        # `gcc_linker_option` only reaches the GCC linker, so a wrap declared under it
+        # alone vanishes from LLVM builds: no flag, no `__wrap_` symbol, no error
+        if gcc != llvm:
+            LOGGER.error(
+                "%s declares --wrap for one toolchain only: gcc-only=%s llvm-only=%s",
+                slcc.relative_to(project_path),
+                sorted(gcc - llvm),
+                sorted(llvm - gcc),
             )
+            sys.exit(1)
+
+        # `metadata` is the SDK's free-form slcc key; a bare top-level key is a
+        # "junk key" warning and spec 8 refuses to generate with any warning
+        definitions = (
+            component.get("metadata", {})
+            .get("nabucasa", {})
+            .get("wrap_definitions", {})
+        )
+
+        if set(definitions) - gcc:
+            LOGGER.error(
+                "%s names definitions for symbols it does not wrap: %s",
+                slcc.relative_to(project_path),
+                sorted(set(definitions) - gcc),
+            )
+            sys.exit(1)
+
+        for target in gcc:
+            declarations[target] = definitions.get(target)
+
+    return declarations
+
+
+def linker_wrap_targets(build: ResolvedBuild) -> set[str]:
+    """The symbols the generated project actually asks the linker to wrap."""
+    return set(re.findall(r"-Wl,--wrap=(\w+)", build.project_cmake.read_text()))
+
+
+def validate_linker_wraps(elf_path: pathlib.Path, targets: set[str]) -> None:
+    """Check that every reference to a wrapped symbol goes via its wrapper."""
+
+    # `--emit-relocs` retains relocations naming the symbol each call site and function
+    # pointer resolved to, so vector table entries are covered as directly as branches
+    with elf_path.open("rb") as f:
+        elf = ELFFile(f)
+        symbols = list(elf.get_section_by_name(".symtab").iter_symbols())
+        names = [symbol.name for symbol in symbols]
+        functions = {
+            symbol.name: (symbol["st_value"] & ~1, symbol["st_size"])
+            for symbol in symbols
+            if symbol["st_info"]["type"] == "STT_FUNC" and symbol.name
+        }
+
+        references: dict[str, list[tuple[str, int]]] = {}
+
+        for section in elf.iter_sections():
+            if section.header["sh_type"] not in ("SHT_REL", "SHT_RELA"):
+                continue
+
+            # `.ARM.exidx` describes functions for unwinding, it does not reference them
+            if ".debug" in section.name or ".ARM.exidx" in section.name:
+                continue
+
+            for reloc in section.iter_relocations():
+                references.setdefault(names[reloc["r_info_sym"]], []).append(
+                    (section.name, reloc["r_offset"])
+                )
+
+    # Without them every target below would trivially pass, which is the failure mode
+    # this check exists to eliminate
+    if targets and not references:
+        raise RuntimeError(
+            f"{elf_path.name} has no relocations, `-Wl,--emit-relocs` is required to"
+            f" validate --wrap"
+        )
+
+    problems = []
+
+    for target in sorted(targets):
+        refs = references.get(target, [])
+        wrapper = functions.get(f"__wrap_{target}")
+
+        if wrapper is None:
+            # With no references left the linker drops the wrapper too, which is fine
+            if refs:
+                section, offset = refs[0]
+                problems.append(
+                    f"--wrap={target}: __wrap_{target} is not in the image, but"
+                    f" {len(refs)} reference(s) remain, e.g. {section}+0x{offset:08x}"
+                )
+
+            continue
+
+        start, size = wrapper
+        stray = [ref for ref in refs if not (start <= ref[1] < start + size)]
+
+        if stray:
+            section, offset = stray[0]
+            problems.append(
+                f"--wrap={target}: {len(stray)} reference(s) bypass __wrap_{target},"
+                f" e.g. {section}+0x{offset:08x}"
+            )
+
+        if target in functions:
+            address = functions[target][0]
+            peers = sorted(n for n, (a, _) in functions.items() if a == address)
+
+            if len(peers) > 1:
+                problems.append(
+                    f"--wrap={target}: __real_{target} shares address 0x{address:08x}"
+                    f" with {peers}, so it is likely an empty stub folded by LTO"
+                )
+
+    if problems:
+        raise RuntimeError(
+            "Linker --wrap validation failed:\n - " + "\n - ".join(problems)
+        )
 
 
 def get_elf_source_paths(elf_path: pathlib.Path) -> set[pathlib.PurePosixPath]:
@@ -233,7 +340,9 @@ def get_elf_source_paths(elf_path: pathlib.Path) -> set[pathlib.PurePosixPath]:
 
     with elf_path.open("rb") as f:
         elf = ELFFile(f)
-        dwarf = elf.get_dwarf_info()
+        # `--emit-relocs` leaves `.rel.debug_*` behind, which pyelftools would otherwise
+        # try to apply, and it has no handler for `R_ARM_NONE`
+        dwarf = elf.get_dwarf_info(relocate_dwarf_sections=False)
 
         for cu in dwarf.iter_CUs():
             line_program = dwarf.line_program_for_CU(cu)
@@ -318,6 +427,10 @@ class ResolvedBuild:
     @property
     def cmake_dir(self) -> pathlib.Path:
         return self.build_dir / f"cmake_{self.toolchain}"
+
+    @property
+    def project_cmake(self) -> pathlib.Path:
+        return self.cmake_dir / f"{self.base_project_name}.cmake"
 
 
 def build_argument_parser() -> argparse.ArgumentParser:
@@ -603,6 +716,87 @@ def run_slc_generate(
     # fmt: on
 
 
+def exclude_archive_member_from_lto(
+    build: ResolvedBuild, archive_name: str, member: str, arch_flags: list[str]
+) -> None:
+    """Replace one bitcode archive member with a precompiled object, in place."""
+    archive = next(build.build_dir.rglob(archive_name)).resolve()
+    workdir = build.build_dir / "no_lto"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    gcc = build.toolchain_path / "bin/arm-none-eabi-gcc"
+    ar = build.toolchain_path / "bin/arm-none-eabi-ar"
+    real_member = f"no_lto_{member}"
+
+    subprocess.run([ar, "x", archive, member], cwd=workdir, check=True)
+    # `nolto-rel` runs LTO codegen but emits a plain relocatable object, so the member's
+    # own references stay undefined instead of being bound internally
+    subprocess.run(
+        [
+            gcc,
+            *arch_flags,
+            "-r",
+            "-nostdlib",
+            "-flinker-output=nolto-rel",
+            member,
+            "-o",
+            real_member,
+        ],
+        cwd=workdir,
+        check=True,
+    )
+    subprocess.run([ar, "r", archive, real_member], cwd=workdir, check=True)
+    subprocess.run([ar, "d", archive, member], check=True)
+
+    LOGGER.info("Excluded %s from LTO (%s)", member, archive.name)
+
+
+def exclude_definitions_from_lto(build: ResolvedBuild, definitions: list[str]) -> None:
+    """Compile the named definitions outside the LTO unit so `--wrap` can see them."""
+    # GNU ld only redirects *undefined* references, so a definition LTO can see is called
+    # directly instead (binutils PR ld/31956). LLD rewrites symbol tables and is immune.
+    if not definitions or build.toolchain is not Toolchain.GCC:
+        return
+
+    text = build.project_cmake.read_text()
+
+    # `-fwhole-program` asserts the LTO unit is the entire program, so a definition
+    # sitting outside it does not resolve at all
+    assert "-fwhole-program" in text
+    text = text.replace(" -fwhole-program", "")
+
+    arch_flags = list(
+        dict.fromkeys(re.findall(r"-m(?:cpu|fpu|float-abi)=[\w.+-]+|-mthumb", text))
+    )
+
+    sources = []
+
+    for definition in definitions:
+        archive_name, separator, member = definition.partition(":")
+
+        if separator:
+            exclude_archive_member_from_lto(build, archive_name, member, arch_flags)
+        else:
+            sources.append(definition)
+
+    if sources:
+        matched = [
+            line.strip().strip('"')
+            for line in text.split("\n")
+            if line.strip().strip('"').endswith(tuple(sources))
+        ]
+        assert len(matched) == len(sources), f"{sources} matched {matched}"
+
+        quoted = "\n    ".join(f'"{path}"' for path in matched)
+        text += (
+            f"\nset_source_files_properties(\n    {quoted}\n"
+            f'    PROPERTIES COMPILE_OPTIONS "-fno-lto"\n)\n'
+        )
+        LOGGER.info("Excluded %s from LTO", sources)
+
+    build.project_cmake.write_text(text)
+
+
 def apply_sdk_patches(build: ResolvedBuild) -> None:
     """Patch the copied SDK. A last resort, prefer SDK extensions wherever possible!"""
     if not build.manifest.get("sdk_patches"):
@@ -788,29 +982,27 @@ def sdk_path_remaps(build: ResolvedBuild) -> dict[str, str]:
 
 def warning_flags(toolchain: Toolchain) -> list[str]:
     """Warnings that are errors, minus the ones the SDK cannot currently satisfy."""
-    flags = ["-Wall", "-Wextra", "-Werror"]
-
-    if toolchain is Toolchain.LLVM:
-        return (
-            flags
-            + [
-                "-Wno-unknown-warning-option",  # ignore GCC-only warning names
-                "-Wno-error=format-security",  # SDK `diagnostic.c` uses a non-literal format string
-                "-Wno-error=unknown-pragmas",  # our `ws2812.c` uses `#pragma GCC optimize`
-                "-Wno-error=unused-function",  # unused statics in SDK/OpenThread sources
-                "-Wno-error=c23-extensions",  # our `cmds_proprietary.c` has a label before a declaration
-                "-Wno-error=unterminated-string-initialization",  # char arrays in zigbee router sources
-            ]
-        )
-
-    return (
-        flags
-        + [
+    return {
+        Toolchain.LLVM: [
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-Wno-unknown-warning-option",  # ignore GCC-only warning names
+            "-Wno-error=format-security",  # SDK `diagnostic.c` uses a non-literal format string
+            "-Wno-error=unknown-pragmas",  # our `ws2812.c` uses `#pragma GCC optimize`
+            "-Wno-error=unused-function",  # unused statics in SDK/OpenThread sources
+            "-Wno-error=c23-extensions",  # our `cmds_proprietary.c` has a label before a declaration
+            "-Wno-error=unterminated-string-initialization",  # char arrays in zigbee router sources
+        ],
+        Toolchain.GCC: [
+            "-Wall",
+            "-Wextra",
+            "-Werror",
             "-Wno-error=maybe-uninitialized",  # Linking fails due to a few SDK bugs
             "-Wno-error=uninitialized",  # False positive in zigbee `core-cli.c` under LTO
             "-Wno-error=unused-function",  # mbedTLS `ssl_tls.c` with X.509 hostname verification disabled
-        ]
-    )
+        ],
+    }[toolchain]
 
 
 def assemble_build_flags(
@@ -828,8 +1020,13 @@ def assemble_build_flags(
     return {
         "C_FLAGS": c_flags,
         "CXX_FLAGS": c_flags,
-        # Ensure deterministic linking order
-        "LD_FLAGS": ["-Wl,--sort-section=name"],
+        "LD_FLAGS": [
+            # Ensure deterministic linking order
+            "-Wl,--sort-section=name",
+            # Kept for `validate_linker_wraps`. Non-alloc, so the GBL and HEX are
+            # byte-identical with or without it.
+            "-Wl,--emit-relocs",
+        ],
     }
 
 
@@ -884,9 +1081,7 @@ def cmake_configure_and_build(
 def verify_build_reproducibility(
     build: ResolvedBuild, output_artifact: pathlib.Path
 ) -> None:
-    """Check the linker wraps and scrub absolute build paths out of the ELF's DWARF."""
-    validate_linker_wrap_symbols(map_file=output_artifact.with_suffix(".map"))
-
+    """Scrub absolute build paths out of the ELF's DWARF and confirm none are left."""
     out_elf = output_artifact.with_suffix(".out")
     remap_debug_build_paths(
         out_elf,
@@ -949,6 +1144,7 @@ def main() -> None:
     run_slc_generate(build, slc=slc, tool_paths=args.tool_paths)
     apply_sdk_patches(build)
     validate_sdk_extensions(build, base_project)
+    declared_wraps = validate_wrap_declarations(build.base_project_path)
 
     # Template variables for C defines and the output filename
     template_env = {
@@ -981,7 +1177,22 @@ def main() -> None:
 
     fix_pti_config_warning(build)
 
+    # Only our own wraps: SDK wrappers such as `main` hand the `__real_` call off to
+    # another function entirely, which the reference check below would flag
+    wrapped = set(declared_wraps) & linker_wrap_targets(build)
+
+    definitions = [
+        declared_wraps[target]
+        for target in sorted(wrapped)
+        if declared_wraps[target] is not None
+    ]
+    exclude_definitions_from_lto(build, definitions)
     cmake_configure_and_build(build, assemble_build_flags(build, c_flag_defines))
+
+    validate_linker_wraps(
+        elf_path=(build.cmake_dir / build.base_project_name).with_suffix(".out"),
+        targets=wrapped,
+    )
 
     # Extract the metadata from the source and build trees, patch the ELF, and build the
     # GBL. This runs before the debug paths below are rewritten, as the GBL contains only

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tool to retarget and build a SLCP project based on a manifest."""
 
 from __future__ import annotations
@@ -21,6 +20,8 @@ from datetime import UTC, datetime
 
 from elftools.elf.elffile import ELFFile
 from ruamel.yaml import YAML
+
+from .create_gbl import create_gbl
 
 LOGGER = logging.getLogger(__name__)
 
@@ -347,12 +348,6 @@ def main():
         help="Path to a folder containing an slc adapter pack",
     )
     parser.add_argument(
-        "--postbuild",
-        default=pathlib.Path(__file__).parent / "create_gbl.py",
-        required=False,
-        help="Postbuild executable",
-    )
-    parser.add_argument(
         "--override",
         action="append",
         dest="overrides",
@@ -544,10 +539,6 @@ def main():
     # Finally, write out the modified base project
     with base_project_slcp.open("w") as f:
         yaml.dump(base_project, f)
-
-    # Create a GBL metadata file
-    with (args.build_dir / "gbl_metadata.yaml").open("w") as f:
-        yaml.dump(manifest["gbl"], f)
 
     # Next, generate a chip-specific project from the modified base project
     LOGGER.info(f"Generating project for {manifest['device']}")
@@ -788,17 +779,9 @@ def main():
 
     build_flags["CXX_FLAGS"] = build_flags["C_FLAGS"]
 
-    # CMake expects a semicolon-separated list for the post-build command
-    # fmt: off
-    cmake_post_build_command = ";".join(
-        [
-            str(args.postbuild), "postbuild",
-            str((args.build_dir / base_project_name).resolve()) + ".slpb",
-            "--parameter", f"build_dir:{cmake_dir.resolve()}",
-            "--parameter", f"sdk_dir:{sdk}",
-        ]
-    )
-    # fmt: on
+    # The GBL is built in-process after the link, so neutralize the SDK's post-build
+    # hook. CMake expects a semicolon-separated list for the command.
+    cmake_post_build_command = ";".join([shutil.which("cmake"), "-E", "true"])
 
     # fmt: off
     subprocess_run_verbose(
@@ -820,7 +803,7 @@ def main():
             "NINJA_EXE_PATH": shutil.which("ninja"),
             # Unused, `post_build_command` replaces it. The SDK's toolchain.cmake still
             # requires it to be non-empty, otherwise it errors out.
-            "POST_BUILD_EXE": str(args.postbuild),
+            "POST_BUILD_EXE": shutil.which("cmake"),
             "SOURCE_DATE_EPOCH": str(int(args.build_timestamp.timestamp())),
         },
         cwd=cmake_dir,
@@ -836,6 +819,18 @@ def main():
             "PATH": f"{pathlib.Path(sys.executable).parent}:{os.environ['PATH']}",
             "SOURCE_DATE_EPOCH": str(int(args.build_timestamp.timestamp())),
         },
+    )
+
+    # Extract the metadata from the source and build trees, patch the ELF, and build the
+    # GBL. This runs before the debug paths below are rewritten, as the GBL contains only
+    # loadable segments and is unaffected by them.
+    extracted_gbl_metadata = create_gbl(
+        build_dir=cmake_dir,
+        project_root=args.build_dir,
+        gsdk_path=sdk,
+        project_name=base_project_name,
+        sdk_version=sdk_version,
+        gbl_metadata=manifest["gbl"],
     )
 
     output_artifact = (cmake_dir / base_project_name).with_suffix(".gbl")
@@ -868,10 +863,6 @@ def main():
             + "\n - ".join(map(str, unreproducible_paths))
         )
 
-    # Read the metadata extracted from the source and build trees
-    extracted_gbl_metadata = json.loads(
-        (output_artifact.parent / "gbl_metadata.json").read_text()
-    )
     base_filename = evaulate_f_string(
         manifest.get("filename", "{manifest_name}"),
         {**value_template_env, **extracted_gbl_metadata},

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -133,12 +133,7 @@ def load_sdks(paths: list[pathlib.Path]) -> dict[pathlib.Path, str]:
 
     for sdk in paths:
         sdk_file = next(sdk.glob("*_sdk.slcs"))
-
-        try:
-            sdk_meta = yaml.load(sdk_file.read_text())
-        except FileNotFoundError:
-            LOGGER.warning("SDK %s is not valid, skipping", sdk)
-            continue
+        sdk_meta = yaml.load(sdk_file.read_text())
 
         sdk_id = sdk_meta["id"]
         sdk_version = sdk_meta["sdk_version"]

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -818,8 +818,9 @@ def main():
             "PATH": f"{pathlib.Path(sys.executable).parent}:{os.environ['PATH']}",
             ("ARM_LLVM_DIR" if is_llvm else "ARM_GCC_DIR"): toolchain,
             "NINJA_EXE_PATH": shutil.which("ninja"),
-            # The SDK's generated cmake otherwise resolves this with `slt where commander`
-            "POST_BUILD_EXE": shutil.which("commander"),
+            # Unused, `post_build_command` replaces it. The SDK's toolchain.cmake still
+            # requires it to be non-empty, otherwise it errors out.
+            "POST_BUILD_EXE": str(args.postbuild),
             "SOURCE_DATE_EPOCH": str(int(args.build_timestamp.timestamp())),
         },
         cwd=cmake_dir,

--- a/tools/create_factory_hex.py
+++ b/tools/create_factory_hex.py
@@ -277,11 +277,11 @@ def main() -> None:
 
     output_hex.flash_data(address=bootloader.address, data=bootloader.data)
 
-    # Flash the application
+    # Flash the application segments
     application_gbl = GBL3Image.from_bytes(args.application.read_bytes())
-    application = application_gbl.get_first_tag(GBL3EraseProg)
 
-    output_hex.flash_data(address=application.address, data=application.data)
+    for application in application_gbl.get_tags(GBL3EraseProg):
+        output_hex.flash_data(address=application.address, data=application.data)
 
     # Flash USERDATA tokens
     tokens_json = json.loads(args.tokens.read_text())

--- a/tools/create_factory_hex.py
+++ b/tools/create_factory_hex.py
@@ -4,7 +4,7 @@ import enum
 import json
 import pathlib
 
-from universal_silabs_flasher.firmware import GBLImage, GBLTagId
+from pygbl import GBL3Bootloader, GBL3EraseProg, GBL3Image
 
 
 @dataclasses.dataclass(frozen=True)
@@ -272,21 +272,16 @@ def main() -> None:
     output_hex = IntelHex()
 
     # Flash the bootloader
-    bootloader_gbl = GBLImage.from_bytes(args.bootloader.read_bytes())
-    bootloader_data = bootloader_gbl.get_first_tag(GBLTagId.BOOTLOADER)
-    bootloader_hdr, bootloader = bootloader_data[:8], bootloader_data[8:]
-    _bootloader_version = int.from_bytes(bootloader_hdr[0:4], "little")
-    bootloader_base_addr = int.from_bytes(bootloader_hdr[4:8], "little")
+    bootloader_gbl = GBL3Image.from_bytes(args.bootloader.read_bytes())
+    bootloader = bootloader_gbl.get_first_tag(GBL3Bootloader)
 
-    output_hex.flash_data(address=bootloader_base_addr, data=bootloader)
+    output_hex.flash_data(address=bootloader.address, data=bootloader.data)
 
     # Flash the application
-    application_gbl = GBLImage.from_bytes(args.application.read_bytes())
-    application_data = application_gbl.get_first_tag(GBLTagId.PROGRAM_DATA2)
-    application_hdr, application = application_data[:4], application_data[4:]
-    application_base_addr = int.from_bytes(application_hdr[0:4], "little")
+    application_gbl = GBL3Image.from_bytes(args.application.read_bytes())
+    application = application_gbl.get_first_tag(GBL3EraseProg)
 
-    output_hex.flash_data(address=application_base_addr, data=application)
+    output_hex.flash_data(address=application.address, data=application.data)
 
     # Flash USERDATA tokens
     tokens_json = json.loads(args.tokens.read_text())

--- a/tools/create_factory_hex.py
+++ b/tools/create_factory_hex.py
@@ -4,7 +4,15 @@ import enum
 import json
 import pathlib
 
-from pygbl import GBL3Bootloader, GBL3EraseProg, GBL3Image
+from pygbl import (
+    GBL3Bootloader,
+    GBL3EraseProg,
+    GBL3Header,
+    GBL3Image,
+    GBL3Prog,
+    GBL3Type,
+    read_encryption_key,
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -239,6 +247,19 @@ class IntelHex:
         )
 
 
+def load_gbl(path: pathlib.Path, key: bytes | None) -> GBL3Image:
+    """Read a GBL, decrypting and decompressing it into plain program data."""
+    image = GBL3Image.from_bytes(path.read_bytes())
+
+    if GBL3Type.ENCRYPTION_AESCCM in image.get_first_tag(GBL3Header).type:
+        if key is None:
+            raise ValueError(f"{path} is encrypted, pass --encryption-key")
+
+        image = image.decrypt(key)
+
+    return image.decompress()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Create an Intel HEX file combining a bootloader, application, and manufacturing tokens."
@@ -262,6 +283,13 @@ def main() -> None:
         help="Path to tokens JSON.",
     )
     parser.add_argument(
+        "--encryption-key",
+        type=pathlib.Path,
+        required=False,
+        default=None,
+        help="Path to the image encryption key token file, for encrypted GBL files.",
+    )
+    parser.add_argument(
         "--output",
         type=pathlib.Path,
         required=True,
@@ -271,16 +299,28 @@ def main() -> None:
 
     output_hex = IntelHex()
 
+    if args.encryption_key is not None:
+        key = read_encryption_key(args.encryption_key.read_text())
+    else:
+        key = None
+
     # Flash the bootloader
-    bootloader_gbl = GBL3Image.from_bytes(args.bootloader.read_bytes())
+    bootloader_gbl = load_gbl(args.bootloader, key)
     bootloader = bootloader_gbl.get_first_tag(GBL3Bootloader)
 
     output_hex.flash_data(address=bootloader.address, data=bootloader.data)
 
-    # Flash the application segments
-    application_gbl = GBL3Image.from_bytes(args.application.read_bytes())
+    # Flash the application segments. Both program data tag ids mean the same thing,
+    # only their erase behavior on the device differs
+    application_gbl = load_gbl(args.application, key)
+    application_tags = [
+        t for t in application_gbl.tags if isinstance(t, (GBL3EraseProg, GBL3Prog))
+    ]
 
-    for application in application_gbl.get_tags(GBL3EraseProg):
+    if not application_tags:
+        raise ValueError(f"{args.application} contains no program data")
+
+    for application in application_tags:
         output_hex.flash_data(address=application.address, data=application.data)
 
     # Flash USERDATA tokens

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -111,7 +111,7 @@ def create_gbl(
     gbl_metadata: dict[str, Any],
 ) -> dict[str, Any]:
     """Build the GBL image for a linked project, returning its metadata."""
-    out_file = build_dir / f"{project_name}.out"
+    elf = build_dir / f"{project_name}.out"
 
     # Prepare the GBL metadata
     metadata = {
@@ -128,13 +128,12 @@ def create_gbl(
     if "ezsp_version" in gbl_dynamic:
         gbl_dynamic.remove("ezsp_version")
 
-        elf = next(iter(build_dir.glob("*.out")))
         with elf.open("rb") as f:
             # Try new SDK symbol name first, fall back to old
             try:
                 ember_version = read_elf_symbol(f, "sl_zigbee_version")
                 version_symbol = "sl_zigbee_version"
-            except ValueError, TypeError:
+            except ValueError:
                 f.seek(0)
                 ember_version = read_elf_symbol(f, "emberVersion")
                 version_symbol = "emberVersion"
@@ -288,7 +287,7 @@ def create_gbl(
 
     metadata_json = json.dumps(metadata, sort_keys=True).encode("utf-8")
 
-    with out_file.open("rb") as f:
+    with elf.open("rb") as f:
         if gbl_metadata.get("fw_type", None) != "gecko-bootloader":
             image = build_application_gbl3(
                 f, metadata=metadata_json if gbl_metadata else None
@@ -316,6 +315,6 @@ def create_gbl(
         image = image.sign(private_key)
 
     # `commander` pads its output to a 4 byte boundary
-    out_file.with_suffix(".gbl").write_bytes(image.serialize(block_size=4))
+    elf.with_suffix(".gbl").write_bytes(image.serialize(block_size=4))
 
     return metadata

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -95,44 +95,6 @@ def parse_c_header_defines(file_content: str) -> dict[str, str]:
     return config
 
 
-def parse_properties_file(file_content: str) -> dict[str, str | list[str]]:
-    """
-    Parses custom .properties file format into a dictionary.
-    Handles double backslashes as escape characters for spaces.
-    """
-    properties = {}
-
-    for line in file_content.split("\n"):
-        line = line.strip()
-
-        if not line or line.startswith("#"):
-            continue
-
-        key, value = line.split("=", 1)
-        key = key.strip()
-
-        properties[key] = []
-        current_value = ""
-        i = 0
-
-        while i < len(value):
-            if value[i : i + 2] == "\\\\":
-                current_value += " "
-                i += 2
-            elif value[i] == " ":
-                properties[key].append(current_value)
-                current_value = ""
-                i += 1
-            else:
-                current_value += value[i]
-                i += 1
-
-        if current_value:
-            properties[key].append(current_value)
-
-    return properties
-
-
 def resolve_key_path(
     key: str, project_root: pathlib.Path, gsdk_path: pathlib.Path
 ) -> pathlib.Path:

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -8,10 +8,17 @@ import ast
 import json
 import pathlib
 import struct
-import subprocess
 from typing import BinaryIO
 
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from elftools.elf.elffile import ELFFile
+from pygbl import (
+    GBL3Compression,
+    build_application_gbl3,
+    build_bootloader_gbl3,
+    read_encryption_key,
+)
 from ruamel.yaml import YAML
 
 
@@ -370,45 +377,38 @@ def main():
 
     print("Generated GBL metadata:", metadata, flush=True)
 
-    # Write it to a file for `commander` to read
-    (artifact_root / "gbl_metadata.json").write_text(
-        json.dumps(metadata, sort_keys=True)
-    )
+    # `build_project.py` reads this back, so keep writing it even though the GBL is now
+    # built in-process rather than by `commander`
+    metadata_json = json.dumps(metadata, sort_keys=True).encode("utf-8")
+    (artifact_root / "gbl_metadata.json").write_bytes(metadata_json)
 
-    commander_args = [
-        "commander",
-        "gbl",
-        "create",
-        out_file.with_suffix(".gbl"),
-        (
-            "--app"
-            if gbl_metadata.get("fw_type", None) != "gecko-bootloader"
-            else "--bootloader"
-        ),
-        out_file,
-    ] + (
-        [
-            "--metadata",
-            (artifact_root / "gbl_metadata.json"),
-        ]
-        if gbl_metadata
-        else []
-    )
+    with out_file.open("rb") as f:
+        if gbl_metadata.get("fw_type", None) != "gecko-bootloader":
+            image = build_application_gbl3(
+                f, metadata=metadata_json if gbl_metadata else None
+            )
+        else:
+            image = build_bootloader_gbl3(
+                f, metadata=metadata_json if gbl_metadata else None
+            )
 
+    # The order matters: compression only touches program data, encryption then wraps
+    # every tag but the header, and the signature covers the resulting ciphertext
     if gbl_metadata.get("compression", None) is not None:
-        commander_args += ["--compress", gbl_metadata["compression"]]
-
-    if gbl_metadata.get("sign_key", None) is not None:
-        commander_args += ["--sign", gbl_metadata["sign_key"].format(SDK_DIR=gsdk_path)]
+        image = image.compress(GBL3Compression(gbl_metadata["compression"]))
 
     if gbl_metadata.get("encrypt_key", None) is not None:
-        commander_args += [
-            "--encrypt",
-            gbl_metadata["encrypt_key"].format(SDK_DIR=gsdk_path),
-        ]
+        key_path = pathlib.Path(gbl_metadata["encrypt_key"].format(SDK_DIR=gsdk_path))
+        image = image.encrypt(read_encryption_key(key_path.read_text()))
 
-    # Finally, generate the GBL
-    subprocess.run(commander_args, check=True)
+    if gbl_metadata.get("sign_key", None) is not None:
+        key_path = pathlib.Path(gbl_metadata["sign_key"].format(SDK_DIR=gsdk_path))
+        private_key = load_pem_private_key(key_path.read_bytes(), password=None)
+        assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+        image = image.sign(private_key)
+
+    # `commander` pads its output to a 4 byte boundary
+    out_file.with_suffix(".gbl").write_bytes(image.serialize(block_size=4))
 
 
 if __name__ == "__main__":

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -133,6 +133,13 @@ def parse_properties_file(file_content: str) -> dict[str, str | list[str]]:
     return properties
 
 
+def resolve_key_path(
+    key: str, project_root: pathlib.Path, gsdk_path: pathlib.Path
+) -> pathlib.Path:
+    """Resolve a manifest key path against the generated project, absolutes pass through."""
+    return project_root / pathlib.Path(key.format(SDK_DIR=gsdk_path))
+
+
 def create_gbl(
     build_dir: pathlib.Path,
     project_root: pathlib.Path,
@@ -335,11 +342,13 @@ def create_gbl(
         image = image.compress(GBL3Compression(gbl_metadata["compression"]))
 
     if gbl_metadata.get("encrypt_key", None) is not None:
-        key_path = pathlib.Path(gbl_metadata["encrypt_key"].format(SDK_DIR=gsdk_path))
+        key_path = resolve_key_path(
+            gbl_metadata["encrypt_key"], project_root, gsdk_path
+        )
         image = image.encrypt(read_encryption_key(key_path.read_text()))
 
     if gbl_metadata.get("sign_key", None) is not None:
-        key_path = pathlib.Path(gbl_metadata["sign_key"].format(SDK_DIR=gsdk_path))
+        key_path = resolve_key_path(gbl_metadata["sign_key"], project_root, gsdk_path)
         private_key = load_pem_private_key(key_path.read_bytes(), password=None)
         assert isinstance(private_key, ec.EllipticCurvePrivateKey)
         image = image.sign(private_key)

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python3
 """Tool to create a GBL image in a Simplicity Studio build directory."""
 
 from __future__ import annotations
 
-import argparse
 import ast
 import json
 import pathlib
 import struct
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
@@ -19,7 +17,6 @@ from pygbl import (
     build_bootloader_gbl3,
     read_encryption_key,
 )
-from ruamel.yaml import YAML
 
 
 def _jump_to_elf_symbol(file: BinaryIO, symbol_name: str) -> tuple[ELFFile, int, int]:
@@ -136,78 +133,21 @@ def parse_properties_file(file_content: str) -> dict[str, str | list[str]]:
     return properties
 
 
-def find_file_in_parent_dirs(root: pathlib.Path, filename: str) -> pathlib.Path:
-    """
-    Finds a file in the given directory or any of its parents.
-    """
-    root = root.resolve()
-
-    while True:
-        if (root / filename).exists():
-            return root / filename
-
-        if root.parent == root:
-            raise FileNotFoundError(
-                f"Could not find {filename} in any parent directory"
-            )
-
-        root = root.parent
-
-
-def main():
-    # Run as a Simplicity Studio post-build step
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-    parser.add_argument("command", type=str, help="Command to execute: postbuild")
-    parser.add_argument("slpb_file", type=pathlib.Path, help="Path to the .slpb file")
-    parser.add_argument(
-        "--parameter",
-        action="append",
-        type=lambda kv: kv.split(":"),
-        dest="parameters",
-        help="Parameters in the format key:value",
-    )
-
-    args = parser.parse_args()
-    args.parameters = dict(args.parameters)
-
-    project_name = args.slpb_file.stem
-    build_dir = pathlib.Path(args.parameters["build_dir"])
+def create_gbl(
+    build_dir: pathlib.Path,
+    project_root: pathlib.Path,
+    gsdk_path: pathlib.Path,
+    project_name: str,
+    sdk_version: str,
+    gbl_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the GBL image for a linked project, returning its metadata."""
     out_file = build_dir / f"{project_name}.out"
-
-    artifact_root = out_file.parent
-    project_name = out_file.stem
-    slcp_path = find_file_in_parent_dirs(
-        root=artifact_root,
-        filename=project_name + ".slcp",
-    )
-
-    project_root = slcp_path.parent
-
-    if "sdk_dir" in args.parameters:
-        gsdk_path = pathlib.Path(args.parameters["sdk_dir"])
-    elif "cmake" in str(build_dir):
-        gsdk_path = pathlib.Path(
-            pathlib.Path(build_dir / f"{project_name}.cmake")
-            .read_text()
-            .split('set(SDK_PATH "', 1)[1]
-            .split('"', 1)[0]
-        )
-    else:
-        raise RuntimeError("Cannot determine SDK directory")
-
-    # Parse the main Simplicity Studio project config
-    slcp = YAML(typ="safe").load(slcp_path.read_text())
-
-    gbl_metadata = YAML(typ="safe").load(
-        (project_root / "gbl_metadata.yaml").read_text()
-    )
 
     # Prepare the GBL metadata
     metadata = {
         "metadata_version": 2,
-        "sdk_version": slcp["sdk"]["version"],
+        "sdk_version": sdk_version,
         "fw_type": gbl_metadata.get("fw_type"),
         "fw_variant": gbl_metadata.get("fw_variant"),
         "baudrate": gbl_metadata.get("baudrate"),
@@ -377,10 +317,7 @@ def main():
 
     print("Generated GBL metadata:", metadata, flush=True)
 
-    # `build_project.py` reads this back, so keep writing it even though the GBL is now
-    # built in-process rather than by `commander`
     metadata_json = json.dumps(metadata, sort_keys=True).encode("utf-8")
-    (artifact_root / "gbl_metadata.json").write_bytes(metadata_json)
 
     with out_file.open("rb") as f:
         if gbl_metadata.get("fw_type", None) != "gecko-bootloader":
@@ -410,6 +347,4 @@ def main():
     # `commander` pads its output to a 4 byte boundary
     out_file.with_suffix(".gbl").write_bytes(image.serialize(block_size=4))
 
-
-if __name__ == "__main__":
-    main()
+    return metadata

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -12,7 +12,7 @@ import re
 import sys
 from datetime import UTC, datetime
 
-from universal_silabs_flasher.firmware import parse_firmware_image
+from pygbl import GBLError, parse_firmware_image
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,16 +62,13 @@ def main():
 
         try:
             firmware = parse_firmware_image(data)
-        except ValueError:
+        except GBLError:
             _LOGGER.warning("Ignoring invalid firmware file: %s", firmware_file)
             continue
 
-        try:
-            gbl_metadata = firmware.get_nabucasa_metadata()
-        except KeyError, ValueError:
-            metadata = None
-        else:
-            metadata = gbl_metadata.original_json
+        # Encrypted images keep their metadata inside the ciphertext, so it is absent
+        raw_metadata = firmware.get_metadata()
+        metadata = json.loads(raw_metadata) if raw_metadata is not None else None
 
         manifest["firmwares"].append(
             {

--- a/uv.lock
+++ b/uv.lock
@@ -3,240 +3,62 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
-name = "aiohappyeyeballs"
-version = "2.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
-]
-
-[[package]]
-name = "aiohttp"
-version = "3.14.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/20/887fdcf832326571b370ffc347b3e70abe101096f3720126aac161b1d872/aiohttp-3.14.3-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:49f7325beb0f85ef4aef5f48f490269575f83e6e2acad00a1d80b807eb027062", size = 509067, upload-time = "2026-07-23T01:55:42.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/a3/92cec936f78cc4bf0fa5554ebe593b73459d94e3c62303e1902a4cccb6f7/aiohttp-3.14.3-cp314-cp314-android_24_x86_64.whl", hash = "sha256:e3be98a7c30b8c25d573dafba7171d66dfb05ee6a9070fc46535464ff97700a6", size = 514774, upload-time = "2026-07-23T01:55:44.937Z" },
-    { url = "https://files.pythonhosted.org/packages/29/ba/2a0c38df3fc557620b6a5acd98364af050053b6285b4dc7ee74100c63c18/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:614c61d478b83953e261d02bb2df750f17227cd33ef8002945bf5aebbde21919", size = 488134, upload-time = "2026-07-23T01:55:47.135Z" },
-    { url = "https://files.pythonhosted.org/packages/48/d6/d51b7d4bf309af3693940d8ffd2b9ed0b682434ef85959b7c9c137f60cf8/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:1caa7b0d05f3e3a36f87788c59e970a7ee1cefcfcbb924a9f138c4a6551c9cb7", size = 494201, upload-time = "2026-07-23T01:55:49.451Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5a/8f624384e5f1efabb5229b94157eb966b021e97bdb188c62860c2ae243c2/aiohttp-3.14.3-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:dfa68deb2a443bdaa3ea5297b0699c1464f08aef3812b486d1348eee61b07dc0", size = 502766, upload-time = "2026-07-23T01:55:51.656Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/26/4ff0164370deec18fb19254ee4ab10b7a73304ac0c860b13f5f84663759b/aiohttp-3.14.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e72ee89e28d907a18f46959b4eb0bb06701cc7f8cf4366e00029e2ccfaaf5924", size = 756557, upload-time = "2026-07-23T01:55:53.964Z" },
-    { url = "https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad4c8b7488d745d2ca4838ebd8ae5ba9b56341d30b1da43640e4ce87f9f49646", size = 510168, upload-time = "2026-07-23T01:55:56.22Z" },
-    { url = "https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db332af25642007330fca8be5c4d194caf2bea7a7fc84415aff3497af5dfee6b", size = 512957, upload-time = "2026-07-23T01:55:58.437Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d1/8aba53f15ccb2238405f5e9d30e2a8ca44f93878c26e7165ade00d374b1c/aiohttp-3.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25bd2708db6bdf6a6630dd37bdcdfcb47c4434d22ac69c64665b802910140b30", size = 1750149, upload-time = "2026-07-23T01:56:00.856Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bd/40c3fee327529284375c6701cbb0fa4600cc2e8432af1378f897e2ef7d3a/aiohttp-3.14.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cef89a58e628c4efcac3275c2d68083f82426dcdc89c1492a6f654f9f7ea6ab9", size = 1707685, upload-time = "2026-07-23T01:56:03.371Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a3/ca0cc6724cca8114b05694abd916060758c79894c3aa5b012cdadc1bc28e/aiohttp-3.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c23ec8ee9d5ab2f5421f9c7fffce208435607af27fd46d4a44e031954352838f", size = 1803911, upload-time = "2026-07-23T01:56:05.817Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b5/85b099c299c3ffd38ad9b3e43694c8a346934e4a30c88c4fd5a841234f77/aiohttp-3.14.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e2667f0bbe7eb6c74eae5e9691441ad186e5845ca3cff63230fc09c4e7514f5d", size = 1876929, upload-time = "2026-07-23T01:56:08.413Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18cb43369747b2ae007bd2655fb8e63a099c2ff1d207962943636dac989b3147", size = 1761112, upload-time = "2026-07-23T01:56:10.918Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/16/bc4b55e3e5cb175fd69c53c90d60d2f47797cb343da5106e23863dc4dba4/aiohttp-3.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d77640cc618c1d99fc4f8589c0f24a730adfa54eb1e57ef7bf0c8dfb78da898c", size = 1583500, upload-time = "2026-07-23T01:56:13.613Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e8/13a9d957a1ee40837f46aa30f0f4c657e673ad86a2e6362a9f9be20d26d9/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:53e5179d8abb5710f8e83ba207c41c8d1261fcffd4616500e15ca2b7a33be10a", size = 1713940, upload-time = "2026-07-23T01:56:15.969Z" },
-    { url = "https://files.pythonhosted.org/packages/38/05/d33c680c1bcf1c7e130f9cbfc1fc02fe8bb0c4af2a94a53dd5fb56131e5c/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cd817772b2fcf2b8c0905795318485f9ec16eae60b29feb7f4c77085311637f0", size = 1724413, upload-time = "2026-07-23T01:56:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/85/1d/af798d306f7a74b6a632dbcabcf62a4c91391b7582d2a8c6d7712e2cc54e/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4e3ac92d90e92773b2362d506068e9a948192bd553e743c5b2429e28527c8661", size = 1770748, upload-time = "2026-07-23T01:56:21.074Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/92/ad720d472556a995049206867765e9410969684f86ee09423ff9969044c1/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3f42e9b78301f11c8f861746175d8b9c1ccef713fcad9eab396e2f6db8ed4a22", size = 1577564, upload-time = "2026-07-23T01:56:23.475Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ad/0ed7586cbef7a884e23a752fa2bb987a122e6a5dd50dab109258d0a95193/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9d9edccfe496b476db5f398d97b865e9a6752bcf8aec4eef8390ce20fb64bb41", size = 1782080, upload-time = "2026-07-23T01:56:25.994Z" },
-    { url = "https://files.pythonhosted.org/packages/97/ea/dbaed0d73e8a69aad653b045dab451c67c2454bb731a37b45a86593e9422/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c5ec8fb1bcc31a8466f74aaf26c345d5c386fa4bd08a3f0eb9c7a4a3fe8b5bf", size = 1745813, upload-time = "2026-07-23T01:56:28.604Z" },
-    { url = "https://files.pythonhosted.org/packages/81/1b/6893d4bc57e434fc93a6c9217c637d967a0b651d989f6e3265179375754a/aiohttp-3.14.3-cp314-cp314-win32.whl", hash = "sha256:38901a84da3ce22249f6e860bf8f90d141bcab7da090cc398f8bb58c0e44b7da", size = 455872, upload-time = "2026-07-23T01:56:31.031Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/8b/c7baa1ba1eda4db6989baefe5de6d99834921b84ebd7918624febcb9f290/aiohttp-3.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:8b3b60de05f3dcb6f6a00f818bb2ec781cee4de0645f59ccaf99b1d1823b6100", size = 481030, upload-time = "2026-07-23T01:56:33.365Z" },
-    { url = "https://files.pythonhosted.org/packages/22/8c/c29d067df825a2df88ca432db848aa2fe8199598359cc06c12b09320cac9/aiohttp-3.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:1576145bdceeb92382d899751e12743a3a5b8e460a841e3e50543859e54864dc", size = 453669, upload-time = "2026-07-23T01:56:35.731Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a4/9c033beb355d39b6147980597ec9645e4729243f686ee4dc73945de72030/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8800c996b01c2772a783e3e46f3e1abd5823029adca0df54231960de9bfefa5b", size = 791403, upload-time = "2026-07-23T01:56:37.972Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ca/87c32a0a7704583cfc49660bd817889bae5b830bf53b5dcb4e92145ac2da/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ebe8e504f058fe91223351cecd2d9d6946c9d241bb0250d898ffbdf584cc72b0", size = 526413, upload-time = "2026-07-23T01:56:40.523Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d8/8ec0e471248c500acdce2be3f46db8fb62b5eb60efef072529cc85ee1d26/aiohttp-3.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30402d03a7c0ff52bce290b57e564e9079fd9d0cb545c8aba73f86a103162d2e", size = 532135, upload-time = "2026-07-23T01:56:42.876Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/45/f8919fd936e8b79fcd9bda7b6d8e62613462a713f4f17987fd7c34399142/aiohttp-3.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc7b5bfec6573f3ae844f457fdde5adeb713f8b8e4a81ad64fc207b49383716", size = 1922742, upload-time = "2026-07-23T01:56:45.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ec/9ca76b28a27525b0cc53e20842e0228b022f301ce1f436b7d814b4aaf2df/aiohttp-3.14.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8a5fd34f7f7410d1730d5c2ba873cacb2eed3fede366feb268a70ba22581ed8f", size = 1787371, upload-time = "2026-07-23T01:56:48.045Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/04/6acdbf17315f7b55f1937e3387acb89a3cddeb4995689553d064af8e92ab/aiohttp-3.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:270d3dace9ca2f10f0da5d8ebe519b7a310fc6112ed916e32df5866df0888553", size = 1912623, upload-time = "2026-07-23T01:56:50.605Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e6/438b0c79ca6f45eb9fd9817dd4c01a91919a38c0de5ee9e05e2b4dc0ece7/aiohttp-3.14.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3ae5b3a59436d089b5395d910121a390feed4d00578eb95a0fd1a329fe963100", size = 2005515, upload-time = "2026-07-23T01:56:53.153Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6b/62cbd6577758699525f5c712d1ddef57d9875fbab0ae8d5f5a202fd598f8/aiohttp-3.14.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2498f0fe69ead802f9675beca44a7c21c62fdaa4ec5145ea1c3ad6edbee29f85", size = 1879906, upload-time = "2026-07-23T01:56:55.818Z" },
-    { url = "https://files.pythonhosted.org/packages/00/95/18bcbf830a21dc3aae24d8f6b6feaf3db1d2090242d00a7868db2ffb0b67/aiohttp-3.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a0dc483c00da8b673abbb367eb6f8d8f4bcec30eb58529ea13cb42e7fd2dfa33", size = 1675849, upload-time = "2026-07-23T01:56:58.861Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/19/47f4968659c5e23606c3790c80fc624e691c153d036148449ee84d31b287/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7d3a97c678d34fc5b59da671ee9cd630096ddc643e7b5a30d54a2a6f3574d3f", size = 1843496, upload-time = "2026-07-23T01:57:01.591Z" },
-    { url = "https://files.pythonhosted.org/packages/64/af/38c33c4dd82fddcb4e56c4653b6f1072a8edbc6b7fa15809f14932c41e2d/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8fb78a83c9e5f741ca3a68cfb455c1f5bb83b4e7249a3848b3cd78d0a8563b0", size = 1827746, upload-time = "2026-07-23T01:57:05.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/9d/0537cda4885ac8f5b7053d164dd06312f4c483a4edcb8ee5b8aaf2a989bf/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:74ab5b6a9fb13e873e5a90946588baecaf488745e1db1a4a5c433f971f035098", size = 1853810, upload-time = "2026-07-23T01:57:08.043Z" },
-    { url = "https://files.pythonhosted.org/packages/19/fe/26f9c5e6458385aa86497836b0dea6fb2f027827d63f37c7856cce9286ee/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd52f811e65f6fb634b1047159657c98f52b407f8efec907bcfc09da9a4c0a25", size = 1668895, upload-time = "2026-07-23T01:57:10.837Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/4c/618b1db9b9ba079b8875d2cdf78e7c4a3bf72903bd5850fee7dd9544600a/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f0f177d1b195b9e06376cfd7d308d8a1b920909a609d03ac82a8c73bbb16d3b9", size = 1883833, upload-time = "2026-07-23T01:57:13.672Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c6/bd959bd1e4771f9fd944e9e436224c48c77b018b73b519b5aad346335bcc/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:498c6c623134f8e09a3c4e60bcd607a0b4590dd7dbf08dd40851b27cbb520ccb", size = 1844251, upload-time = "2026-07-23T01:57:16.593Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload-time = "2026-07-23T01:57:19.306Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload-time = "2026-07-23T01:57:21.762Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload-time = "2026-07-23T01:57:24.241Z" },
-]
-
-[[package]]
-name = "aiosignal"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "frozenlist" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
-]
-
-[[package]]
-name = "aiosqlite"
-version = "0.21.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
-]
-
-[[package]]
-name = "attrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "bellows"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "click-log" },
-    { name = "voluptuous" },
-    { name = "zigpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/b3/47b68835ffbbdf03f468a0e01f11c5c650403404233e8fe19befabd7362c/bellows-1.0.0.tar.gz", hash = "sha256:fd04dbc3e072aa2bc7ada42343006cc77a50e6b68f8621bfacdfa1d56ed0ec18", size = 187912, upload-time = "2026-07-29T04:00:10.434Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/01/dc9058c8f0c4a62a777095a1af5798fdc719752e53546bb4dddddb3fc731/bellows-1.0.0-py3-none-any.whl", hash = "sha256:bb61f8416c28c493abf7175b460b6f7445495cb649abdbd8b7c67eff6c4d440c", size = 160833, upload-time = "2026-07-29T04:00:09.073Z" },
-]
-
-[[package]]
 name = "cffi"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
-    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
-    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
-    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
-    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
-    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
-    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
-]
-
-[[package]]
-name = "click-log"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/32/228be4f971e4bd556c33d52a22682bfe318ffe57a1ddb7a546f347a90260/click-log-0.4.0.tar.gz", hash = "sha256:3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975", size = 9985, upload-time = "2022-03-13T11:10:15.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/5a/4f025bc751087833686892e17e7564828e409c43b632878afeae554870cd/click_log-0.4.0-py2.py3-none-any.whl", hash = "sha256:a43e394b528d52112af599f2fc9e4b7cf3c15f94e53581f74fa6867e68c91756", size = 4273, upload-time = "2022-03-13T11:10:17.594Z" },
-]
-
-[[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
-]
-
-[[package]]
-name = "crc"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/e6/c3488c35ecae290751466252e5ea01ef50fc67bfc1a9aba43983329b7025/crc-7.1.0.tar.gz", hash = "sha256:99dd540909a37ae4f62c65441df8ecb4e7f9af014fecaf4f331052a41d66c07d", size = 9888, upload-time = "2024-11-05T20:34:28.983Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/ff/5ebeae9b53e8cddd9e6f3b6b0c98da3f112d9a7e1ea638a00876aa8fb5b4/crc-7.1.0-py3-none-any.whl", hash = "sha256:b9845c81d0b900d8fda1aae7af977035bee0359c279713814e9fd23a2d59db6a", size = 8790, upload-time = "2024-11-05T20:34:27.629Z" },
-]
-
-[[package]]
-name = "crccheck"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/d1/a943f4f1ca899917cc3fe1cb89d59348edd1b407503e4b02608e8d6b421e/crccheck-1.3.1.tar.gz", hash = "sha256:1544c0110bf0a697d875d4f29dc40d7079f9d4d402a9317383f55f90ca72563a", size = 41696, upload-time = "2025-07-10T07:01:08.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/b5/68a9054be852e61f31de1be4e8d95802646b93344ce17c2380a1748706fa/crccheck-1.3.1-py3-none-any.whl", hash = "sha256:1680c9a7bb1ca4bec45fa19b8ca64319f10d2ce4eb8b0d25d51cb99a20ca0108", size = 24608, upload-time = "2025-07-10T07:01:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
 ]
 
 [[package]]
@@ -290,205 +112,19 @@ wheels = [
 ]
 
 [[package]]
-name = "frozendict"
-version = "2.4.7"
+name = "lz4"
+version = "4.4.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
-]
-
-[[package]]
-name = "frozenlist"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
-    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
-    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
-    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
-    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
-    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
-    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
-    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
-    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
-    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
-]
-
-[[package]]
-name = "gpiod"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/c2/c7bc26965855f39ae3e1b09b404a1fdc3b172dac371012c316f5b9b6a314/gpiod-2.5.0.tar.gz", hash = "sha256:53ae5a1f14d6388c155b591ca0fc0cfa73b44d4f6d8d117e8a9e68f5902d187a", size = 75527, upload-time = "2026-06-17T07:46:25.985Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/77/c713b1ef7c033081c564b9c4c9947d5e6e66f887dd8d2ec4c9db37f6c867/gpiod-2.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c23e246249f78628bcda026349e58e5414fa33c46ec30d214f51ac911c9e557e", size = 115749, upload-time = "2026-06-17T07:46:16.653Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/2f/12fc27a96f41cd0faa92db82732de6761c922da454543bcab826e690c761/gpiod-2.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8faf1337e74871980377ba19283d5f6cddec14d15b3741dca0981e98bf37f07b", size = 115267, upload-time = "2026-06-17T07:46:17.698Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/bb/66266c13df04cc6467809dd099f3c30f3ef98a19a5d6e7b2445e56fbb56d/gpiod-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:087a7a81f3875c70a11691cc705321f7764358f6fb320e7e801b2c16b4e01d98", size = 113773, upload-time = "2026-06-17T07:46:18.819Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/cf/bf30830aecba9eb146d7bf1054ed08dacf1468891ef375689174e351b564/gpiod-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:36810ddf5ad35d30eef75c8c317339b1da8e8faf799953406925fa6777f82de2", size = 113611, upload-time = "2026-06-17T07:46:19.988Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/e3/c22faee30bd2341be94f8426b1829e141e1da4f24113aeeed77bcd0134c1/gpiod-2.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30331f030422aa400670a9c004a64e3e2f715a2c03b61ee349fe94730b75d2f9", size = 122174, upload-time = "2026-06-17T07:46:21.323Z" },
-    { url = "https://files.pythonhosted.org/packages/25/5c/0245ab49b43d57d93fcf57504b728429f92a083d876bfcc1b42167417682/gpiod-2.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34db3048b6e293ec387e7687e4027c9add8d55441bbaeb2d92cbcb528238dfc3", size = 120230, upload-time = "2026-06-17T07:46:22.45Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/40/9d1786c5b1e0f8664f6d2e56de95cd43dceb430514e95c47137bda564133/gpiod-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:48e41ba6883fcf136bfae411440b3b05b211e84a751b4733a139ce9d90f920e1", size = 119723, upload-time = "2026-06-17T07:46:23.541Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/4f634d271e24138fe8bbc3aa890aa768efc03e98ee2bac8ded9ba0a27715/gpiod-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72b768c1f847a5c75f301920d690e408120f4b0ceafe91304cadcd571f9c3e04", size = 118557, upload-time = "2026-06-17T07:46:24.744Z" },
-]
-
-[[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
-]
-
-[[package]]
-name = "jsonschema"
-version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
-]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "multidict"
-version = "6.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
-    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
-    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
-    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
-    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
-    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
-    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
-    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "propcache"
-version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
-    { url = "https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
-    { url = "https://files.pythonhosted.org/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
-    { url = "https://files.pythonhosted.org/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
-    { url = "https://files.pythonhosted.org/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
-    { url = "https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
-    { url = "https://files.pythonhosted.org/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
-    { url = "https://files.pythonhosted.org/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
-    { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
 ]
 
 [[package]]
@@ -510,104 +146,21 @@ wheels = [
 ]
 
 [[package]]
-name = "pyreadline3"
-version = "3.5.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
-]
-
-[[package]]
-name = "pywin32"
-version = "312"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
-    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
-    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
-]
-
-[[package]]
-name = "referencing"
-version = "0.37.0"
+name = "pygbl"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
+    { name = "pyelftools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/50/92a582eedf3a825fd4ac3ad7de7130b44e1fcad2ee94039ec3e34225c48f/pygbl-1.0.0.tar.gz", hash = "sha256:d1d85932d583519d1b311796048a2b1b27264b881ab773a156dae5f2800e1e92", size = 7720896, upload-time = "2026-08-07T00:38:26.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f5/e6b8f178ef8c7ff6dc3bdaea499e57cd2f03b01d9665d25e89db33abacc4/pygbl-1.0.0-py3-none-any.whl", hash = "sha256:75590e5ab19240387a80d133a25ae46685ab6eb033d21c1b26e5ccf91a1b3e9e", size = 28976, upload-time = "2026-08-07T00:38:25.554Z" },
 ]
 
-[[package]]
-name = "rpds-py"
-version = "2026.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
-    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
-    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
-    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
-    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
-    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
-    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
-    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
-    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
-    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
-    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
-    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
-    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
-    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+[package.optional-dependencies]
+all = [
+    { name = "cryptography" },
+    { name = "lz4" },
 ]
 
 [[package]]
@@ -620,154 +173,18 @@ wheels = [
 ]
 
 [[package]]
-name = "serialx"
-version = "1.8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/80/778c6da23924b718c282024bcde331cf8e417ec1274d2f198f65cff7503a/serialx-1.8.2.tar.gz", hash = "sha256:90c912ec8ceb4ae26a7dca158ca21e5bd8d73ddfc93c5e8d8b101a22ddccbb9a", size = 695526, upload-time = "2026-06-12T16:06:57.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/4b/b4c05bfbe7021874f4f8b007d0057bf50e92854d63bb1dab07fd3677e376/serialx-1.8.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d2904605e59357b9815aaa70828f28429767821638fceef228f32b8fca9ffb5c", size = 285301, upload-time = "2026-06-12T16:06:48.23Z" },
-    { url = "https://files.pythonhosted.org/packages/38/32/e6998be005770fbefd71bd3b9e095eb3a4fc055649967dcf82a6747fb6dc/serialx-1.8.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:abaee5c042194eaf95466e8e5eec6920af2eb0dbc00b91f1d765a0602bfd0d23", size = 282856, upload-time = "2026-06-12T16:06:49.91Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d5/598fc77e904c584e4420cc4be7878292f595f40e6f32092649d7cd580f28/serialx-1.8.2-cp310-abi3-win32.whl", hash = "sha256:42cd054add10e390856608a6b0abb3bdf1b8aa078f26f60d7fcd852603f91417", size = 183863, upload-time = "2026-06-12T16:06:51.191Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1d/8dfbd66cdf4129d991574c4ebcd502636b178e408a41cdf8ebc04353cab5/serialx-1.8.2-cp310-abi3-win_amd64.whl", hash = "sha256:3e098c502639c7b220c419634101f28b9878a82fcee0cf06e074abb3e97f2c3e", size = 189886, upload-time = "2026-06-12T16:06:52.792Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b9/138584b89a109f4e4ce82176380b44a748808033d55c9cbb1b39de0f52eb/serialx-1.8.2-cp310-abi3-win_arm64.whl", hash = "sha256:36f82e21c9b0215beae4c983d221071a44ecdcf2f7a98c659af596ff7adbaa65", size = 186459, upload-time = "2026-06-12T16:06:54.283Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/90/9cd83042a221756e41ed8c018344e8833788c16e9bac144dab3292f9fa3c/serialx-1.8.2-py3-none-any.whl", hash = "sha256:6e6cffc1caec242fb06d8e16dd7880c8ba53c366ee2c43045fc38e8935ac8a6d", size = 66674, upload-time = "2026-06-12T16:06:55.724Z" },
-]
-
-[[package]]
 name = "silabs-firmware-builder"
 version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pyelftools" },
+    { name = "pygbl", extra = ["all"] },
     { name = "ruamel-yaml" },
-    { name = "universal-silabs-flasher" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pyelftools" },
+    { name = "pygbl", extras = ["all"], specifier = ">=1.0.0" },
     { name = "ruamel-yaml" },
-    { name = "universal-silabs-flasher", specifier = ">=0.0.25" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.70.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
-]
-
-[[package]]
-name = "universal-silabs-flasher"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "bellows" },
-    { name = "coloredlogs" },
-    { name = "crc" },
-    { name = "gpiod", marker = "sys_platform == 'linux'" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-    { name = "zigpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/eb/1e1fb2bfee0da37fe72afb9100fe1db5e5b5ce446f59e452e6e03a52a705/universal_silabs_flasher-1.1.0.tar.gz", hash = "sha256:35bfcbf6314641d66fcd4745e7b6d3faef9e61844fb9d36b883260d0093cb4a3", size = 60016, upload-time = "2026-04-20T17:21:39.954Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a8/b69c630237cd777416a2183777af707c0ed534fc3c525b595343e2bc46c1/universal_silabs_flasher-1.1.0-py3-none-any.whl", hash = "sha256:e0aedb6e0f65992032169046c73fde54664855d8732faab660a614d30acd2cf8", size = 52310, upload-time = "2026-04-20T17:21:38.831Z" },
-]
-
-[[package]]
-name = "voluptuous"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/f4/0738e6849858deae22218be3bbb8207ba83a96e9d0ec7e8e8cd67b30e5ca/voluptuous-0.16.0.tar.gz", hash = "sha256:006535e22fed944aec17bef6e8725472476194743c87bd233e912eb463f8ff05", size = 54238, upload-time = "2025-12-18T23:18:46.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/00/0e0da784245c93cf346150ab67634177bf277f93b7a162bb56c928c39c04/voluptuous-0.16.0-py3-none-any.whl", hash = "sha256:ee342095263e1b5afbd4d418cb5adc92810eebfd07696bb033a261210df33db4", size = 31931, upload-time = "2025-12-18T23:18:44.694Z" },
-]
-
-[[package]]
-name = "yarl"
-version = "1.24.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/33/ebe9e3d1f86c7a0b51094c0a146392045ca1631d2664889539dec8088a33/yarl-1.24.5.tar.gz", hash = "sha256:e81b83143bee16329c23db3c1b2d82b29892fcbcb849186d2f6e98a5abe9a57f", size = 228679, upload-time = "2026-07-20T02:07:45.435Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/08/5f3085fef9564217074db9dd8573de1795bc82cde61a7ad10b6a7234a569/yarl-1.24.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2729fcfc4f6a596fb0c50f32090400aa9367774ac296a00387e65098c0befa76", size = 135680, upload-time = "2026-07-20T02:06:33.273Z" },
-    { url = "https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff330d3c30db4eb6b01d79e29d2d0b407a7ecad39cfd9ec993ece57396a2ec0d", size = 97395, upload-time = "2026-07-20T02:06:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a9/a07f76f3c44e02b25cc743af5ef93eef27f7013eadca770451b6a6ccb5db/yarl-1.24.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e42d75862735da90e7fc5a7b23db0c976f737113a54b3c9777a9b665e9cbff75", size = 97223, upload-time = "2026-07-20T02:06:37.216Z" },
-    { url = "https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3732e66413163e72508da9eff9ce9d2846fde51fae45d3605393d3e6cd303e9", size = 108777, upload-time = "2026-07-20T02:06:39.292Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/44/e0b86c302471fabd6f02808ecf2ac52b8412b624787849d4bf2cdb466f6f/yarl-1.24.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5b8ee53be440a0cffc991a27be3057e0530122548dbe7c0892df08822fce5ede", size = 103119, upload-time = "2026-07-20T02:06:41.456Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/16/9c16d180bf8faaf223225eb50e1245870ff1ae0e302a27153988e65c51fd/yarl-1.24.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:af3aefa655adb5869491fa907e652290386800ae99cc50095cba71e2c6aefdca", size = 116471, upload-time = "2026-07-20T02:06:43.696Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/8d/b219b9df28a02ce95cfbdd41d2f7caa5669d0ff979c1c9975697145e33c5/yarl-1.24.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2120b96872df4a117cde97d270bac96aea7cc52205d305cf4611df694a487027", size = 115974, upload-time = "2026-07-20T02:06:45.874Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66410eb6345d467151934b49bfa70fb32f5b35a6140baa40ad97d6436abea2e9", size = 110830, upload-time = "2026-07-20T02:06:47.852Z" },
-    { url = "https://files.pythonhosted.org/packages/db/18/199b85109a53eeca64ee19c9cca228287e8e4ab0cc1a09b28f530e65cce0/yarl-1.24.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4af7b7e1be0a69bee8210735fe6dcfc38879adfac6d62e789d53ba432d1ffa41", size = 110054, upload-time = "2026-07-20T02:06:49.84Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/2f/ed28147f8cd7f48c49367c90713b30a555284b6105a6a56f3a05568da795/yarl-1.24.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa139875ff98ab97da323cfadfaff08900d1ad42f1b5087b0b812a55c5a06373", size = 108312, upload-time = "2026-07-20T02:06:51.835Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/c5/55e16ae0a5c227cea8df1c6871ba57d614a34243146c05729caf2a1bd9c5/yarl-1.24.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0055afc45e864b92729ac7600e2d102c17bef060647e74bca75fa84d66b9ff36", size = 103662, upload-time = "2026-07-20T02:06:54.061Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/ea/dbd7c2caec459c9a426f18b02688ecbfb58620d0f6a3422d24769fbaf8ab/yarl-1.24.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f0e466ed7511fe9d459a819edbc6c2585c0b6eabde9fa8a8947552468a7a6ef0", size = 116090, upload-time = "2026-07-20T02:06:56.015Z" },
-    { url = "https://files.pythonhosted.org/packages/06/84/39ce4ce3059e07fece5fbdbee8c4053406af9aca911ce9fa5f8548aab6af/yarl-1.24.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f141474e85b7e54998ec5180530a7cda99ab29e282fa50e0756d89981a9b43c5", size = 109523, upload-time = "2026-07-20T02:06:57.926Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/8b/71ff44137b405c64a7788075669c24010019f57a7464b78c3a6cbee539d9/yarl-1.24.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e2935f8c39e3b03e83519292d78f075189978f3f4adc15a78144c7c8e2a1cba5", size = 116084, upload-time = "2026-07-20T02:06:59.868Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c0/423078fdd4042e1862c11f0ffd977a0ffa393783c12bee94685923bc189e/yarl-1.24.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d1216a7f6f77836617dba35687c5b78a4170afc3c3f18fc788f785ba26565c4", size = 111006, upload-time = "2026-07-20T02:07:01.907Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl", hash = "sha256:5ba4f78df2bcc19f764a4b26a8a4f5049c110090ad5825993aacb052bf8003ad", size = 99215, upload-time = "2026-07-20T02:07:03.852Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0e/464a847d7359e0da75dd9fc5c1d1aa35d0159ea31e5f8e66a3c1c29ff3d0/yarl-1.24.5-cp314-cp314-win_arm64.whl", hash = "sha256:9e4e16c73d717c5cf27626c524d0a2e261ad20e46932b2670f64ad5dde23e26f", size = 94566, upload-time = "2026-07-20T02:07:06.074Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/55/e03acc4446772660bc335e86e41ef31e4d0d838fd641531a11a5ee33b493/yarl-1.24.5-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e1ae548a9d901adca07899a4147a7c826bbcc06239d3ce9a59f57886a28a4c88", size = 142533, upload-time = "2026-07-20T02:07:08.284Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/71/4acd3a1fc7cf14345cdb302665ecd2097f62c365b4f14ca17d4f37775cf9/yarl-1.24.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff405d91509d88e8d44129cd87b18d70acd1f0c1aeabd7bc3c46792b1fe2acba", size = 100776, upload-time = "2026-07-20T02:07:10.197Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0b/cfb76b7fe99686db264bff829779a539d923e7564ffd7ef18da6c54c3774/yarl-1.24.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:47e98aab9d8d82ff682e7b0b5dded33bf138a32b817fcf7fa3b27b2d7c412928", size = 100913, upload-time = "2026-07-20T02:07:12.357Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/3f/7116e782992abbd4fb6948488aec72078895e929a23078290739e8396fce/yarl-1.24.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f0a658a6d3fafee5c6f63c58f3e785c8c43c93fbc02bf9f2b6663f8185e0971f", size = 106507, upload-time = "2026-07-20T02:07:14.173Z" },
-    { url = "https://files.pythonhosted.org/packages/33/90/d4d2d73ee78229cc889872eb8e085d8f5c6f51abdb178409fd9b23cf74fd/yarl-1.24.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4377407001ca3c057773f44d8ddd6358fa5f691407c1ba92210bd3cf8d9e4c95", size = 99219, upload-time = "2026-07-20T02:07:16.019Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/fa/a6df1a9bccd644eec00abee0dff4277416222cec435330fd1f2858523ec1/yarl-1.24.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7c0494a31a1ac5461a226e7947a9c9b78c44e1dc7185164fa7e9651557a5d9bc", size = 111804, upload-time = "2026-07-20T02:07:18.141Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/9e/7b2a1f4bcc20e9447156dd2b1c4d01f70d9df0759025ee7d09a84ffae134/yarl-1.24.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a7cff474ab7cd149765bb784cf6d78b32e18e20473fb7bda860bce98ab58e9da", size = 110943, upload-time = "2026-07-20T02:07:20.06Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ff/22c92affb0f9b623ca753d27d968b5625b868f12c6378d049d55ae247643/yarl-1.24.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbb833ccacdb5519eff9b8b71ee618cc2801c878e77e288775d77c3a2ced858a", size = 108251, upload-time = "2026-07-20T02:07:22.217Z" },
-    { url = "https://files.pythonhosted.org/packages/45/44/5769b96298c1e195fb412997b6090af2a84105cf59c17613558a2d011d1f/yarl-1.24.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:82f75e05912e84b7a0fe57075d9c59de3cb352b928330f2eb69b2e1f54c3e1f0", size = 106025, upload-time = "2026-07-20T02:07:24.083Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/40/009e8e791fd9762c0e1567e69248acb4f49064597e1680874c16dd8bb798/yarl-1.24.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:16a2f5010280020e90f5330257e6944bc33e73593b136cc5a241e6c1dc292498", size = 106573, upload-time = "2026-07-20T02:07:26.248Z" },
-    { url = "https://files.pythonhosted.org/packages/20/c6/b7480578f8a0a80946f36ad6df547ecec704f9ba69d2de60f8aa6f1c1cbf/yarl-1.24.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:ffcd54362564dc1a30fb74d8b8a6e5a6b11ebd5e27266adc3b7427a21a6c9104", size = 100751, upload-time = "2026-07-20T02:07:28.098Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/27/4476f3360b91a48c5cf125e91f59a3bd35299d84a431a258d57f5977bb11/yarl-1.24.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0465ec8cedc2349b97a6b595ace64084a50c6e839eca40aa0626f38b8350e331", size = 111643, upload-time = "2026-07-20T02:07:30.88Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4b/5cdd3e5ee944e8af31e52f6cd3d3af5fd7b937e036ccbbba2c9ffebede95/yarl-1.24.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4db9aecb141cb7a5447171b57aa1ed3a8fee06af40b992ffc31206c0b0121550", size = 106312, upload-time = "2026-07-20T02:07:33.06Z" },
-    { url = "https://files.pythonhosted.org/packages/18/86/f406b0c2a6f99575de2da671ef47aa06f89a5be83a27a46971c3b86cecdb/yarl-1.24.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f540c013589084679a6c7fac07096b10159737918174f5dfc5e11bf5bca4dfe6", size = 110379, upload-time = "2026-07-20T02:07:35.155Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/6c/9f3adfbd3b30b4fa0f7ccb3a83eba2c1152d3fff554d535e640ba0f7ba2b/yarl-1.24.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a61834fb15d81322d872eaafd333838ae7c9cea84067f232656f75965933d047", size = 108497, upload-time = "2026-07-20T02:07:37.35Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
-    { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
-]
-
-[[package]]
-name = "zigpy"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "aiosqlite" },
-    { name = "attrs" },
-    { name = "crccheck" },
-    { name = "cryptography" },
-    { name = "frozendict" },
-    { name = "jsonschema" },
-    { name = "serialx" },
-    { name = "typing-extensions" },
-    { name = "voluptuous" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/f9/1d26fc086bcfb8142e621c51cfdd8a393a22b60b8ac4b8c2aec452b0d0de/zigpy-2.1.0.tar.gz", hash = "sha256:ccb73420c1be8825e32fe03634e496642dcaa7e6115a8b390a479b8877c9fcdd", size = 333257, upload-time = "2026-07-28T20:13:51.863Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/05/d0e72683d31f079508b4492cb7b9df5f2cf8423fc1cdaec9c89a2dab6910/zigpy-2.1.0-py3-none-any.whl", hash = "sha256:868f670bbf1e61c715893be4a996035d68918ebbc66c2f3e2c0475fe0dcce97a", size = 251969, upload-time = "2026-07-28T20:13:50.679Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -147,14 +147,14 @@ wheels = [
 
 [[package]]
 name = "pygbl"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyelftools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/50/92a582eedf3a825fd4ac3ad7de7130b44e1fcad2ee94039ec3e34225c48f/pygbl-1.0.0.tar.gz", hash = "sha256:d1d85932d583519d1b311796048a2b1b27264b881ab773a156dae5f2800e1e92", size = 7720896, upload-time = "2026-08-07T00:38:26.923Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/1b/e0fc748c05e54b647f1a4f8af99f80dce261cfdadf9f9052d4c14eb86763/pygbl-1.0.1.tar.gz", hash = "sha256:aafd10948167ea17ff5d345172c18deeb2962d65559c63d9fd0606ec49cd0fd5", size = 7860164, upload-time = "2026-08-07T13:21:48.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/f5/e6b8f178ef8c7ff6dc3bdaea499e57cd2f03b01d9665d25e89db33abacc4/pygbl-1.0.0-py3-none-any.whl", hash = "sha256:75590e5ab19240387a80d133a25ae46685ab6eb033d21c1b26e5ccf91a1b3e9e", size = 28976, upload-time = "2026-08-07T00:38:25.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/62/0cfff6a218879da4ae766f51fc139b3256ed7ad0137b6c62f5826c4d05e1/pygbl-1.0.1-py3-none-any.whl", hash = "sha256:ea8fc6d89e249725c47fbe42bb13f4792032fe84b90de3351a9888442b1700d5", size = 29225, upload-time = "2026-08-07T13:21:46.667Z" },
 ]
 
 [package.optional-dependencies]
@@ -185,6 +185,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pyelftools" },
-    { name = "pygbl", extras = ["all"], specifier = ">=1.0.0" },
+    { name = "pygbl", extras = ["all"], specifier = ">=1.0.1" },
     { name = "ruamel-yaml" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -147,14 +147,14 @@ wheels = [
 
 [[package]]
 name = "pygbl"
-version = "1.0.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyelftools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/1b/e0fc748c05e54b647f1a4f8af99f80dce261cfdadf9f9052d4c14eb86763/pygbl-1.0.1.tar.gz", hash = "sha256:aafd10948167ea17ff5d345172c18deeb2962d65559c63d9fd0606ec49cd0fd5", size = 7860164, upload-time = "2026-08-07T13:21:48.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/a7/3627bb98b916f2f151656929aba524a2ab91bc7ece96281e8f7876da4df8/pygbl-1.1.0.tar.gz", hash = "sha256:83cee49e964264281902a3bc134d81fbad5bf295d275e580319328c9af60fadc", size = 7989150, upload-time = "2026-08-07T22:25:04.633Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/62/0cfff6a218879da4ae766f51fc139b3256ed7ad0137b6c62f5826c4d05e1/pygbl-1.0.1-py3-none-any.whl", hash = "sha256:ea8fc6d89e249725c47fbe42bb13f4792032fe84b90de3351a9888442b1700d5", size = 29225, upload-time = "2026-08-07T13:21:46.667Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e9/7df6628852fdf18a66507daa71cf7f771a718338c3eff99a446423b3dfd3/pygbl-1.1.0-py3-none-any.whl", hash = "sha256:629e5625518c044ab10716dddcc6b6972aa5f83ffb8ad6fd7e42a2f4cf3e7b3c", size = 29717, upload-time = "2026-08-07T22:25:03.156Z" },
 ]
 
 [package.optional-dependencies]
@@ -185,6 +185,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pyelftools" },
-    { name = "pygbl", extras = ["all"], specifier = ">=1.0.1" },
+    { name = "pygbl", extras = ["all"], specifier = ">=1.1.0" },
     { name = "ruamel-yaml" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -147,14 +147,14 @@ wheels = [
 
 [[package]]
 name = "pygbl"
-version = "1.1.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyelftools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/a7/3627bb98b916f2f151656929aba524a2ab91bc7ece96281e8f7876da4df8/pygbl-1.1.0.tar.gz", hash = "sha256:83cee49e964264281902a3bc134d81fbad5bf295d275e580319328c9af60fadc", size = 7989150, upload-time = "2026-08-07T22:25:04.633Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/49/b15b3fdbd1e3249db5c1294285654c859c1d87540927ba34de64ceb73c98/pygbl-1.2.0.tar.gz", hash = "sha256:fd3ec9afbb4fffaae602d3ac2401da378f1868eb53f7dc22203f93dea6f5d3b5", size = 7989338, upload-time = "2026-08-09T18:53:10.047Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/e9/7df6628852fdf18a66507daa71cf7f771a718338c3eff99a446423b3dfd3/pygbl-1.1.0-py3-none-any.whl", hash = "sha256:629e5625518c044ab10716dddcc6b6972aa5f83ffb8ad6fd7e42a2f4cf3e7b3c", size = 29717, upload-time = "2026-08-07T22:25:03.156Z" },
+    { url = "https://files.pythonhosted.org/packages/40/86/180182ccb6f1158535b158eb44f4c99ff09264cbb9746822f242a3cb9dc5/pygbl-1.2.0-py3-none-any.whl", hash = "sha256:a3fe099fb5ecda44e650f589a6c4b51bb7c8d98f15e97f779ad6b634b9c0642b", size = 29684, upload-time = "2026-08-09T18:53:07.974Z" },
 ]
 
 [package.optional-dependencies]
@@ -185,6 +185,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pyelftools" },
-    { name = "pygbl", extras = ["all"], specifier = ">=1.1.0" },
+    { name = "pygbl", extras = ["all"], specifier = ">=1.2.0" },
     { name = "ruamel-yaml" },
 ]


### PR DESCRIPTION
This PR drops Silicon Labs' `commander` binary as a dependency, replacing it with https://github.com/zigpy/pygbl. It generates byte-identical GBLs for all of our chips and fully supports both signing and encryption. Now that we've migrated away from Makefiles and directly to CMake, we can get rid of running `create_gbl.py` as a script and instead use it as a normal Python module (opening up the possibility of [easier firmware signing](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/cloudhsm/)).

At this point the only SiLabs binary is `slc`, which is a cross-platform Java application with a few OSS binary components that can be swapped out if SiLabs stops distributing the remaining ARM64 builds. Maybe https://github.com/AlCalzone/slc can break this dependency as well 😄.

---

Since this change more explicitly supports LLVM as a backend (as opposed to a hacked-in flag), here are the GBL sizes for each firmware:
  | Manifest | GCC 14.2.1 | LLVM 21.1.1 | Δ vs GCC |
  | --- | ---: | ---: | ---: |
  | `zbt2_bootloader` | 12,164 | 11,884 | −2.30% |
  | `zbt2_openthread_rcp` | 139,316 | 125,644 | **−9.81%** |
  | `zbt2_router` | 372,640 | 376,768 |  1.11% |
  | `zbt2_zigbee_ncp` | 273,600 | 284,924 |  4.14% |
  | `zwa2_controller` | 147,748 | 145,708 | −1.38% |
  | `yellow_bootloader` | 11,716 | 11,372 | −2.94% |
  | `yellow_openthread_rcp` | 103,296 | 101,712 | −1.53% |
  | `yellow_zigbee_ncp` | 249,400 | 263,320 |  **5.58%** |
  | `skyconnect_bootloader` | 11,652 | 11,308 | −2.95% |
  | `skyconnect_openthread_rcp` | 106,584 | 100,456 | −5.75% |
  | `skyconnect_zigbee_ncp` | 252,756 | 262,092 |  3.69% |

Overall, it looks like Zigbee firmwares grow a little but everything else shrinks. The runtime impact is untested (and probably untestable without synthetic benchmarks).