### PR TITLE
fix: work around missing listening flag in controller node info

### DIFF
--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.1
 * Added a proprietary Serial API command to query the bootloader version and capabilities without rebooting into the bootloader.
-* Fixed the radio turning off after the first received frame on controllers migrated from the 500 series, where the listening flag in the controller's own node info was left unset.
+* Fixed an issue where the radio could turn off after one received frame. This affected some controllers migrated from the 500 series, where the listening flag in the controller's own node info was left unset.
 
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.

--- a/src/zwa2_controller/CHANGELOG.md
+++ b/src/zwa2_controller/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.3.1
 * Added a proprietary Serial API command to query the bootloader version and capabilities without rebooting into the bootloader.
+* Fixed the radio turning off after the first received frame on controllers migrated from the 500 series, where the listening flag in the controller's own node info was left unset.
 
 # 1.3.0
 Updated to Simplicity SDK 2026.6.1 (Z-Wave SDK 8.1.1), restoring runtime Image Rejection calibration and fixing a transmission stall under LBT/CSMA.

--- a/src/zwa2_controller/app.c
+++ b/src/zwa2_controller/app.c
@@ -453,6 +453,15 @@ appFileSystemInit(void)
    */
   if (SerialApiFileInit()) {
     ReadApplicationSettings(&AppNodeInfo->DeviceOptionsMask, &AppNodeInfo->NodeType.generic, &AppNodeInfo->NodeType.specific);
+
+    // Workaround: Migrations from older 500-series controllers could leave the
+    // listening flag unset. SDK 8.0.0+ started evaluating it though, so we must
+    // set it here to prevent controllers from turning off their radio.
+    if (!(AppNodeInfo->DeviceOptionsMask & APPLICATION_NODEINFO_LISTENING)) {
+      AppNodeInfo->DeviceOptionsMask |= APPLICATION_NODEINFO_LISTENING;
+      SaveApplicationSettings(AppNodeInfo->DeviceOptionsMask, AppNodeInfo->NodeType.generic, AppNodeInfo->NodeType.specific);
+    }
+
     ReadApplicationCCInfo(&CommandClasses.UnSecureIncludedCC.iListLength,
                           (uint8_t*)CommandClasses.UnSecureIncludedCC.pCommandClasses,
                           &CommandClasses.SecureIncludedUnSecureCC.iListLength,


### PR DESCRIPTION
Migrations from older 500-series controllers could leave the listening flag in the controller's own node info unset. SDK 8.0.0+ started using this flag as the source of truth for configuring the radio, rather than a hardcoded compile time constant. This causes controllers with the flag unset to turn off their radio after the first RX event.

This PR ensures we correct the flag if it is detected to be unset.

Fixes: https://github.com/NabuCasa/zwave-firmware/issues/19