### PR TITLE
Add bootloader info Serial API command for ZWA-2

### DIFF
--- a/manifests/nabucasa/zwa2/zwa2_controller.yaml
+++ b/manifests/nabucasa/zwa2/zwa2_controller.yaml
@@ -127,7 +127,7 @@ c_defines:
   # See src/zwa2_controller/README.md for versioning scheme details.
   USER_APP_VERSION: 1
   USER_APP_REVISION: 3
-  USER_APP_PATCH: 0
+  USER_APP_PATCH: 1
 
   # USART0 serial API pins
   SERIAL_API_TX_PORT: gpioPortA

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 1.3.1
-Added a proprietary Serial API command that reports the bootloader version and capabilities without rebooting into the bootloader.
-
-* Added `NABU_CASA_BOOTLOADER_INFO` (subcommand 9 of `FUNC_ID_PROPRIETARY_0`), returning the bootloader version and its capability mask.
+* Added a proprietary Serial API command to reports the bootloader version and capabilities without rebooting into the bootloader.
 
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.1
+Added a proprietary Serial API command that reports the bootloader version, checksum and capabilities without rebooting into the bootloader.
+
+* Added `NABU_CASA_BOOTLOADER_INFO` (subcommand 9 of `FUNC_ID_PROPRIETARY_0`), returning the bootloader version, a CRC-32 over the bootloader image, and its capability mask.
+
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.
 

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.3.1
-* Added a proprietary Serial API command to reports the bootloader version and capabilities without rebooting into the bootloader.
+* Added a proprietary Serial API command to query the bootloader version and capabilities without rebooting into the bootloader.
 
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.3.1
-Added a proprietary Serial API command that reports the bootloader version, checksum and capabilities without rebooting into the bootloader.
+Added a proprietary Serial API command that reports the bootloader version and capabilities without rebooting into the bootloader.
 
-* Added `NABU_CASA_BOOTLOADER_INFO` (subcommand 9 of `FUNC_ID_PROPRIETARY_0`), returning the bootloader version, a CRC-32 over the bootloader image, and its capability mask.
+* Added `NABU_CASA_BOOTLOADER_INFO` (subcommand 9 of `FUNC_ID_PROPRIETARY_0`), returning the bootloader version and its capability mask.
 
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.

--- a/src/zwa2_controller/extension/nabucasa_zwa2_extension/cmds_proprietary_zwa2.slcc
+++ b/src/zwa2_controller/extension/nabucasa_zwa2_extension/cmds_proprietary_zwa2.slcc
@@ -1,7 +1,7 @@
 id: cmds_proprietary_zwa2
 label: Proprietary Serial API Commands (ZWA-2)
 package: custom
-description: Nabu Casa proprietary Serial API commands for LED control, system indication, and configuration
+description: Nabu Casa proprietary Serial API commands for LED control, system indication, configuration, and bootloader info
 category: Z-Wave|Serial API
 quality: production
 source:
@@ -15,3 +15,4 @@ provides:
 requires:
   - name: led_effects_base
   - name: led_manager
+  - name: bootloader_interface

--- a/src/zwa2_controller/extension/nabucasa_zwa2_extension/inc/cmds_proprietary.h
+++ b/src/zwa2_controller/extension/nabucasa_zwa2_extension/inc/cmds_proprietary.h
@@ -18,6 +18,7 @@ typedef enum
   NABU_CASA_CONFIG_SET = 6,
   NABU_CASA_LED_GET_BINARY = 7,
   NABU_CASA_LED_SET_BINARY = 8,
+  NABU_CASA_BOOTLOADER_INFO = 9,
 } eNabuCasaCmd;
 
 typedef enum

--- a/src/zwa2_controller/extension/nabucasa_zwa2_extension/src/cmds_proprietary.c
+++ b/src/zwa2_controller/extension/nabucasa_zwa2_extension/src/cmds_proprietary.c
@@ -24,29 +24,6 @@
 /* Track whether the manual LED layer is "on" (for GET commands) */
 static bool manual_led_on = false;
 
-// Compute a standard CRC-32 (reflected, polynomial 0xEDB88320) so a host can
-// reproduce the value from a released bootloader image.
-// The nibble-wise loop keeps the lookup table at 64 bytes.
-static uint32_t nc_crc32(const uint8_t *data, uint32_t length)
-{
-  static const uint32_t table[16] = {
-    0x00000000, 0x1DB71064, 0x3B6E20C8, 0x26D930AC,
-    0x76DC4190, 0x6B6B51F4, 0x4DB26158, 0x5005713C,
-    0xEDB88320, 0xF00F9344, 0xD6D6A3E8, 0xCB61B38C,
-    0x9B64C2B0, 0x86D3D2D4, 0xA00AE278, 0xBDBDF21C
-  };
-
-  uint32_t crc = 0xFFFFFFFF;
-  for (uint32_t j = 0; j < length; j++)
-  {
-    crc ^= data[j];
-    crc = table[crc & 0x0F] ^ (crc >> 4);
-    crc = table[crc & 0x0F] ^ (crc >> 4);
-  }
-
-  return ~crc;
-}
-
 bool nc_config_get(eNabuCasaConfigKey key)
 {
   NabuCasaConfigStorage_t cfg = CONFIG_STORAGE_DEFAULTS;
@@ -314,25 +291,14 @@ ZW_ADD_CMD(FUNC_ID_NABU_CASA)
   case NABU_CASA_BOOTLOADER_INFO:
   {
     // HOST->ZW (REQ): NABU_CASA_BOOTLOADER_INFO
-    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | version[4] | crc32[4] | capabilities[4]
-    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | false, if no bootloader is present
+    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | version[4] | capabilities[4]
 
+    // bootloader_getInfo() leaves the version untouched when it finds no
+    // bootloader table, so the initializer defines what gets reported.
     BootloaderInformation_t btlInfo = { 0 };
     bootloader_getInfo(&btlInfo);
 
-    if (SL_BOOTLOADER != btlInfo.type)
-    {
-      response[i++] = cmdRes;
-      break;
-    }
-
-    // A type of SL_BOOTLOADER means bootloader_getInfo() found a valid table
-    // pointer and magic word, so the size field can be trusted.
-    const uint32_t words[] = {
-      btlInfo.version,
-      nc_crc32((const uint8_t *)BTL_MAIN_STAGE_BASE, mainBootloaderTable->size),
-      btlInfo.capabilities
-    };
+    const uint32_t words[] = { btlInfo.version, btlInfo.capabilities };
 
     for (unsigned w = 0; w < sizeof(words) / sizeof(words[0]); w++)
     {

--- a/src/zwa2_controller/extension/nabucasa_zwa2_extension/src/cmds_proprietary.c
+++ b/src/zwa2_controller/extension/nabucasa_zwa2_extension/src/cmds_proprietary.c
@@ -10,6 +10,7 @@
 #include <cmds_proprietary.h>
 #include <string.h>
 #include <ZAF_nvm_app.h>
+#include "btl_interface.h"
 #include "cmd_handlers.h"
 #include "SerialAPI.h"
 #include "led_manager_zwa2.h"
@@ -22,6 +23,29 @@
 
 /* Track whether the manual LED layer is "on" (for GET commands) */
 static bool manual_led_on = false;
+
+// Compute a standard CRC-32 (reflected, polynomial 0xEDB88320) so a host can
+// reproduce the value from a released bootloader image.
+// The nibble-wise loop keeps the lookup table at 64 bytes.
+static uint32_t nc_crc32(const uint8_t *data, uint32_t length)
+{
+  static const uint32_t table[16] = {
+    0x00000000, 0x1DB71064, 0x3B6E20C8, 0x26D930AC,
+    0x76DC4190, 0x6B6B51F4, 0x4DB26158, 0x5005713C,
+    0xEDB88320, 0xF00F9344, 0xD6D6A3E8, 0xCB61B38C,
+    0x9B64C2B0, 0x86D3D2D4, 0xA00AE278, 0xBDBDF21C
+  };
+
+  uint32_t crc = 0xFFFFFFFF;
+  for (uint32_t j = 0; j < length; j++)
+  {
+    crc ^= data[j];
+    crc = table[crc & 0x0F] ^ (crc >> 4);
+    crc = table[crc & 0x0F] ^ (crc >> 4);
+  }
+
+  return ~crc;
+}
 
 bool nc_config_get(eNabuCasaConfigKey key)
 {
@@ -87,9 +111,10 @@ ZW_ADD_CMD(FUNC_ID_NABU_CASA)
     BITMASK_ADD_CMD(supportedBitmask, NABU_CASA_SYSTEM_INDICATION_SET);
     BITMASK_ADD_CMD(supportedBitmask, NABU_CASA_CONFIG_GET);
     BITMASK_ADD_CMD(supportedBitmask, NABU_CASA_CONFIG_SET);
+    BITMASK_ADD_CMD(supportedBitmask, NABU_CASA_BOOTLOADER_INFO);
 
     // Copy as few bytes as necessary into the output buffer
-    for (int j = 0; j <= NABU_CASA_LED_SET_BINARY / 8; j++)
+    for (int j = 0; j <= NABU_CASA_BOOTLOADER_INFO / 8; j++)
     {
       response[i++] = supportedBitmask[j];
     }
@@ -285,6 +310,39 @@ ZW_ADD_CMD(FUNC_ID_NABU_CASA)
 
     response[i++] = cmdRes;
     break;
+
+  case NABU_CASA_BOOTLOADER_INFO:
+  {
+    // HOST->ZW (REQ): NABU_CASA_BOOTLOADER_INFO
+    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | version[4] | crc32[4] | capabilities[4]
+    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | false, if no bootloader is present
+
+    BootloaderInformation_t btlInfo = { 0 };
+    bootloader_getInfo(&btlInfo);
+
+    if (SL_BOOTLOADER != btlInfo.type)
+    {
+      response[i++] = cmdRes;
+      break;
+    }
+
+    // A type of SL_BOOTLOADER means bootloader_getInfo() found a valid table
+    // pointer and magic word, so the size field can be trusted.
+    const uint32_t words[] = {
+      btlInfo.version,
+      nc_crc32((const uint8_t *)BTL_MAIN_STAGE_BASE, mainBootloaderTable->size),
+      btlInfo.capabilities
+    };
+
+    for (unsigned w = 0; w < sizeof(words) / sizeof(words[0]); w++)
+    {
+      response[i++] = (uint8_t)(words[w] >> 24);
+      response[i++] = (uint8_t)(words[w] >> 16);
+      response[i++] = (uint8_t)(words[w] >> 8);
+      response[i++] = (uint8_t)(words[w]);
+    }
+    break;
+  }
 
   default:
     // Unsupported. Return false

--- a/src/zwa2_controller/extension/nabucasa_zwa2_extension/src/cmds_proprietary.c
+++ b/src/zwa2_controller/extension/nabucasa_zwa2_extension/src/cmds_proprietary.c
@@ -291,22 +291,23 @@ ZW_ADD_CMD(FUNC_ID_NABU_CASA)
   case NABU_CASA_BOOTLOADER_INFO:
   {
     // HOST->ZW (REQ): NABU_CASA_BOOTLOADER_INFO
-    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | version[4] | capabilities[4]
+    // ZW->HOST (RES): NABU_CASA_BOOTLOADER_INFO | major | minor | customer | capabilities[4]
 
     // bootloader_getInfo() leaves the version untouched when it finds no
     // bootloader table, so the initializer defines what gets reported.
     BootloaderInformation_t btlInfo = { 0 };
     bootloader_getInfo(&btlInfo);
 
-    const uint32_t words[] = { btlInfo.version, btlInfo.capabilities };
+    // The SDK's customer field is 16 bits wide, but only its low byte is sent
+    // because the version is consumed as major.minor.customer.
+    response[i++] = (uint8_t)(btlInfo.version >> BOOTLOADER_VERSION_MAJOR_SHIFT);
+    response[i++] = (uint8_t)(btlInfo.version >> BOOTLOADER_VERSION_MINOR_SHIFT);
+    response[i++] = (uint8_t)btlInfo.version;
 
-    for (unsigned w = 0; w < sizeof(words) / sizeof(words[0]); w++)
-    {
-      response[i++] = (uint8_t)(words[w] >> 24);
-      response[i++] = (uint8_t)(words[w] >> 16);
-      response[i++] = (uint8_t)(words[w] >> 8);
-      response[i++] = (uint8_t)(words[w]);
-    }
+    response[i++] = (uint8_t)(btlInfo.capabilities >> 24);
+    response[i++] = (uint8_t)(btlInfo.capabilities >> 16);
+    response[i++] = (uint8_t)(btlInfo.capabilities >> 8);
+    response[i++] = (uint8_t)btlInfo.capabilities;
     break;
   }
 


### PR DESCRIPTION
Lets the host read the bootloader version while the application is running, instead of rebooting into the bootloader and parsing the `Gecko Bootloader vX.YY.ZZ` banner off the XMODEM menu.

## New command

```
HOST->ZW: FUNC_ID_PROPRIETARY_0 | NABU_CASA_BOOTLOADER_INFO
ZW->HOST: FUNC_ID_PROPRIETARY_0 | NABU_CASA_BOOTLOADER_INFO | major | minor | customer | capabilities[4]
```

The response is always 7 bytes after the subcommand echo.

- **version** — the three fields of `MainBootloaderTable_t.header.version`, one byte each, matching how the version is consumed and displayed. The customer field is the part we bump per bootloader release. The SDK stores it as 16 bits, so only its low byte is reported.
- **capabilities** — the bootloader capability mask, big-endian. `0x001004F1` on the shipped ZWA-2 bootloader: enforces signed upgrades, is upgradable, parses plain/signed/encrypted GBL, exposes a peripheral list, has a communication interface.

## Where the data comes from

`bootloader_getInfo()` supplies both values. The 10th word of the bootloader vector table (0x08000028 on EFR32ZG23) points to `MainBootloaderTable_t`, and the SDK reads the version and capabilities out of it after checking that pointer and the `0x5ECDB007` magic.

There is no failure path. The ZWA-2 application is linked at `BTL_APPLICATION_BASE` (0x08006000) while the bootloader owns the reset vector at flash base, so an application that is running at all has a valid bootloader below it. The `{ 0 }` initializer on `BootloaderInformation_t` still matters, because `bootloader_getInfo()` leaves the version field untouched on its `NO_BOOTLOADER` paths.

The header layout version (`header.layout`, currently 2) is deliberately not sent. If Silicon Labs ever changes the table format, the firmware can translate before responding.

## Notes

- `bootloader_interface` is added to the component's `requires`. It was already pulled in transitively by `zw_core`, so this only makes the dependency explicit.
- Version bumped to 1.3.1 (`USER_APP_PATCH: 1`) with a changelog entry, per the `A.BBC` scheme in the project README.

## Testing

Verified on a ZWA-2 (serial 8CBFEA8F69D8) with the CI artifact from this branch. The exchange on the wire:

```
» [REQ] [Proprietary_F0]  payload: 0x09
« [RES] [Proprietary_F0]  payload: 0x09 030201 001004f1
```

That decodes to version `3.2.1`, which matches the banner the bootloader itself prints (`Gecko Bootloader v3.02.01`), and capabilities `0x001004F1`. The supported-subcommands bitmask advertises 9, so older hosts and older firmware both degrade cleanly.

Host support: zwave-js/zwave-js#9095
