### PR TITLE
Add ZWA-2 bootloader manifest

### DIFF
--- a/manifests/nabucasa/zwa2/config/README.md
+++ b/manifests/nabucasa/zwa2/config/README.md
@@ -1,0 +1,9 @@
+# ZWA-2 signing keys
+
+`keys` is a symlink to `src/zwa2_controller/keys`, the canonical copy of the
+ZWA-2 vendor keys.
+
+The bootloader manifest pulls the keys in from here via its `config_file`
+section. It cannot use the controller's approach of listing them in the base
+project's slcp, because its base project `src/bootloader` is shared with the
+other boards' bootloader manifests.

--- a/manifests/nabucasa/zwa2/config/keys
+++ b/manifests/nabucasa/zwa2/config/keys
@@ -1,0 +1,1 @@
+../../../../src/zwa2_controller/keys

--- a/manifests/nabucasa/zwa2/zwa2_bootloader.yaml
+++ b/manifests/nabucasa/zwa2/zwa2_bootloader.yaml
@@ -1,0 +1,54 @@
+name: Home Assistant Connect ZWA-2 Bootloader
+device: EFR32ZG23A020F512GM40
+base_project: src/bootloader
+filename: "{manifest_name}_{gecko_bootloader_version}"
+sdk: "simplicity_sdk:2026.6.1"
+toolchain: "gcc:14.2.1.20241119"
+
+gbl:
+  fw_type: gecko-bootloader
+  gecko_bootloader_version: dynamic
+  encrypt_key: config/keys/vendor_encrypt.key
+  sign_key: config/keys/vendor_sign.key
+  compression: lzma
+
+# Signing/encryption keys, shared with the ZWA-2 application firmwares
+config_file:
+  - path: config/keys/vendor_encrypt.key
+    directory: keys
+  - path: config/keys/vendor_sign.key
+    directory: keys
+
+sdk_patches:
+  # Adds a "4. erase nvm" command to the bootloader menu
+  - xmodem-erase-nvm.patch
+
+add_components:
+  - id: bootloader_compression_lzma
+
+configuration:
+  BOOTLOADER_ENFORCE_SIGNED_UPGRADE: 1
+  BOOTLOADER_WRITE_DISABLE: 1
+  # Reset to 1 when bumping the SDK version. Bump when modifying the bootloader
+  # without bumping the SDK version.
+  # We use 1 to signify that this is not the stock Gecko Bootloader.
+  BOOTLOADER_VERSION_MAIN_CUSTOMER: 1
+  APPLICATION_VERIFICATION_SKIP_EM4_RST: 1
+  BOOTLOADER_FALLBACK_LEGACY_KEY: 1
+  BTL_STORAGE_BASE_ADDRESS: 134496256
+
+c_defines:
+  SL_SERIAL_UART_FLOW_CONTROL: 0
+
+  SL_SERIAL_UART_PERIPHERAL: USART0
+  SL_SERIAL_UART_PERIPHERAL_NO: 0
+
+  SL_SERIAL_UART_TX_PORT: gpioPortA
+  SL_SERIAL_UART_TX_PIN:  8
+
+  SL_SERIAL_UART_RX_PORT: gpioPortA
+  SL_SERIAL_UART_RX_PIN:  7
+
+  SL_GPIO_ACTIVATION_POLARITY: LOW
+  SL_BTL_BUTTON_PORT: gpioPortA
+  SL_BTL_BUTTON_PIN: 5

--- a/src/bootloader/CHANGELOG.md
+++ b/src/bootloader/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 3.2.1
+Updated to Simplicity SDK 2026.6.1, migrating the ZWA-2 bootloader from the standalone nc-zwave-bootloader repository.
+
+- Updated to Simplicity SDK 2026.6.1, up from Simplicity SDK 2024.12.2.
+
+# 3.0.1
+Initial ZWA-2 bootloader release based on Simplicity SDK 2024.12.2.
+
+- Standalone UART XMODEM bootloader with enforced signed and encrypted upgrades.
+- Added an "erase nvm" menu command that erases the Z-Wave NVM region while preserving the token page.
+- The bootloader can be entered through the recessed button.

--- a/src/bootloader/sdk_patches/xmodem-erase-nvm.patch
+++ b/src/bootloader/sdk_patches/xmodem-erase-nvm.patch
@@ -1,0 +1,114 @@
+diff --git a/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.h b/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.h
+index 47274eb..0777ea8 100644
+--- a/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.h
++++ b/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem.h
+@@ -67,6 +67,8 @@ typedef enum {
+   RECEIVE_DATA,
+   BOOT,
+   COMPLETE,
++  CONFIRM_ERASE_NVM,
++  ERASE_NVM,
+ } XmodemState_t;
+ 
+ /** @endcond */
+diff --git a/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem_common.c b/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem_common.c
+index 509d8e9..0b56593 100644
+--- a/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem_common.c
++++ b/bootloader/platform/bootloader/communication/xmodem-uart/btl_comm_xmodem_common.c
+@@ -24,6 +24,8 @@
+ #include "driver/btl_serial_driver.h"
+ #include "driver/btl_driver_delay.h"
+ 
++#include "core/flash/btl_internal_flash.h"
++
+ #if defined(BOOTLOADER_NONSECURE)
+ // NS headers
+   #include "core/btl_reset_ns.h"
+@@ -118,7 +120,7 @@ static int32_t receivePacket(XmodemPacket_t *packet)
+   return ret;
+ }
+ 
+-static XmodemState_t getAction(void)
++static XmodemState_t getAction(bool confirm_erase)
+ {
+   uint8_t c;
+   XmodemState_t state;
+@@ -138,6 +140,17 @@ static XmodemState_t getAction(void)
+     case '3':
+       state = MENU;
+       break;
++    case '4': {
++      char str[] = "\r\nAre you sure? (y/n) > ";
++      uart_sendBuffer((uint8_t *)str, sizeof(str), true);
++      return CONFIRM_ERASE_NVM;
++      break;
++    }
++    case 'y':
++      if (confirm_erase) {
++        return ERASE_NVM;
++      }
++      // Fall through
+     default:
+       state = MENU;
+       break;
+@@ -248,6 +261,7 @@ int32_t bootloader_xmodem_communication_start(void)
+                "1. upload gbl\r\n"
+                "2. run\r\n"
+                "3. ebl info\r\n"
++               "4. erase nvm\r\n"
+                "BL > ";
+ 
+   uint32_t version = bootload_getBootloaderVersion();
+@@ -269,6 +283,7 @@ int32_t bootloader_xmodem_communication_main(ImageProperties_t *imageProps,
+   XmodemState_t state = IDLE;
+   XmodemReceiveBuffer_t buf;
+   uint8_t response = 0;
++  bool confirm_erase = false;
+   int packetTimeout = 60;
+ #if BTL_XMODEM_IDLE_TIMEOUT > 0
+   int idleTimeout = BTL_XMODEM_IDLE_TIMEOUT;
+@@ -295,7 +310,7 @@ int32_t bootloader_xmodem_communication_main(ImageProperties_t *imageProps,
+ 
+       case IDLE:
+         // Get user input
+-        state = getAction();
++        state = getAction(confirm_erase);
+ 
+ #if BTL_XMODEM_IDLE_TIMEOUT > 0
+         if (state == IDLE) {
+@@ -501,6 +516,35 @@ int32_t bootloader_xmodem_communication_main(ImageProperties_t *imageProps,
+         handleBootState(imageProps, &parserContext);
+ #endif
+         break;
++
++      case CONFIRM_ERASE_NVM:
++        confirm_erase = true;
++        state = IDLE;
++        break;
++
++      case ERASE_NVM:
++        // Erase NVM
++        // The address and size can be determined from the .map files after firmware compilation.
++        // Right now, those are either:
++        // - Controller 0x08074000, size 0xa000
++        // - End device 0x08076000, size 0x8000
++        // ...which both end at address 0x0807dfff
++        uint32_t nvm_address = 0x08074000;
++        uint32_t nvm_size = 0x0000a000;
++
++        // Erase all pages that start inside the write range
++        for (uint32_t pageAddress = nvm_address & ~(FLASH_PAGE_SIZE - 1UL);
++            pageAddress < (nvm_address + nvm_size);
++            pageAddress += FLASH_PAGE_SIZE) {
++          flash_erasePage(pageAddress);
++        }
++
++        char str[] = "\r\nNVM erased\r\n";
++        uart_sendBuffer((uint8_t *)str, sizeof(str), true);
++
++        confirm_erase = false;
++        state = MENU;
++        break;
+     }
+   }
+ }


### PR DESCRIPTION
Ports the ZWA-2 OTW bootloader from the standalone [nc-zwave-bootloader](https://github.com/NabuCasa/nc-zwave-bootloader) repository, updating it from Simplicity SDK 2024.12.2 to 2026.6.1.

The manifest reuses the shared `src/bootloader` project with Z-Wave specific modifications on top.