### PR TITLE
Add ZWA-2 Z-Wave repeater firmware

### DIFF
--- a/manifests/nabucasa/zwa2/zwa2_repeater.yaml
+++ b/manifests/nabucasa/zwa2/zwa2_repeater.yaml
@@ -1,0 +1,80 @@
+name: Home Assistant Connect ZWA-2 Z-Wave Repeater
+device: EFR32ZG23A020F512GM40
+base_project: src/zwa2_repeater
+filename: "{manifest_name}_{zwave_version}"
+sdk: "simplicity_sdk:2026.6.1"
+toolchain: "gcc:14.2.1.20241119"
+gbl:
+  fw_type: zwave_repeater
+  zwave_version: dynamic
+  encrypt_key: config/keys/vendor_encrypt.key
+  sign_key: config/keys/vendor_sign.key
+  compression: lzma
+
+sdk_patches:
+  # Restore the persisted LED color from NVM at startup
+  - cc-color-switch-restore-from-nvm.patch
+
+sdk_extension:
+  - id: nabucasa_hardware
+    vendor: nabucasa
+    version: 1.0.0
+
+add_components:
+  - id: spidrv_eusart
+    instance: [ws2812]
+  - id: ws2812_driver
+    vendor: nabucasa
+    package: nabucasa_hardware
+
+# SLC reads `configuration` during validation, before c_defines are patched
+configuration:
+  SL_SPIDRV_EUSART_WS2812_CS_CONTROL: spidrvCsControlApplication
+
+c_defines:
+  # Z-Wave device identity
+  ZAF_CONFIG_MANUFACTURER_ID: '0x0466'
+  ZAF_CONFIG_PRODUCT_TYPE_ID: '0x0001'
+  ZAF_CONFIG_PRODUCT_ID: '0x0001'
+
+  # Firmware version
+  USER_APP_VERSION: 1
+  USER_APP_REVISION: 3
+  USER_APP_PATCH: 0
+
+  # Default RF region and TX power
+  ZW_REGION: REGION_EU
+  APP_MAX_TX_POWER: 130
+
+  # The ZWA-2 hardware runs the DC-DC converter in bypass mode. Since Z-Wave
+  # SDK 8.1.0, this setting is applied at startup and would otherwise switch
+  # the converter dynamically.
+  ZW_DCDC_CONFIG: EDCDCMODE_BYPASS
+
+  # Button
+  SL_SIMPLE_BUTTON_INSTANCE0_PORT: SL_GPIO_PORT_C
+  SL_SIMPLE_BUTTON_INSTANCE0_PIN: 5
+
+  # USART0 CLI pins
+  SL_IOSTREAM_USART_INST_PERIPHERAL: USART0
+  SL_IOSTREAM_USART_INST_PERIPHERAL_NO: 0
+  SL_IOSTREAM_USART_INST_TX_PORT: SL_GPIO_PORT_A
+  SL_IOSTREAM_USART_INST_TX_PIN: 8
+  SL_IOSTREAM_USART_INST_RX_PORT: SL_GPIO_PORT_A
+  SL_IOSTREAM_USART_INST_RX_PIN: 7
+
+  # WS2812 LED driver
+  SL_SPIDRV_EUSART_WS2812_PERIPHERAL: EUSART1
+  SL_SPIDRV_EUSART_WS2812_PERIPHERAL_NO: 1
+  SL_SPIDRV_EUSART_WS2812_TX_PORT: SL_GPIO_PORT_C
+  SL_SPIDRV_EUSART_WS2812_TX_PIN: 2
+  SL_SPIDRV_EUSART_WS2812_RX_PORT: SL_GPIO_PORT_C
+  SL_SPIDRV_EUSART_WS2812_RX_PIN: 1
+  SL_SPIDRV_EUSART_WS2812_SCLK_PORT: SL_GPIO_PORT_D
+  SL_SPIDRV_EUSART_WS2812_SCLK_PIN: 2
+  SL_SPIDRV_EUSART_WS2812_CS_CONTROL: spidrvCsControlApplication
+  SL_SPIDRV_EUSART_WS2812_BITRATE: 3200000
+  SL_SPIDRV_EUSART_WS2812_BIT_ORDER: spidrvBitOrderMsbFirst
+  WS2812_EN_PORT: gpioPortC
+  WS2812_EN_PIN: 3
+  WS2812_NUM_LEDS: 4

--- a/src/zwa2_repeater/CHANGELOG.md
+++ b/src/zwa2_repeater/CHANGELOG.md
@@ -1,0 +1,14 @@
+# 1.3.0
+* Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1)
+* The LEDs are now driven by the shared WS2812 driver from the nabucasa_hardware SDK extension, controlled by a timer instead of a dedicated task
+* The default RF region is now EU
+* Reconcile the persisted Z-Wave S2 identity with the manufacturing tokens on startup
+
+# 1.2.0
+* Match how the controller firmware adjusts region and powerlevels
+
+# 1.1.0
+* Added a CLI command to change the RF region
+
+# 1.0.0
+* Initial release based on Simplicity SDK 2024.12.1

--- a/src/zwa2_repeater/README.md
+++ b/src/zwa2_repeater/README.md
@@ -1,0 +1,21 @@
+# Home Assistant Connect ZWA-2 Z-Wave Repeater
+
+Z-Wave repeater firmware for the Home Assistant Connect ZWA-2. It turns the
+stick into an always-on Z-Wave end device that repeats frames for the network.
+
+The project is based on the Z-Wave LED Bulb sample application:
+
+- Dimming support is removed. The on-board button toggles learn mode on a
+  short press and factory-resets on a very long press.
+- The RGB LEDs are driven by the shared WS2812 driver from the
+  `nabucasa_hardware` SDK extension. The LED color can be controlled remotely
+  through Color Switch CC, and the Indicator CC blinks the LEDs to identify
+  the device.
+- A CLI on the USB serial port allows changing the RF region and TX power,
+  which are persisted in NVM (`set_region`, `set_powerlevel`, `bootloader`,
+  ...).
+
+## Versioning
+
+The firmware version is defined in the `zwa2_repeater.yaml` manifest through
+`USER_APP_VERSION`, `USER_APP_REVISION` and `USER_APP_PATCH`.

--- a/src/zwa2_repeater/app.c
+++ b/src/zwa2_repeater/app.c
@@ -1,0 +1,241 @@
+/**
+ * Z-Wave Application Repeater
+ *
+ * A repeater application for the Home Assistant Connect ZWA-2, based on the
+ * Z-Wave LED Bulb sample application.
+ *
+ * @copyright 2020 Silicon Laboratories Inc.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "MfgTokens.h"
+#include "zpal_log.h"
+#include "ZW_system_startup_api.h"
+#include "ZAF_Common_helper.h"
+#include "ZAF_Common_interface.h"
+#include "ZAF_network_learn.h"
+#include "events.h"
+#include "zpal_watchdog.h"
+#include "board_indicator.h"
+#include "zw_region_config.h"
+#include "ZAF_ApplicationEvents.h"
+#include "zaf_event_distributor_soc.h"
+#include "zpal_misc.h"
+#include "zaf_protocol_config.h"
+#include "ZAF_PrintAppInfo.h"
+#include "ZAF_nvm_app.h"
+#include "board_indicator_control.h"
+#include "repeater_config_nvm.h"
+#include "CC_ColorSwitch.h"
+#include "cc_color_switch_config_api.h"
+#include "cc_color_switch_io.h"
+#include "zwave_identity.h"
+#include "btl_interface.h"
+#include "app_hw.h"
+
+#if defined(SL_COMPONENT_CATALOG_PRESENT)
+#include "sl_component_catalog.h"
+#endif
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
+#ifdef SL_CATALOG_ZW_CLI_COMMON_PRESENT
+#include "zw_cli_common.h"
+#endif
+
+static void ApplicationTask(SApplicationHandles* pAppHandles);
+
+bool m_indicator_active_from_cc = false;
+
+bool restore_color_switch_cc_state() {
+  s_colorComponent* components = cc_color_switch_get_colorComponents();
+  for (int i = 0; i < cc_color_switch_get_length_colorComponents(); i++) {
+    bool result = cc_color_switch_read(i, &components[i]);
+    if (!result) {
+      return false;
+    }
+  }
+
+  uint8_t red = ZAF_Actuator_GetCurrentValue(&components[0].obj);
+  uint8_t green = ZAF_Actuator_GetCurrentValue(&components[1].obj);
+  uint8_t blue = ZAF_Actuator_GetCurrentValue(&components[2].obj);
+
+  if (red != 0 || green != 0 || blue != 0) {
+    rgb_t color = {
+        .R = red,
+        .G = green,
+        .B = blue
+    };
+    set_idle_color(&color);
+  }
+
+  return true;
+}
+
+
+/**
+ * @brief See description for function prototype in ZW_basis_api.h.
+ */
+ZW_APPLICATION_STATUS ApplicationInit(__attribute__((unused)) zpal_reset_reason_t eResetReason)
+{
+  SRadioConfig_t* RadioConfig;
+  zpal_radio_region_t regionMfg;
+
+  zpal_watchdog_init();
+  zpal_enable_watchdog(true);
+
+  ZPAL_LOG_INFO(ZPAL_LOG_APP, "ApplicationInit eResetReason = %d\n", eResetReason);
+
+  RadioConfig = zaf_get_radio_config();
+
+  bool nvm_init_done = ZAF_nvm_app_init();
+
+  // Mirror how the controller firmware handles radio settings,
+  // namely using the mfg token only as a fallback.
+  if (nvm_init_done && RepeaterConfigExists()) {
+    ReadApplicationRfRegion(&RadioConfig->eRegion);
+    ReadApplicationTxPowerlevel(&RadioConfig->iTxPowerLevelMax,
+                                &RadioConfig->iTxPowerLevelAdjust);
+    ReadApplicationMaxLRTxPwr(&RadioConfig->iTxPowerLevelMaxLR);
+  } else {
+    ZW_GetMfgTokenDataCountryFreq((void*) &regionMfg);
+    if (isRfRegionValid(regionMfg)) {
+      RadioConfig->eRegion = regionMfg;
+    }
+
+    if (nvm_init_done) {
+      RepeaterConfigWriteDefaults(RadioConfig);
+    }
+  }
+
+  // Repair/Reconcile the S2 identity before the protocol validates it.
+  if (!zwave_identity_reconcile(ZAF_isLongRangeRegion(RadioConfig->eRegion))) {
+    bootloader_rebootAndInstall();
+    return APPLICATION_POWER_DOWN;
+  }
+
+  /*
+   * Register the main application task.
+   *
+   * Attention: this is the only FreeRTOS task that can invoke the ZAF API.
+   *
+   * ZW_UserTask_CreateTask() can be used to create additional application tasks. See the
+   * Sensor PIR application for an example use of ZW_UserTask_CreateTask().
+   */
+  __attribute__((unused)) bool bWasTaskCreated = ZW_ApplicationRegisterTask(
+    ApplicationTask,
+    EAPPLICATIONEVENT_ZWRX,
+    EAPPLICATIONEVENT_ZWCOMMANDSTATUS,
+    zaf_get_protocol_config()
+    );
+  assert(bWasTaskCreated);
+
+  return (APPLICATION_RUNNING);
+}
+
+/**
+ * A pointer to this function is passed to ZW_ApplicationRegisterTask() making it the FreeRTOS
+ * application task.
+ */
+static void ApplicationTask(SApplicationHandles* pAppHandles)
+{
+  uint32_t unhandledEvents = 0;
+  ZAF_Init(xTaskGetCurrentTaskHandle(), pAppHandles);
+
+  ZAF_PrintAppInfo();
+
+  // Enables the button through the zw_app_hw_init event
+  app_hw_init();
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+  // Add EM1 requirement to prevent the application from entering EM2 sleep mode.
+  // The EUSART used by the WS2812 LED driver is only available in EM1.
+  sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
+#endif
+
+  // Restore Color Switch CC state from NVM - if that fails, use the default idle color
+  if (!restore_color_switch_cc_state()) {
+    Board_IndicateStatus(BOARD_STATUS_IDLE);
+  }
+
+  // Initialize other NC-specific hardware
+
+  /* Enter SmartStart*/
+  /* Protocol will commence SmartStart only if the node is NOT already included in the network */
+  ZAF_setNetworkLearnMode(E_NETWORK_LEARN_MODE_INCLUSION_SMARTSTART);
+
+  // Wait for and process events
+  ZPAL_LOG_DEBUG(ZPAL_LOG_APP, "Repeater Event processor Started\r\n");
+  for (;;)
+  {
+    unhandledEvents = zaf_event_distributor_distribute();
+    if (0 != unhandledEvents)
+    {
+      ZPAL_LOG_DEBUG(ZPAL_LOG_APP, "Unhandled Events: 0x%08lx\n", unhandledEvents);
+#ifdef UNIT_TEST
+      return;
+#endif
+    }
+  }
+}
+
+/**
+ * @brief The core state machine of this sample application.
+ * @param event The event that triggered the call of zaf_event_distributor_app_event_manager.
+ */
+void zaf_event_distributor_app_event_manager(const uint8_t event)
+{
+  ZPAL_LOG_DEBUG(ZPAL_LOG_APP, "zaf_event_distributor_app_event_manager Ev: %d\r\n", event);
+
+  switch (event)
+  {
+  case EVENT_APP_BOOTLOADER:
+    bootloader_rebootAndInstall();
+    break;
+
+  default:
+    // Unknown event - do nothing.
+    break;
+  }
+
+#ifdef SL_CATALOG_ZW_CLI_COMMON_PRESENT
+  cli_log_system_events(event);
+#endif
+}
+
+// Gets called when the current color was changed through Color Switch CC
+void cc_color_switch_cb(s_colorComponent *colorComponent)
+{
+
+  // Get the current color
+  s_colorComponent *components = cc_color_switch_get_colorComponents();
+  uint8_t red = ZAF_Actuator_GetTargetValue(&components[0].obj);
+  uint8_t green = ZAF_Actuator_GetTargetValue(&components[1].obj);
+  uint8_t blue = ZAF_Actuator_GetTargetValue(&components[2].obj);
+
+  // And merge it with the new value
+  uint8_t new_value = ZAF_Actuator_GetTargetValue(&colorComponent->obj);
+  switch (colorComponent->colorId)
+  {
+  case ECOLORCOMPONENT_RED:
+    red = new_value;
+    break;
+  case ECOLORCOMPONENT_GREEN:
+    green = new_value;
+    break;
+  case ECOLORCOMPONENT_BLUE:
+    blue = new_value;
+    break;
+  default:
+    // Unsupported color changed
+    return;
+  }
+
+  rgb_t color = {
+      green, red, blue};
+  indicator_solid(&color);
+}

--- a/src/zwa2_repeater/app_btn_handler.c
+++ b/src/zwa2_repeater/app_btn_handler.c
@@ -1,0 +1,96 @@
+/***************************************************************************//**
+ * @file
+ * @brief app_btn_handler.c
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+//                                   Includes
+// -----------------------------------------------------------------------------
+#include <events.h>
+#include <zaf_event_distributor_soc.h>
+#include "app_button_handler.h"
+
+// -----------------------------------------------------------------------------
+//                              Macros and Typedefs
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                          Static Function Declarations
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                                Global Variables
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                                Static Variables
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                          Public Functions Declarations
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                          Public Function Definitions
+// -----------------------------------------------------------------------------
+
+/**
+ * @brief Handles button 1 press events.
+ *
+ * This function is called when button 1 is pressed. It determines the duration
+ * of the press and enqueues the corresponding application event.
+ *
+ * @param duration The duration of the button press. Possible values are:
+ * - `APP_BUTTON_PRESS_DURATION_SHORT`: Short press duration.
+ * - `APP_BUTTON_PRESS_DURATION_VERYLONG`: Very long press duration.
+ *
+ * The function enqueues the following events based on the duration:
+ * - `EVENT_SYSTEM_LEARNMODE_TOGGLE` for short press.
+ * - `EVENT_SYSTEM_RESET` for very long press.
+ *
+ * If the duration does not match any of the predefined values, no event is enqueued.
+ */
+void app_button_press_btn_0_handler(uint8_t duration)
+{
+  uint8_t app_event = EVENT_EMPTY;
+
+  switch (duration) {
+    case APP_BUTTON_PRESS_DURATION_SHORT:
+      app_event = EVENT_SYSTEM_LEARNMODE_TOGGLE;
+      break;
+    case APP_BUTTON_PRESS_DURATION_VERYLONG:
+      app_event = EVENT_SYSTEM_RESET;
+      break;
+    default:
+      break;
+  }
+
+  if (app_event != EVENT_EMPTY) {
+    app_event_enqueue(app_event);
+  }
+}

--- a/src/zwa2_repeater/app_cli.c
+++ b/src/zwa2_repeater/app_cli.c
@@ -1,0 +1,296 @@
+/***************************************************************************//**
+ * @file
+ * @brief CLI commands of the repeater application
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+//                                   Includes
+// -----------------------------------------------------------------------------
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <strings.h>
+#include "sl_component_catalog.h"
+
+#ifdef SL_CATALOG_ZW_CLI_COMMON_PRESENT
+
+#include "ZAF_Common_interface.h"
+#include "repeater_config_nvm.h"
+#include "zw_cli_common.h"
+#include "zaf_event_distributor_soc.h"
+#include "sl_cli.h"
+#include "sl_sleeptimer.h"
+#include "ev_man.h"
+#include "events.h"
+#include "zaf_config.h"
+#include "zaf_protocol_config.h"
+#include "zpal_misc.h"
+#include "zpal_radio.h"
+
+// -----------------------------------------------------------------------------
+//                              Macros and Typedefs
+// -----------------------------------------------------------------------------
+typedef struct {
+  const char *name;
+  zpal_radio_region_t region;
+} cli_region_name_t;
+
+#define TX_POWER_LIMIT_MIN_DDBM     (-100)
+#define TX_POWER_ADJUST_LIMIT_DDBM  (100)
+#define LR_TX_POWER_LIMIT_MAX_DDBM  (200)
+#define DBM_TO_DDBM(value)          ((value) * 10)
+#define CLI_REBOOT_DELAY_MS         (50)
+
+// -----------------------------------------------------------------------------
+//                          Static Function Declarations
+// -----------------------------------------------------------------------------
+static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *region);
+static const char *sli_get_region_name(zpal_radio_region_t region);
+static void sli_reboot_after_cli_delay(void);
+static bool sli_validate_powerlevel(zpal_tx_power_decidbm_t tx_power_level,
+                                    zpal_tx_power_decidbm_t tx_power_adjust,
+                                    zpal_tx_power_decidbm_t max_tx_power_lr);
+static void sli_log_supported_regions(void);
+
+// -----------------------------------------------------------------------------
+//                                Global Variables
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                                Static Variables
+// -----------------------------------------------------------------------------
+static const cli_region_name_t sli_region_names[] = {
+  { "EU", REGION_EU },
+  { "US", REGION_US },
+  { "ANZ", REGION_ANZ },
+  { "HK", REGION_HK },
+  { "IN", REGION_IN },
+  { "IL", REGION_IL },
+  { "RU", REGION_RU },
+  { "CN", REGION_CN },
+  { "US_LR", REGION_US_LR },
+  { "US-LR", REGION_US_LR },
+  { "EU_LR", REGION_EU_LR },
+  { "EU-LR", REGION_EU_LR },
+  { "JP", REGION_JP },
+  { "KR", REGION_KR },
+};
+
+// -----------------------------------------------------------------------------
+//                          Public Function Definitions
+// -----------------------------------------------------------------------------
+
+/******************************************************************************
+ * CLI - bootloader: Reboot into bootloader
+ *****************************************************************************/
+void cli_bootloader(sl_cli_command_arg_t *arguments)
+{
+  (void) arguments;
+  cli_printf("Rebooting into bootloader\r\n");
+  zaf_event_distributor_enqueue_app_event(EVENT_APP_BOOTLOADER);
+}
+
+/******************************************************************************
+ * CLI - set_region: Update the configured RF region token
+ *****************************************************************************/
+void cli_set_region(sl_cli_command_arg_t *arguments)
+{
+  zpal_radio_region_t active_region;
+  zpal_radio_region_t region;
+  const char *region_name;
+
+  if (sl_cli_get_argument_count(arguments) != 1) {
+    cli_printf("Usage: set_region <region>\r\n");
+    sli_log_supported_regions();
+    return;
+  }
+
+  region_name = sl_cli_get_argument_string(arguments, 0);
+  if (!sli_try_parse_region_name(region_name, &region)) {
+    cli_printf("Unknown region '%s'\r\n", region_name);
+    sli_log_supported_regions();
+    return;
+  }
+
+  if (!isRfRegionValid(region)) {
+    cli_printf("Region '%s' is not supported by this firmware\r\n", sli_get_region_name(region));
+    sli_log_supported_regions();
+    return;
+  }
+
+  active_region = zpal_radio_get_region();
+  if (!SaveApplicationRfRegion(region)) {
+    cli_printf("Failed to persist region %s.\r\n", sli_get_region_name(region));
+    return;
+  }
+
+  if (region == active_region) {
+    cli_printf("Configured region set to %s in NVM. Region already active, no reboot required.\r\n",
+                 sli_get_region_name(region));
+    return;
+  }
+
+  cli_printf("Configured region set to %s in NVM. Rebooting to apply the new region.\r\n",
+               sli_get_region_name(region));
+  sli_reboot_after_cli_delay();
+}
+
+/******************************************************************************
+ * CLI - get_powerlevel: Read the persisted RF power configuration
+ *****************************************************************************/
+void cli_get_powerlevel(sl_cli_command_arg_t *arguments)
+{
+  zpal_tx_power_decidbm_t tx_power_level;
+  zpal_tx_power_decidbm_t tx_power_adjust;
+  zpal_tx_power_decidbm_t max_tx_power_lr;
+
+  (void) arguments;
+
+  if (!ReadApplicationTxPowerlevel(&tx_power_level, &tx_power_adjust)
+      || !ReadApplicationMaxLRTxPwr(&max_tx_power_lr)) {
+    cli_printf("Power configuration is not available in NVM.\r\n");
+    return;
+  }
+
+  cli_printf("iTxPowerLevelMax=%d iTxPowerLevelAdjust=%d iTxPowerLevelMaxLR=%d\r\n",
+               (int)tx_power_level,
+               (int)tx_power_adjust,
+               (int)max_tx_power_lr);
+}
+
+/******************************************************************************
+ * CLI - set_powerlevel: Update the persisted RF power configuration
+ *****************************************************************************/
+void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
+{
+  SRadioConfig_t *radio_config = zaf_get_radio_config();
+  zpal_tx_power_decidbm_t tx_power_level;
+  zpal_tx_power_decidbm_t tx_power_adjust;
+  zpal_tx_power_decidbm_t max_tx_power_lr;
+  bool requires_reboot;
+
+  if (sl_cli_get_argument_count(arguments) != 3) {
+    cli_printf("Usage: set_powerlevel <iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>\r\n");
+    return;
+  }
+
+  tx_power_level = (zpal_tx_power_decidbm_t)sl_cli_get_argument_int16(arguments, 0);
+  tx_power_adjust = (zpal_tx_power_decidbm_t)sl_cli_get_argument_int16(arguments, 1);
+  max_tx_power_lr = (zpal_tx_power_decidbm_t)sl_cli_get_argument_int16(arguments, 2);
+
+  if (!sli_validate_powerlevel(tx_power_level, tx_power_adjust, max_tx_power_lr)) {
+    cli_printf("Invalid power levels. iTxPowerLevelMax range: %d..%d, iTxPowerLevelAdjust range: %d..%d, iTxPowerLevelMaxLR range: %d..%d\r\n",
+                 TX_POWER_LIMIT_MIN_DDBM,
+                 (int)zpal_radio_get_maximum_tx_power(),
+                 TX_POWER_LIMIT_MIN_DDBM,
+                 TX_POWER_ADJUST_LIMIT_DDBM,
+                 (int)DBM_TO_DDBM(zpal_radio_get_minimum_lr_tx_power()),
+                 LR_TX_POWER_LIMIT_MAX_DDBM);
+    return;
+  }
+
+  if (!SaveApplicationTxPowerlevel(tx_power_level, tx_power_adjust)
+      || !SaveApplicationMaxLRTxPwr(max_tx_power_lr)) {
+    cli_printf("Failed to persist power configuration.\r\n");
+    return;
+  }
+
+  requires_reboot = (radio_config->iTxPowerLevelMax != tx_power_level)
+                 || (radio_config->iTxPowerLevelAdjust != tx_power_adjust)
+                 || (radio_config->iTxPowerLevelMaxLR != max_tx_power_lr);
+
+  if (!requires_reboot) {
+    cli_printf("Power configuration stored in NVM. Values are already active, no reboot required.\r\n");
+    return;
+  }
+
+  cli_printf("Power configuration stored in NVM. Rebooting to apply the new settings.\r\n");
+  sli_reboot_after_cli_delay();
+}
+
+// -----------------------------------------------------------------------------
+//                          Static Function Definitions
+// -----------------------------------------------------------------------------
+
+static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *region)
+{
+  size_t i;
+
+  for (i = 0; i < (sizeof(sli_region_names) / sizeof(sli_region_names[0])); i++) {
+    if (strcasecmp(value, sli_region_names[i].name) == 0) {
+      *region = sli_region_names[i].region;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static const char *sli_get_region_name(zpal_radio_region_t region)
+{
+  switch (region) {
+    case REGION_EU:    return "EU";
+    case REGION_US:    return "US";
+    case REGION_ANZ:   return "ANZ";
+    case REGION_HK:    return "HK";
+    case REGION_IN:    return "IN";
+    case REGION_IL:    return "IL";
+    case REGION_RU:    return "RU";
+    case REGION_CN:    return "CN";
+    case REGION_US_LR: return "US_LR";
+    case REGION_EU_LR: return "EU_LR";
+    case REGION_JP:    return "JP";
+    case REGION_KR:    return "KR";
+    default:           return "Unknown";
+  }
+}
+
+static void sli_reboot_after_cli_delay(void)
+{
+  sl_sleeptimer_delay_millisecond(CLI_REBOOT_DELAY_MS);
+  zpal_reboot_with_info(ZAF_CONFIG_MANUFACTURER_ID, ZPAL_RESET_INFO_DEFAULT);
+}
+
+static bool sli_validate_powerlevel(zpal_tx_power_decidbm_t tx_power_level,
+                                    zpal_tx_power_decidbm_t tx_power_adjust,
+                                    zpal_tx_power_decidbm_t max_tx_power_lr)
+{
+  return (tx_power_level >= TX_POWER_LIMIT_MIN_DDBM)
+      && (tx_power_level <= zpal_radio_get_maximum_tx_power())
+      && (tx_power_adjust >= TX_POWER_LIMIT_MIN_DDBM)
+      && (tx_power_adjust <= TX_POWER_ADJUST_LIMIT_DDBM)
+      && (max_tx_power_lr >= DBM_TO_DDBM(zpal_radio_get_minimum_lr_tx_power()))
+      && (max_tx_power_lr <= LR_TX_POWER_LIMIT_MAX_DDBM);
+}
+
+static void sli_log_supported_regions(void)
+{
+  cli_printf("Accepted region names: EU US ANZ HK IN IL RU CN US_LR EU_LR JP KR\r\n");
+}
+
+#endif // SL_CATALOG_ZW_CLI_COMMON_PRESENT

--- a/src/zwa2_repeater/board_indicator.c
+++ b/src/zwa2_repeater/board_indicator.c
@@ -1,0 +1,195 @@
+// A modification of the SDK's AppsHw board_indicator.c to work with our custom LEDs.
+// Blinking is driven by a sleeptimer, matching how the controller firmware controls
+// its LEDs.
+
+#include "board_indicator.h"
+#include "board_indicator_control.h"
+#include "led_adapter.h"
+#include "CC_ColorSwitch.h"
+#include "em_core.h"
+#include "sl_sleeptimer.h"
+
+extern bool m_indicator_active_from_cc;
+rgb_t IDLE_COLOR = {4, 0, 0};
+rgb_t OFF_COLOR = {0, 0, 0};
+rgb_t LEARNMODE_COLOR = {255, 0, 255};
+rgb_t DEFAULT_COLOR = {255, 0, 0};
+
+// Active blink state. The timer alternates between the on and off phase until
+// the requested number of cycles completes or a new command replaces the blink.
+static sl_sleeptimer_timer_handle_t blink_timer;
+static rgb_t blink_color;
+static rgb_t blink_restore_color;
+static uint32_t blink_on_time_ms;
+static uint32_t blink_off_time_ms;
+static uint32_t blink_cycles_remaining;
+static bool blink_stay_on;
+static bool blink_phase_on;
+
+static void apply_color(const rgb_t *color)
+{
+	set_color_buffer(color);
+}
+
+static void blink_timer_callback(sl_sleeptimer_timer_handle_t *handle, void *data)
+{
+	(void)handle;
+	(void)data;
+
+	if (blink_phase_on)
+	{
+		blink_phase_on = false;
+		apply_color(&OFF_COLOR);
+		sl_sleeptimer_start_timer_ms(&blink_timer, blink_off_time_ms, blink_timer_callback, NULL, 0, 0);
+		return;
+	}
+
+	if (blink_cycles_remaining != BLINK_INDEFINITELY)
+	{
+		blink_cycles_remaining--;
+		if (blink_cycles_remaining == 0)
+		{
+			// Blink finished: restore the color from before the blink
+			apply_color(blink_stay_on ? &blink_color : &blink_restore_color);
+			m_indicator_active_from_cc = false;
+			return;
+		}
+	}
+
+	blink_phase_on = true;
+	apply_color(&blink_color);
+	sl_sleeptimer_start_timer_ms(&blink_timer, blink_on_time_ms, blink_timer_callback, NULL, 0, 0);
+}
+
+void set_idle_color(rgb_t *color)
+{
+	IDLE_COLOR.R = color->R;
+	IDLE_COLOR.G = color->G;
+	IDLE_COLOR.B = color->B;
+}
+
+uint8_t cc_color_switch_get_default_value(s_colorComponent* colorComponent) {
+	switch (colorComponent->colorId) {
+		case ECOLORCOMPONENT_RED:
+			return IDLE_COLOR.R;
+		case ECOLORCOMPONENT_GREEN:
+			return IDLE_COLOR.G;
+		case ECOLORCOMPONENT_BLUE:
+			return IDLE_COLOR.B;
+		default:
+			return 0;
+	}
+}
+
+bool indicator_solid(rgb_t *color)
+{
+	CORE_DECLARE_IRQ_STATE;
+	CORE_ENTER_ATOMIC();
+	sl_sleeptimer_stop_timer(&blink_timer);
+	apply_color(color);
+	m_indicator_active_from_cc = false;
+	CORE_EXIT_ATOMIC();
+	return true;
+}
+
+bool indicator_blink(rgb_t *color, uint32_t on_time_ms, uint32_t off_time_ms, uint32_t num_cycles, bool stay_on)
+{
+	CORE_DECLARE_IRQ_STATE;
+	CORE_ENTER_ATOMIC();
+	sl_sleeptimer_stop_timer(&blink_timer);
+
+	// Remember the current color to restore it when a finite blink completes
+	get_color_buffer(&blink_restore_color);
+
+	blink_color = *color;
+	blink_on_time_ms = on_time_ms;
+	blink_off_time_ms = off_time_ms;
+	blink_cycles_remaining = num_cycles;
+	blink_stay_on = stay_on;
+	blink_phase_on = true;
+
+	apply_color(color);
+	sl_status_t status = sl_sleeptimer_start_timer_ms(&blink_timer, on_time_ms, blink_timer_callback, NULL, 0, 0);
+	CORE_EXIT_ATOMIC();
+
+	return status == SL_STATUS_OK;
+}
+
+void Board_IndicateStatus(board_status_t status)
+{
+	if (status == BOARD_STATUS_LEARNMODE_ACTIVE)
+	{
+		indicator_blink(
+			&LEARNMODE_COLOR,
+			500,
+			500,
+			BLINK_INDEFINITELY,
+			false);
+	}
+	else
+	{
+		indicator_solid(&IDLE_COLOR);
+	}
+}
+
+void Board_IndicatorInit(void)
+{
+	initWs2812();
+}
+
+bool Board_IndicatorControl(uint32_t on_time_ms,
+							uint32_t off_time_ms,
+							uint32_t num_cycles,
+							bool called_from_indicator_cc)
+{
+
+	// Blink in the current color unless it is off or the Indicator CC asks
+	rgb_t color = {0};
+	get_color_buffer(&color);
+
+	// Indicator CC indicates indefinite blinking with 0
+	if (num_cycles == 0)
+	{
+		num_cycles = BLINK_INDEFINITELY;
+	}
+
+	bool result;
+	if (called_from_indicator_cc || (color.R == 0 && color.G == 0 && color.B == 0))
+	{
+		result = indicator_blink(&DEFAULT_COLOR, on_time_ms, off_time_ms, num_cycles, false);
+	}
+	else
+	{
+		result = indicator_blink(&color, on_time_ms, off_time_ms, num_cycles, false);
+	}
+	if (result)
+	{
+		m_indicator_active_from_cc = called_from_indicator_cc;
+	}
+
+	return result;
+}
+
+bool Board_IsIndicatorActive(void)
+{
+	return m_indicator_active_from_cc;
+}
+
+void cc_indicator_handler(uint32_t on_time_ms, uint32_t off_time_ms, uint32_t num_cycles)
+{
+	// V1 indicator handling
+	if (num_cycles == 0 && on_time_ms == 0 && off_time_ms == 0) {
+		indicator_solid(&IDLE_COLOR);
+		return;
+	} else if (num_cycles == 0xff && on_time_ms == 0xff && off_time_ms == 0xff) {
+		indicator_solid(&DEFAULT_COLOR);
+		return;
+	}
+
+	if (num_cycles == 0)
+	{
+		num_cycles = BLINK_INDEFINITELY;
+	}
+
+	m_indicator_active_from_cc = indicator_blink(&DEFAULT_COLOR, on_time_ms, off_time_ms, num_cycles, false);
+}

--- a/src/zwa2_repeater/board_indicator_control.h
+++ b/src/zwa2_repeater/board_indicator_control.h
@@ -1,0 +1,14 @@
+#include <stdbool.h>
+#include "led_adapter.h"
+
+#ifndef BOARD_INDICATOR_CONTROL_H
+#define BOARD_INDICATOR_CONTROL_H
+
+#define BLINK_INDEFINITELY UINT32_MAX
+
+void set_idle_color(rgb_t *color);
+
+bool indicator_solid(rgb_t *color);
+bool indicator_blink(rgb_t *color, uint32_t on_time_ms, uint32_t off_time_ms, uint32_t num_cycles, bool stay_on);
+
+#endif // BOARD_INDICATOR_CONTROL_H

--- a/src/zwa2_repeater/events.h
+++ b/src/zwa2_repeater/events.h
@@ -1,0 +1,30 @@
+/**
+ * @file
+ *
+ * Definitions of events for the repeater application.
+ *
+ * @copyright 2020 Silicon Laboratories Inc.
+ */
+#ifndef APPS_REPEATER_EVENTS_H_
+#define APPS_REPEATER_EVENTS_H_
+
+#include <ev_man.h>
+
+/**
+ * Defines events for the application.
+ *
+ * These events are not referred to anywhere else than in the application. Hence, they can be
+ * altered to suit the required application flow.
+ *
+ * The events are located in a separate file to make it possible to include them in other
+ * application files. An example could be a peripheral driver that enqueues an event when something
+ * specific happens.
+ */
+typedef enum EVENT_APP_REPEATER
+{
+  EVENT_EMPTY = DEFINE_EVENT_APP_NBR,
+  EVENT_APP_BOOTLOADER,
+}
+EVENT_APP;
+
+#endif /* APPS_REPEATER_EVENTS_H_ */

--- a/src/zwa2_repeater/extension/nabucasa_hardware_extension
+++ b/src/zwa2_repeater/extension/nabucasa_hardware_extension
@@ -1,0 +1,1 @@
+../../../extension/nabucasa_hardware_extension

--- a/src/zwa2_repeater/keys
+++ b/src/zwa2_repeater/keys
@@ -1,0 +1,1 @@
+../zwa2_controller/keys

--- a/src/zwa2_repeater/led_adapter.c
+++ b/src/zwa2_repeater/led_adapter.c
@@ -1,0 +1,38 @@
+#include "led_adapter.h"
+
+#include "sl_led.h"
+#include "ws2812.h"
+
+void initWs2812(void)
+{
+  // The driver initializes itself through the driver_init event. It defaults
+  // to a dim white color. Start black like the original driver did, and keep
+  // the LED logically on. Blackness is controlled through the color alone.
+  sl_led_set_rgb_color(&sl_led_ws2812, 0, 0, 0);
+  sl_led_turn_on(&sl_led_ws2812.led_common);
+  ws2812_led_driver_refresh();
+}
+
+void set_color_buffer(const rgb_t *color)
+{
+  // Shift into the driver's 16-bit range with a zero fraction, so its temporal
+  // dithering stays inert and the 8-bit values are reproduced exactly.
+  sl_led_set_rgb_color(&sl_led_ws2812,
+                       (uint16_t)(color->R << 8),
+                       (uint16_t)(color->G << 8),
+                       (uint16_t)(color->B << 8));
+  ws2812_led_driver_refresh();
+}
+
+void get_color_buffer(rgb_t *color)
+{
+  uint16_t red;
+  uint16_t green;
+  uint16_t blue;
+
+  sl_led_get_rgb_color(&sl_led_ws2812, &red, &green, &blue);
+
+  color->R = (uint8_t)(red >> 8);
+  color->G = (uint8_t)(green >> 8);
+  color->B = (uint8_t)(blue >> 8);
+}

--- a/src/zwa2_repeater/led_adapter.h
+++ b/src/zwa2_repeater/led_adapter.h
@@ -1,0 +1,28 @@
+/**
+ * Adapter between the repeater's LED code and the shared WS2812 driver.
+ *
+ * The original firmware used a driver with a per-LED color buffer. The shared
+ * driver holds a single color for all LEDs, which is all the repeater needs.
+ */
+
+#ifndef LED_ADAPTER_H_
+#define LED_ADAPTER_H_
+
+#include <stdint.h>
+#include "ws2812_config.h"
+
+#define NUMBER_OF_LEDS WS2812_NUM_LEDS
+
+typedef struct rgb_t {
+  uint8_t G, R, B;
+} rgb_t;
+
+void initWs2812(void);
+
+// Apply the color to all LEDs
+void set_color_buffer(const rgb_t *color);
+
+// Read back the current color
+void get_color_buffer(rgb_t *color);
+
+#endif /* LED_ADAPTER_H_ */

--- a/src/zwa2_repeater/repeater_config_nvm.c
+++ b/src/zwa2_repeater/repeater_config_nvm.c
@@ -1,0 +1,133 @@
+#include "repeater_config_nvm.h"
+
+#include <string.h>
+
+#include "ZAF_nvm_app.h"
+
+#define FILE_ID_APPLICATIONCONFIGURATION  104
+
+typedef struct __attribute__((packed)) {
+  zpal_radio_region_t     rfRegion;
+  zpal_tx_power_decidbm_t         iTxPower;
+  zpal_tx_power_decidbm_t         ipower0dbmMeasured;
+  zpal_tx_power_decidbm_t         maxTxPower;
+} SApplicationConfiguration;
+
+static bool object_exists(zpal_nvm_object_key_t key)
+{
+  size_t object_size = 0;
+
+  return (ZPAL_STATUS_OK == ZAF_nvm_app_get_object_size(key, &object_size));
+}
+
+static bool read_application_configuration(SApplicationConfiguration *configuration)
+{
+  if (!object_exists(FILE_ID_APPLICATIONCONFIGURATION)) {
+    return false;
+  }
+
+  return (ZPAL_STATUS_OK == ZAF_nvm_app_read(FILE_ID_APPLICATIONCONFIGURATION,
+                                             configuration,
+                                             sizeof(*configuration)));
+}
+
+static bool write_application_configuration(const SApplicationConfiguration *configuration)
+{
+  return (ZPAL_STATUS_OK == ZAF_nvm_app_write(FILE_ID_APPLICATIONCONFIGURATION,
+                                              configuration,
+                                              sizeof(*configuration)));
+}
+
+bool RepeaterConfigExists(void)
+{
+  return object_exists(FILE_ID_APPLICATIONCONFIGURATION);
+}
+
+bool RepeaterConfigWriteDefaults(const SRadioConfig_t *radio_config)
+{
+  SApplicationConfiguration configuration;
+
+  memset(&configuration, 0, sizeof(configuration));
+  configuration.rfRegion = radio_config->eRegion;
+  configuration.iTxPower = radio_config->iTxPowerLevelMax;
+  configuration.ipower0dbmMeasured = radio_config->iTxPowerLevelAdjust;
+  configuration.maxTxPower = radio_config->iTxPowerLevelMaxLR;
+
+  return write_application_configuration(&configuration);
+}
+
+bool SaveApplicationRfRegion(zpal_radio_region_t rf_region)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  configuration.rfRegion = rf_region;
+  return write_application_configuration(&configuration);
+}
+
+bool ReadApplicationRfRegion(zpal_radio_region_t *rf_region)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  *rf_region = configuration.rfRegion;
+  return true;
+}
+
+bool SaveApplicationTxPowerlevel(zpal_tx_power_decidbm_t tx_power_level,
+                                 zpal_tx_power_decidbm_t tx_power_adjust)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  configuration.iTxPower = tx_power_level;
+  configuration.ipower0dbmMeasured = tx_power_adjust;
+  return write_application_configuration(&configuration);
+}
+
+bool ReadApplicationTxPowerlevel(zpal_tx_power_decidbm_t *tx_power_level,
+                                 zpal_tx_power_decidbm_t *tx_power_adjust)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  *tx_power_level = configuration.iTxPower;
+  *tx_power_adjust = configuration.ipower0dbmMeasured;
+  return true;
+}
+
+bool SaveApplicationMaxLRTxPwr(zpal_tx_power_decidbm_t max_tx_power_lr)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  configuration.maxTxPower = max_tx_power_lr;
+  return write_application_configuration(&configuration);
+}
+
+bool ReadApplicationMaxLRTxPwr(zpal_tx_power_decidbm_t *max_tx_power_lr)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  *max_tx_power_lr = configuration.maxTxPower;
+  return true;
+}

--- a/src/zwa2_repeater/repeater_config_nvm.h
+++ b/src/zwa2_repeater/repeater_config_nvm.h
@@ -1,0 +1,22 @@
+#ifndef REPEATER_CONFIG_NVM_H
+#define REPEATER_CONFIG_NVM_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "ZW_application_transport_interface.h"
+
+bool RepeaterConfigExists(void);
+bool RepeaterConfigWriteDefaults(const SRadioConfig_t *radio_config);
+
+bool SaveApplicationRfRegion(zpal_radio_region_t rf_region);
+bool ReadApplicationRfRegion(zpal_radio_region_t *rf_region);
+
+bool SaveApplicationTxPowerlevel(zpal_tx_power_decidbm_t tx_power_level,
+                                 zpal_tx_power_decidbm_t tx_power_adjust);
+bool ReadApplicationTxPowerlevel(zpal_tx_power_decidbm_t *tx_power_level,
+                                 zpal_tx_power_decidbm_t *tx_power_adjust);
+
+bool SaveApplicationMaxLRTxPwr(zpal_tx_power_decidbm_t max_tx_power_lr);
+bool ReadApplicationMaxLRTxPwr(zpal_tx_power_decidbm_t *max_tx_power_lr);
+
+#endif

--- a/src/zwa2_repeater/sdk_patches/cc-color-switch-restore-from-nvm.patch
+++ b/src/zwa2_repeater/sdk_patches/cc-color-switch-restore-from-nvm.patch
@@ -1,0 +1,36 @@
+diff --git a/zwave/ZAF/CommandClasses/ColorSwitch/src/CC_ColorSwitch.c b/zwave/ZAF/CommandClasses/ColorSwitch/src/CC_ColorSwitch.c
+index 895e9a4..9208b0d 100644
+--- a/zwave/ZAF/CommandClasses/ColorSwitch/src/CC_ColorSwitch.c
++++ b/zwave/ZAF/CommandClasses/ColorSwitch/src/CC_ColorSwitch.c
+@@ -37,6 +37,13 @@ ZW_WEAK void cc_color_switch_refresh_cb(void)
+ {
+ }
+ 
++extern uint8_t cc_color_switch_get_default_value(s_colorComponent* colorComponent);
++ZW_WEAK uint8_t cc_color_switch_get_default_value(s_colorComponent* colorComponent)
++{
++  (void) colorComponent;
++  return 0xff;
++}
++
+ typedef void (*color_callback_t)(s_colorComponent *colorComponent);
+ 
+ /**
+@@ -58,7 +65,16 @@ static void init_and_reset(void)
+   }
+   for (uint8_t i = 0; i < colorsSupportedCount; i++) {
+     ZAF_Actuator_Init(&pColorComponents[i].obj, 0, 0xFF, 20, durationDefault, &CC_ColorSwitch_ColorChanged_cb);
+-    ZAF_Actuator_Set(&pColorComponents[i].obj, 0xFF, 0);
++    uint8_t color_component_id = findColorComponentIndexByObj(&pColorComponents[i].obj);
++    if (!cc_color_switch_read(color_component_id, &pColorComponents[i]))
++    {
++      // If the color was not found in NVM, set it to default value
++      ZAF_Actuator_Set(
++        &pColorComponents[i].obj,
++        cc_color_switch_get_default_value(&pColorComponents[i]),
++        0
++      );
++    }
+     cc_color_switch_write((uint8_t) i, &pColorComponents[i]);
+   }
+ }

--- a/src/zwa2_repeater/zwa2_repeater.cc_config
+++ b/src/zwa2_repeater/zwa2_repeater.cc_config
@@ -1,0 +1,5 @@
+zw_cc_color_switch:
+  colors:
+    - id: ECOLORCOMPONENT_RED
+    - id: ECOLORCOMPONENT_GREEN
+    - id: ECOLORCOMPONENT_BLUE

--- a/src/zwa2_repeater/zwa2_repeater.slcp
+++ b/src/zwa2_repeater/zwa2_repeater.slcp
@@ -1,0 +1,213 @@
+# Silicon Labs Project Configuration Tools: slcp, v0, Component selection file.
+project_name: zwa2_repeater
+label: zwa2_repeater
+category: Z-Wave|Apps
+description: >
+  Z-Wave repeater firmware for the Home Assistant Connect ZWA-2. Based on the
+  Z-Wave LED Bulb sample application, with buttons and dimming removed and a
+  CLI to configure the RF region and TX power.
+package: zwave_sample_app
+quality: production
+component:
+  - id: emlib_letimer
+  - id: emlib_timer
+  - id: emlib_msc
+  - id: gpiointerrupt
+  - id: zw_role_type_always_on
+  - id: zaf_soc
+  - id: zw_core
+  - id: zw_zaf
+  - id: zw_true_status
+  - id: zw_ota
+  - id: zw_cc_association
+  - id: zw_cc_basic
+  - id: zw_cc_color_switch
+  - id: zw_cc_color_switch_nvm
+  - id: zw_cc_common
+  - id: zw_cc_deviceresetlocally
+  - id: zw_cc_firmwareupdate
+  - id: zw_cc_indicator
+  - id: zw_cc_manufacturerspecific
+  - id: zw_cc_multi_channel_control
+  - id: zw_cc_powerlevel
+  - id: zw_cc_supervision
+  - id: zw_cc_version
+  - id: zw_cc_zwaveplusinfo
+  - id: zw_appshw
+  - id: sl_main
+  - id: device_init
+  - id: mpu # disable execution from RAM
+  - id: ZW_MIGRATION_TO_7_19
+  - id: zw_cli_common
+  - id: app_button_press
+  - id: app_assert
+  - id: simple_button
+    instance: [instance0]
+  - id: clock_manager
+  - id: iostream_usart
+    instance: [inst]
+  - id: led
+
+source:
+  - path: app.c
+  - path: app_cli.c
+    condition: [zw_cli_common]
+  - path: app_btn_handler.c
+    condition: [simple_button]
+  - path: board_indicator.c
+  - path: led_adapter.c
+  - path: repeater_config_nvm.c
+  - path: zwave_identity.c
+
+include:
+  - path: .
+    file_list:
+      - path: events.h
+      - path: board_indicator_control.h
+      - path: led_adapter.h
+      - path: repeater_config_nvm.h
+      - path: zwave_identity.h
+
+configuration:
+  - name: SHORT_BUTTON_PRESS_DURATION_MS
+    value: (400)
+  - name: MEDIUM_BUTTON_PRESS_DURATION_MS
+    value: (1500)
+  - name: ZAF_CONFIG_REQUEST_KEY_S0
+    value: 0
+  - name: ZAF_CONFIG_REQUEST_KEY_S2_UNAUTHENTICATED
+    value: 1
+  - name: ZAF_CONFIG_REQUEST_KEY_S2_AUTHENTICATED
+    value: 1
+  - name: ZAF_CONFIG_GENERIC_TYPE
+    value: GENERIC_TYPE_SWITCH_MULTILEVEL
+  - name: ZAF_CONFIG_SPECIFIC_TYPE
+    value: SPECIFIC_TYPE_COLOR_TUNABLE_MULTILEVEL
+  - name: ZAF_CONFIG_USER_ICON_TYPE
+    value: ICON_TYPE_GENERIC_LIGHT_DIMMER_SWITCH
+  - name: ZAF_CONFIG_INSTALLER_ICON_TYPE
+    value: ICON_TYPE_GENERIC_LIGHT_DIMMER_SWITCH
+  - name: NVM3_DEFAULT_MAX_OBJECT_SIZE
+    value: 1900
+  - name: NVM3_DEFAULT_CACHE_SIZE
+    value: 100
+  - name: SL_BOARD_ENABLE_VCOM
+    value: 1
+  - name: SL_DEVICE_INIT_DCDC_BYPASS
+    value: 1
+  - name: configUSE_IDLE_HOOK
+    value: 1
+  - name: configTIMER_TASK_PRIORITY
+    value: 55
+  - name: configMAX_SYSCALL_INTERRUPT_PRIORITY
+    value: 16
+    condition: [device_series_2]
+  - name: configKERNEL_INTERRUPT_PRIORITY
+    value: 112
+    condition: [device_series_2]
+  - name: configTIMER_QUEUE_LENGTH
+    value: 8
+  - name: SL_PSA_ITS_USER_MAX_FILES
+    value: 32
+    condition: ["device_series_2", "device_security_vault"]
+  - name: SL_PSA_KEY_USER_SLOT_COUNT
+    value: 14
+    condition: ["device_series_2", "device_security_vault"]
+  - name: SL_SLEEPTIMER_PERIPHERAL
+    value: SL_SLEEPTIMER_PERIPHERAL_DEFAULT
+    condition: ["device_series_2"]
+  - name: CC_ASSOCIATION_MAX_GROUPS_PER_ENDPOINT
+    value: 1
+  - name: CC_ASSOCIATION_MAX_NODES_IN_GROUP
+    value: 5
+  - name: SL_PSA_ITS_SUPPORT_V1_DRIVER
+    value: 1
+  - name: SL_PSA_ITS_SUPPORT_V2_DRIVER
+    value: 1
+  - name: SL_PSA_ITS_SUPPORT_V3_DRIVER
+    value: 1
+  - name: ZAF_APP_NAME
+    value: '"nc_repeater"'
+  - name: SL_CLOCK_MANAGER_WDOG0CLK_SOURCE
+    value: CMU_WDOG0CLKCTRL_CLKSEL_LFRCO
+  # USART configuration
+  - name: SL_IOSTREAM_USART_VCOM_CONVERT_BY_DEFAULT_LF_TO_CRLF
+    value: 1
+  - name: SL_IOSTREAM_USART_VCOM_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION
+    value: 0    # UART RX shouldn't prevent EM2
+
+define:
+  - name: APP_PROPERTIES_CONFIG_FILE
+    value: <application_properties_config.h>
+  - name: FILE_ID_APPLICATIONDATA # File identifiers for application file system
+    value: "0x00000" # Range: 0x00000 - 0x0FFFF
+
+config_file:
+  - path: zwa2_repeater.cc_config
+    directory: cc_config
+  # Keys for signing and encrypting OTA firmware updates
+  - path: keys/vendor_encrypt.key
+    directory: keys
+  - path: keys/vendor_sign.key
+    directory: keys
+
+provides:
+  - name: zwave_sample_application
+  # zw_log requires an EUSART iostream on SoC devices, but the ZWA-2 has no
+  # UART to spare. Satisfying the requirement here keeps the EUSART driver out
+  # of the build. zw_log then finds no "vcom" stream and drops all output.
+  - name: iostream_eusart
+
+template_contribution:
+  - name: cli_command
+    condition: [zw_cli_common]
+    value:
+      name: set_region
+      handler: cli_set_region
+      help: Set the configured region
+      argument:
+        - type: string
+          help: <region>
+  - name: cli_command
+    condition: [zw_cli_common]
+    value:
+      name: get_powerlevel
+      handler: cli_get_powerlevel
+      help: Get the configured RF power values
+  - name: cli_command
+    condition: [zw_cli_common]
+    value:
+      name: set_powerlevel
+      handler: cli_set_powerlevel
+      help: Set the configured RF power values
+      argument:
+        - type: int16
+          help: <iTxPowerLevelMax>
+        - type: int16
+          help: <iTxPowerLevelAdjust>
+        - type: int16
+          help: <iTxPowerLevelMaxLR>
+  - name: cli_command
+    condition: [zw_cli_common]
+    value:
+      name: bootloader
+      handler: cli_bootloader
+      help: Restart into bootloader
+
+tag:
+  - prebuilt_demo
+  - hwfilter:device:device_supports_zwave
+  - toolchain:gcc
+
+filter:
+  - name: "Wireless Technology"
+    value: ["Z-Wave"]
+  - name: "Device Type"
+    value: ["SoC"]
+  - name: "Project Difficulty"
+    value: ["Beginner"]
+
+readme:
+   - path: README.md
+ui_hints:
+   highlight: README.md

--- a/src/zwa2_repeater/zwave_identity.c
+++ b/src/zwa2_repeater/zwave_identity.c
@@ -1,0 +1,167 @@
+#include "zwave_identity.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "MfgTokens.h"
+#include "psa/crypto.h"
+#include "zpal_misc.h"
+
+// Controller firmware stores no S2 identity or QR code. After switching to repeater firmware,
+// both are missing. Reconcile them in NVM and token storage, so the end device can join a network.
+// The protocol uses this fixed PSA key ID for its static S2 identity.
+#define ZWAVE_ECC_KEY_ID ((psa_key_id_t)0x70000)
+
+extern void compose_qr_code(bool region_lr,
+                            const uint8_t public_key[TOKEN_MFG_ZW_PUK_SIZE],
+                            uint8_t qrcode[TOKEN_MFG_ZW_QR_CODE_SIZE]);
+
+static bool all_ff(const uint8_t *data, size_t length)
+{
+  for (size_t i = 0; i < length; i++) {
+    if (data[i] != 0xff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void clear_secret(uint8_t *data, size_t length)
+{
+  volatile uint8_t *cursor = data;
+  while (length-- > 0) {
+    *cursor++ = 0;
+  }
+}
+
+static void set_key_attributes(psa_key_attributes_t *attributes)
+{
+  psa_set_key_type(attributes,
+                   PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY));
+  psa_set_key_bits(attributes, 255);
+  psa_set_key_usage_flags(attributes,
+                          PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_DERIVE);
+  psa_set_key_algorithm(attributes, PSA_ALG_ECDH);
+}
+
+static bool public_key_matches(mbedtls_svc_key_id_t key,
+                               const uint8_t expected[TOKEN_MFG_ZW_PUK_SIZE])
+{
+  uint8_t actual[TOKEN_MFG_ZW_PUK_SIZE];
+  size_t actual_length = 0;
+
+  return psa_export_public_key(key, actual, sizeof(actual), &actual_length)
+           == PSA_SUCCESS
+         && actual_length == sizeof(actual)
+         && memcmp(actual, expected, sizeof(actual)) == 0;
+}
+
+static bool validate_token_keypair(
+  const uint8_t private_key[TOKEN_MFG_ZW_PRK_SIZE],
+  const uint8_t public_key[TOKEN_MFG_ZW_PUK_SIZE])
+{
+  // Validate the token pair before replacing persistent identity storage.
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  mbedtls_svc_key_id_t temporary_key = MBEDTLS_SVC_KEY_ID_INIT;
+
+  set_key_attributes(&attributes);
+  zpal_psa_set_location_volatile_key(&attributes);
+
+  psa_status_t status = psa_import_key(&attributes,
+                                       private_key,
+                                       TOKEN_MFG_ZW_PRK_SIZE,
+                                       &temporary_key);
+  bool valid = status == PSA_SUCCESS
+               && public_key_matches(temporary_key, public_key);
+
+  if (status == PSA_SUCCESS) {
+    valid = psa_destroy_key(temporary_key) == PSA_SUCCESS && valid;
+  }
+  psa_reset_key_attributes(&attributes);
+  return valid;
+}
+
+static bool reconcile_private_key(
+  const uint8_t private_key[TOKEN_MFG_ZW_PRK_SIZE],
+  const uint8_t public_key[TOKEN_MFG_ZW_PUK_SIZE])
+{
+  if (public_key_matches(ZWAVE_ECC_KEY_ID, public_key)) {
+    return true;
+  }
+
+  psa_status_t status = psa_destroy_key(ZWAVE_ECC_KEY_ID);
+  if (status != PSA_SUCCESS && status != PSA_ERROR_DOES_NOT_EXIST) {
+    return false;
+  }
+
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  mbedtls_svc_key_id_t imported_key = MBEDTLS_SVC_KEY_ID_INIT;
+  set_key_attributes(&attributes);
+  psa_set_key_id(&attributes, ZWAVE_ECC_KEY_ID);
+  zpal_psa_set_location_persistent_key(&attributes);
+
+  status = psa_import_key(&attributes,
+                          private_key,
+                          TOKEN_MFG_ZW_PRK_SIZE,
+                          &imported_key);
+  psa_reset_key_attributes(&attributes);
+
+  return status == PSA_SUCCESS
+         && imported_key == ZWAVE_ECC_KEY_ID
+         && public_key_matches(imported_key, public_key);
+}
+
+static bool reconcile_qr_code(
+  bool region_lr,
+  const uint8_t public_key[TOKEN_MFG_ZW_PUK_SIZE])
+{
+  uint8_t stored[TOKEN_MFG_ZW_QR_CODE_SIZE];
+  ZW_GetMfgTokenData(stored, TOKEN_MFG_ZW_QR_CODE_ID, sizeof(stored));
+
+  // Static token writes are write-once, so repair only a fully erased QR token.
+  if (!all_ff(stored, sizeof(stored))) {
+    return true;
+  }
+
+  uint8_t expected[TOKEN_MFG_ZW_QR_CODE_SIZE];
+  compose_qr_code(region_lr, public_key, expected);
+  ZW_SetMfgTokenData(TOKEN_MFG_ZW_QR_CODE_ID, expected, sizeof(expected));
+
+  memset(stored, 0xff, sizeof(stored));
+  ZW_GetMfgTokenData(stored, TOKEN_MFG_ZW_QR_CODE_ID, sizeof(stored));
+  return memcmp(stored, expected, sizeof(stored)) == 0;
+}
+
+bool zwave_identity_reconcile(bool region_lr)
+{
+  uint8_t initialized = 0xff;
+  ZW_GetMfgTokenData(&initialized,
+                     TOKEN_MFG_ZW_INITIALIZED_ID,
+                     sizeof(initialized));
+
+  // While this token is erased, the Z-Wave protocol initializes the QR code on its own.
+  if (initialized == 0xff) {
+    return true;
+  }
+
+  uint8_t private_key[TOKEN_MFG_ZW_PRK_SIZE];
+  uint8_t public_key[TOKEN_MFG_ZW_PUK_SIZE];
+  ZW_GetMfgTokenData(private_key,
+                     TOKEN_MFG_ZW_PRK_ID,
+                     sizeof(private_key));
+  ZW_GetMfgTokenData(public_key,
+                     TOKEN_MFG_ZW_PUK_ID,
+                     sizeof(public_key));
+
+  bool success = false;
+  if (!all_ff(private_key, sizeof(private_key))
+      && !all_ff(public_key, sizeof(public_key))
+      && validate_token_keypair(private_key, public_key)) {
+    success = reconcile_private_key(private_key, public_key)
+              && reconcile_qr_code(region_lr, public_key);
+  }
+
+  clear_secret(private_key, sizeof(private_key));
+  return success;
+}

--- a/src/zwa2_repeater/zwave_identity.h
+++ b/src/zwa2_repeater/zwave_identity.h
@@ -1,0 +1,8 @@
+#ifndef ZWAVE_IDENTITY_H
+#define ZWAVE_IDENTITY_H
+
+#include <stdbool.h>
+
+bool zwave_identity_reconcile(bool region_lr);
+
+#endif // ZWAVE_IDENTITY_H

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -970,6 +970,8 @@ def sdk_path_remaps(build: ResolvedBuild) -> dict[str, str]:
         "/home/buildengineer/.silabs/slt/installs/conan/p/platf6edd0cd4d4914/p": f"{sdk_src}/platform_core",
         # Z-Wave's platform_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1
         "/home/buildengineer/.silabs/slt/installs/conan/p/platf0f636d352884d/p": f"{sdk_src}/platform_core",
+        # The Z-Wave end device libraries reference the mbedtls package they were built against
+        "/home/buildengineer/.silabs/slt/installs/conan/p/mbedt41879ab8b510b/p": f"{sdk_src}/mbedtls",
         # The zigbee stack libraries reference the silabs_core package they were built against
         "/github/home/.silabs/slt/installs/conan/p/commo8335073ce327e/p": f"{sdk_src}/platform_core",
         # silabs_core was repackaged under a new conan hash in Simplicity SDK 2026.6.1


### PR DESCRIPTION
Ports the repeater firmware from the standalone [nc-zwave-repeater](https://github.com/NabuCasa/nc-zwave-repeater) repository, updating it from Simplicity SDK 2024.12.1 to 2026.6.1 (Z-Wave SDK 7.23.1 → 8.1.1). Reports version 1.3.0.

The base project (`src/zwa2_repeater`) derives from the Z-Wave LED Bulb sample application, with the same modifications as the standalone repository:

- On-board button (PC05): short press toggles learn mode, very long press factory-resets
- CLI on USART0: `set_region`, `get_powerlevel`/`set_powerlevel` (persisted in NVM) and `bootloader`. The default region is EU.
- The persisted S2 identity is reconciled with the manufacturing tokens on startup, repairing it after switching from controller firmware
- LEDs use the shared WS2812 driver from the `nabucasa_hardware` extension, driven by a sleeptimer like on the controller. Color Switch CC sets the color, Indicator CC blinks to identify.
- An SDK patch restores the persisted LED color from NVM at startup

Two portability notes:

- On SoC devices, `zw_core` → `zw_log` hard-requires `iostream_eusart`, and the ZWA-2 has no UART to spare. The project satisfies the component name via `provides:`, so no EUSART is instantiated and zpal log output is dropped — matching the old firmware, which had no such logging.
- The Z-Wave end device libraries reference the mbedtls conan package they were built against, which needs a new debug path remap in `build_project.py` to keep the reproducibility check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)