### PR TITLE
Fix manifest generation for encrypted GBLs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -288,7 +288,9 @@ jobs:
 
       - name: Generate manifest
         run: |
-          /opt/venv/bin/python3 tools/create_manifest.py artifacts src > artifacts/manifest.json
+          /opt/venv/bin/python3 tools/create_manifest.py artifacts src \
+            --encryption-key src/zwa2_controller/keys/vendor_encrypt.key \
+            > artifacts/manifest.json
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -288,8 +288,9 @@ jobs:
 
       - name: Generate manifest
         run: |
-          /opt/venv/bin/python3 tools/create_manifest.py artifacts src \
-            --encryption-key src/zwa2_controller/keys/vendor_encrypt.key \
+          /opt/venv/bin/python3 -m tools.create_manifest \
+            --manifests manifests \
+            --artifacts artifacts \
             > artifacts/manifest.json
 
       - name: Upload artifact

--- a/manifests/nabucasa/zwa2/zwa2_bootloader.yaml
+++ b/manifests/nabucasa/zwa2/zwa2_bootloader.yaml
@@ -8,6 +8,7 @@ toolchain: "gcc:14.2.1.20241119"
 gbl:
   fw_type: gecko-bootloader
   gecko_bootloader_version: dynamic
+  baudrate: 115200
   encrypt_key: config/keys/vendor_encrypt.key
   sign_key: config/keys/vendor_sign.key
   compression: lzma

--- a/manifests/nabucasa/zwa2/zwa2_controller.yaml
+++ b/manifests/nabucasa/zwa2/zwa2_controller.yaml
@@ -4,9 +4,11 @@ base_project: src/zwa2_controller
 filename: "{manifest_name}_{zwave_version}"
 sdk: "simplicity_sdk:2026.6.1"
 toolchain: "gcc:14.2.1.20241119"
+
 gbl:
   fw_type: zwave_ncp
   zwave_version: dynamic
+  baudrate: 115200
   encrypt_key: config/keys/vendor_encrypt.key
   sign_key: config/keys/vendor_sign.key
   compression: lzma

--- a/src/bootloader/CHANGELOG.md
+++ b/src/bootloader/CHANGELOG.md
@@ -3,6 +3,9 @@ Updated to Simplicity SDK 2026.6.1, migrating the ZWA-2 bootloader from the stan
 
 - Updated to Simplicity SDK 2026.6.1, up from Simplicity SDK 2024.12.2.
 
+# 3.2.0
+Updated to Simplicity SDK 2026.6.1.
+
 # 3.0.1
 Initial ZWA-2 bootloader release based on Simplicity SDK 2024.12.2.
 

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -27,6 +27,7 @@ from .create_gbl import create_gbl
 
 LOGGER = logging.getLogger(__name__)
 
+PROJECTS_ROOT = pathlib.Path(__file__).parent.parent
 
 yaml = YAML(typ="safe")
 
@@ -396,14 +397,77 @@ def remap_debug_build_paths(elf_path: pathlib.Path, prefix_map: dict[str, str]) 
 
 
 @dataclasses.dataclass(frozen=True)
+class Manifest:
+    """A build manifest."""
+
+    path: pathlib.Path
+    config: dict[str, typing.Any]
+
+    @classmethod
+    def load(cls, path: pathlib.Path) -> Manifest:
+        return cls(path=path, config=yaml.load(path.read_text()))
+
+    @property
+    def name(self) -> str:
+        return self.path.stem
+
+    @property
+    def gbl(self) -> dict[str, typing.Any]:
+        return self.config["gbl"]
+
+    @property
+    def sdk_version(self) -> str:
+        """The SDK version the manifest pins, without the SDK's name."""
+        return self.config["sdk"].split(":", 1)[1]
+
+    @property
+    def base_project_path(self) -> pathlib.Path:
+        path = PROJECTS_ROOT / self.config["base_project"]
+        assert path.is_relative_to(PROJECTS_ROOT)
+
+        return path
+
+    @property
+    def encryption_key_path(self) -> pathlib.Path | None:
+        """The image encryption key, if the manifest encrypts its firmware."""
+        if "encrypt_key" not in self.gbl:
+            return None
+
+        # `gbl.encrypt_key` points into the generated project, where the manifest's
+        # `config_file` entries are copied under that same relative path
+        return self.path.parent / self.gbl["encrypt_key"]
+
+    @property
+    def version_key(self) -> str | None:
+        """The metadata key holding this firmware's own version, if it has one."""
+        version_keys = [
+            key
+            for key, value in self.gbl.items()
+            if value == "dynamic" and key.endswith("_version")
+        ]
+
+        # Some firmwares, such as the Zigbee router, carry no version of their own
+        if not version_keys:
+            return None
+
+        (version_key,) = version_keys
+
+        return version_key
+
+    def output_stem(self, template_env: dict[str, typing.Any]) -> str:
+        """The output filename, without an extension, for a build's metadata."""
+        return evaluate_f_string(
+            self.config.get("filename", "{manifest_name}"),
+            {"manifest_name": self.name, **template_env},
+        )
+
+
+@dataclasses.dataclass(frozen=True)
 class ResolvedBuild:
     """Everything about a build that is resolved up front and never changes."""
 
-    manifest: dict[str, typing.Any]
-    manifest_path: pathlib.Path
+    manifest: Manifest
     build_dir: pathlib.Path
-    projects_root: pathlib.Path
-    base_project_path: pathlib.Path
     base_project_name: str
     sdk: pathlib.Path
     sdk_name: str
@@ -413,8 +477,12 @@ class ResolvedBuild:
     build_timestamp: datetime
 
     @property
+    def base_project_path(self) -> pathlib.Path:
+        return self.manifest.base_project_path
+
+    @property
     def manifest_dir(self) -> pathlib.Path:
-        return self.manifest_path.parent
+        return self.manifest.path.parent
 
     @property
     def build_template_path(self) -> pathlib.Path:
@@ -533,14 +601,16 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
 def resolve_build(args: argparse.Namespace) -> ResolvedBuild:
     """Load the manifest and pin down the SDK, toolchain, and build paths."""
-    manifest = yaml.load(args.manifest.read_text())
+    manifest = Manifest.load(args.manifest)
 
     for key, override in args.overrides:
-        manifest[key] = override
+        manifest.config[key] = override
 
     sdks = load_sdks(args.sdks)
     sdk, sdk_and_version = next(
-        (path, version) for path, version in sdks.items() if version == manifest["sdk"]
+        (path, version)
+        for path, version in sdks.items()
+        if version == manifest.config["sdk"]
     )
     sdk_name, sdk_version = sdk_and_version.split(":", 1)
 
@@ -548,23 +618,16 @@ def resolve_build(args: argparse.Namespace) -> ResolvedBuild:
     toolchain_path = next(
         path
         for path, name in toolchains.items()
-        if manifest["toolchain"] in (name, name.split(":", 1)[1])
+        if manifest.config["toolchain"] in (name, name.split(":", 1)[1])
     )
     toolchain = Toolchain(toolchains[toolchain_path].split(":", 1)[0])
 
-    projects_root = pathlib.Path(__file__).parent.parent
-    base_project_path = projects_root / manifest["base_project"]
-    assert base_project_path.is_relative_to(projects_root)
-
     # The template copy preserves `.slcp` files, so the source project names the build
-    (base_project_slcp,) = base_project_path.glob("*.slcp")
+    (base_project_slcp,) = manifest.base_project_path.glob("*.slcp")
 
     return ResolvedBuild(
         manifest=manifest,
-        manifest_path=args.manifest,
         build_dir=args.build_dir,
-        projects_root=projects_root,
-        base_project_path=base_project_path,
         base_project_name=base_project_slcp.stem,
         sdk=sdk,
         sdk_name=sdk_name,
@@ -595,7 +658,7 @@ def copy_base_project(build: ResolvedBuild) -> None:
 
     # Copy SDK files into the build template (e.g. unmodified sample app sources).
     # Files already present in the project (customized) are not overwritten.
-    for sdk_file in build.manifest.get("copy_sdk_files", []):
+    for sdk_file in build.manifest.config.get("copy_sdk_files", []):
         src = build.sdk / sdk_file["source"]
         dst = build.build_template_path / sdk_file["path"]
 
@@ -666,7 +729,7 @@ def merge_manifest_into_slcp(
 def prepare_project_slcp(build: ResolvedBuild) -> dict[str, typing.Any]:
     """Merge the manifest into the copied project and write it back out."""
     # Config files (e.g. ZAP files) live next to the manifest, not in the base project
-    for config_file in build.manifest.get("config_file", []):
+    for config_file in build.manifest.config.get("config_file", []):
         src_path = build.manifest_dir / config_file["path"]
         dst_path = build.build_template_path / config_file["path"]
         dst_path.parent.mkdir(parents=True, exist_ok=True)
@@ -674,7 +737,7 @@ def prepare_project_slcp(build: ResolvedBuild) -> dict[str, typing.Any]:
         LOGGER.info("Copied config file: %s", config_file["path"])
 
     base_project = merge_manifest_into_slcp(
-        yaml.load(build.base_project_slcp.read_text()), build.manifest
+        yaml.load(build.base_project_slcp.read_text()), build.manifest.config
     )
 
     with build.base_project_slcp.open("w") as f:
@@ -687,7 +750,7 @@ def run_slc_generate(
     build: ResolvedBuild, slc: list[str], tool_paths: list[pathlib.Path]
 ) -> None:
     """Generate a chip-specific project from the modified base project."""
-    LOGGER.info(f"Generating project for {build.manifest['device']}")
+    LOGGER.info(f"Generating project for {build.manifest.config['device']}")
 
     # fmt: off
     subprocess_run_verbose(
@@ -696,7 +759,7 @@ def run_slc_generate(
             "generate",
             "--verbose", "DEBUG",
             "--trust-totality",
-            "--with", build.manifest["device"],
+            "--with", build.manifest.config["device"],
             "--project-file", build.base_project_slcp.resolve(),
             "--export-destination", build.build_dir.resolve(),
             "--copy-proj-sources",
@@ -799,23 +862,23 @@ def exclude_definitions_from_lto(build: ResolvedBuild, definitions: list[str]) -
 
 def apply_sdk_patches(build: ResolvedBuild) -> None:
     """Patch the copied SDK. A last resort, prefer SDK extensions wherever possible!"""
-    if not build.manifest.get("sdk_patches"):
+    if not build.manifest.config.get("sdk_patches"):
         return
 
     copied_sdk_dir = next(build.build_dir.glob(f"{build.sdk_name}_*"))
 
-    for patch_path in build.manifest["sdk_patches"]:
+    for patch_path in build.manifest.config["sdk_patches"]:
         patch_file = build.base_project_path / "sdk_patches" / patch_path
         LOGGER.info("Applying SDK patch: %s", patch_file.name)
         subprocess.run(
             [
                 "git",
                 "apply",
-                f"--directory={copied_sdk_dir.resolve().relative_to(build.projects_root.resolve())}",
+                f"--directory={copied_sdk_dir.resolve().relative_to(PROJECTS_ROOT.resolve())}",
                 str(patch_file.resolve()),
             ],
             check=True,
-            cwd=build.projects_root,
+            cwd=PROJECTS_ROOT,
         )
 
 
@@ -1148,12 +1211,12 @@ def main() -> None:
 
     # Template variables for C defines and the output filename
     template_env = {
-        "git_repo_hash": get_git_commit_id(repo=build.projects_root),
-        "manifest_name": build.manifest_path.stem,
+        "git_repo_hash": get_git_commit_id(repo=PROJECTS_ROOT),
+        "manifest_name": build.manifest.name,
         "now": build.build_timestamp,
     }
 
-    c_defines = normalize_c_defines(build.manifest)
+    c_defines = normalize_c_defines(build.manifest.config)
     c_flag_defines = [
         f"-D{define}={config['value']}"
         for define, config in c_defines.items()
@@ -1203,15 +1266,14 @@ def main() -> None:
         gsdk_path=build.sdk,
         project_name=build.base_project_name,
         sdk_version=build.sdk_version,
-        gbl_metadata=build.manifest["gbl"],
+        gbl_metadata=build.manifest.gbl,
     )
 
     output_artifact = (build.cmake_dir / build.base_project_name).with_suffix(".gbl")
     verify_build_reproducibility(build, output_artifact)
 
-    base_filename = evaluate_f_string(
-        build.manifest.get("filename", "{manifest_name}"),
-        {**template_env, **extracted_gbl_metadata},
+    base_filename = build.manifest.output_stem(
+        {**template_env, **extracted_gbl_metadata}
     )
 
     args.output_dir.mkdir(exist_ok=True)

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -24,6 +24,12 @@ from pygbl import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# A firmware's `fw_type` names its source directory, except where the two have drifted
+SOURCE_DIRS = {
+    "gecko-bootloader": "bootloader",
+    "zwave_ncp": "zwa2_controller",
+}
+
 
 def parse_markdown_changelog(text: str) -> list[dict[str, str | None]]:
     """Parse a changelog into an ordered list of entries, newest first."""
@@ -149,7 +155,10 @@ def main():
             continue
 
         fw_type = fw["metadata"]["fw_type"]
-        changelog_md = args.source_dir / fw_type / "CHANGELOG.md"
+
+        changelog_md = (
+            args.source_dir / SOURCE_DIRS.get(fw_type, fw_type) / "CHANGELOG.md"
+        )
 
         if fw_type not in changelogs:
             if changelog_md.exists():

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tool to create a JSON manifest file for a collection of firmwares."""
 
 from __future__ import annotations
@@ -10,6 +9,7 @@ import logging
 import pathlib
 import re
 import sys
+import typing
 from datetime import UTC, datetime
 
 from pygbl import (
@@ -22,13 +22,12 @@ from pygbl import (
     read_encryption_key,
 )
 
+from .build_project import Manifest
+
 _LOGGER = logging.getLogger(__name__)
 
-# A firmware's `fw_type` names its source directory, except where the two have drifted
-SOURCE_DIRS = {
-    "gecko-bootloader": "bootloader",
-    "zwave_ncp": "zwa2_controller",
-}
+# Metadata fields copied verbatim from the manifest's `gbl` section by `create_gbl`
+STATIC_METADATA_KEYS = ("fw_type", "fw_variant", "baudrate")
 
 
 def parse_markdown_changelog(text: str) -> list[dict[str, str | None]]:
@@ -55,38 +54,94 @@ def parse_markdown_changelog(text: str) -> list[dict[str, str | None]]:
     return entries
 
 
-def get_firmware_version(metadata: dict) -> str | None:
-    """Extract the firmware version from its metadata, if it is versioned at all."""
-    version_keys = {k for k in metadata if k.endswith("_version")} - {
-        "sdk_version",
-        "metadata_version",
-    }
+def load_manifests(directory: pathlib.Path) -> list[Manifest]:
+    """Load every build manifest below a directory."""
+    paths = sorted(
+        path for pattern in ("*.yaml", "*.yml") for path in directory.rglob(pattern)
+    )
 
-    # Some firmwares, such as the Zigbee router, carry no version of their own
-    if not version_keys:
+    return [Manifest.load(path) for path in paths]
+
+
+def is_encrypted(firmware: FirmwareImage) -> bool:
+    """Whether an image's payload is encrypted, and so needs a key to be read."""
+    if not isinstance(firmware, GBL3Image):
+        return False
+
+    return GBL3Type.ENCRYPTION_AESCCM in firmware.get_first_tag(GBL3Header).type
+
+
+def unlock(manifest: Manifest, firmware: FirmwareImage) -> FirmwareImage | None:
+    """Open an image with a manifest's own key, or `None` if it did not build it."""
+    if is_encrypted(firmware) != (manifest.encryption_key_path is not None):
         return None
 
-    (version_key,) = version_keys
-
-    return metadata[version_key]
-
-
-def maybe_decrypt_firmware(firmware: FirmwareImage, keys: list[bytes]) -> FirmwareImage:
-    """Decrypt an encrypted image to access metadata."""
-    if not isinstance(firmware, GBL3Image):
+    if manifest.encryption_key_path is None:
         return firmware
 
-    if GBL3Type.ENCRYPTION_AESCCM not in firmware.get_first_tag(GBL3Header).type:
-        return firmware
+    key = read_encryption_key(manifest.encryption_key_path.read_text())
 
-    # The image does not identify its key, so every key is tried until one decrypts
-    for key in keys:
-        try:
-            return firmware.decrypt(key)
-        except GBLError:
+    try:
+        return firmware.decrypt(key)
+    except GBLError:
+        return None
+
+
+def metadata_mismatches(
+    manifest: Manifest, metadata: dict[str, typing.Any]
+) -> list[str]:
+    """Describe every way an image's metadata disagrees with its manifest."""
+    expected = {
+        "sdk_version": manifest.sdk_version,
+        **{key: manifest.gbl.get(key) for key in STATIC_METADATA_KEYS},
+    }
+
+    mismatches = [
+        f"{key}: manifest declares {value!r}, image has {metadata.get(key)!r}"
+        for key, value in expected.items()
+        if metadata.get(key) != value
+    ]
+
+    mismatches.extend(
+        f"{key}: manifest declares it dynamic but the image has no such key"
+        for key, value in manifest.gbl.items()
+        if value == "dynamic" and key not in metadata
+    )
+
+    return mismatches
+
+
+def find_manifest(
+    manifests: list[Manifest], firmware: FirmwareImage, stem: str
+) -> tuple[Manifest, dict[str, typing.Any]] | None:
+    """Find the manifest whose build produced a firmware file, and read its metadata."""
+    matches = []
+
+    for manifest in manifests:
+        image = unlock(manifest, firmware)
+
+        if image is None:
             continue
 
-    raise ValueError("Image is encrypted, pass a matching --encryption-key")
+        raw_metadata = image.get_metadata()
+
+        if raw_metadata is None:
+            continue
+
+        metadata = json.loads(raw_metadata)
+
+        # `fw_type` is checked first: the output filename of an unrelated firmware is
+        # templated on metadata this image does not carry
+        if (
+            manifest.gbl.get("fw_type") == metadata["fw_type"]
+            and manifest.output_stem(metadata) == stem
+        ):
+            matches.append((manifest, metadata))
+
+    if len(matches) != 1:
+        return None
+
+    return matches[0]
 
 
 def main():
@@ -94,28 +149,24 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
-        "firmware_dir",
+        "--manifests",
         type=pathlib.Path,
+        required=True,
+        help="Directory containing the build manifests the firmwares were built from",
+    )
+    parser.add_argument(
+        "--artifacts",
+        type=pathlib.Path,
+        required=True,
         help="Directory containing firmware images",
-    )
-    parser.add_argument(
-        "source_dir",
-        type=pathlib.Path,
-        help="Directory containing the source tree to identify changelogs",
-    )
-    parser.add_argument(
-        "--encryption-key",
-        type=pathlib.Path,
-        action="append",
-        default=[],
-        help="Path to an image encryption key token file, for encrypted GBL files. Can be passed more than once",
     )
 
     args = parser.parse_args()
 
-    keys = [read_encryption_key(p.read_text()) for p in args.encryption_key]
+    manifests = load_manifests(args.manifests)
+    _LOGGER.info("Loaded %d manifests from %s", len(manifests), args.manifests)
 
-    manifest = {
+    output = {
         "metadata": {
             "created_at": datetime.now(UTC).isoformat(),
         },
@@ -123,7 +174,11 @@ def main():
         "firmwares": [],
     }
 
-    for firmware_file in sorted(args.firmware_dir.glob("*.gbl")):
+    inconsistent = False
+    matched: dict[pathlib.Path, Manifest] = {}
+    changelogs: dict[str, list[dict[str, str | None]]] = {}
+
+    for firmware_file in sorted(args.artifacts.glob("*.gbl")):
         data = firmware_file.read_bytes()
 
         try:
@@ -132,33 +187,46 @@ def main():
             _LOGGER.warning("Ignoring invalid firmware file: %s", firmware_file)
             continue
 
-        raw_metadata = maybe_decrypt_firmware(firmware, keys).get_metadata()
-        metadata = json.loads(raw_metadata) if raw_metadata is not None else None
+        match = find_manifest(manifests, firmware, firmware_file.stem)
 
-        manifest["firmwares"].append(
-            {
-                "filename": firmware_file.name,
-                "version": get_firmware_version(metadata) if metadata else None,
-                "checksum": f"sha3-256:{hashlib.sha3_256(data).hexdigest()}",
-                "size": len(data),
-                "metadata": metadata,
-                "release_notes": None,
-                "release_summary": None,
-            }
-        )
-
-    missing_changelogs = False
-    changelogs: dict[str, list[dict[str, str | None]]] = {}
-
-    for fw in manifest["firmwares"]:
-        if fw["metadata"] is None:
+        if match is None:
+            _LOGGER.error(
+                "Firmware %s matches no manifest in %s", firmware_file, args.manifests
+            )
+            inconsistent = True
             continue
 
-        fw_type = fw["metadata"]["fw_type"]
+        source_manifest, metadata = match
+        mismatches = metadata_mismatches(source_manifest, metadata)
 
-        changelog_md = (
-            args.source_dir / SOURCE_DIRS.get(fw_type, fw_type) / "CHANGELOG.md"
-        )
+        if mismatches:
+            _LOGGER.error(
+                "Firmware %s disagrees with %s:\n - %s",
+                firmware_file,
+                source_manifest.path,
+                "\n - ".join(mismatches),
+            )
+            inconsistent = True
+            continue
+
+        matched[source_manifest.path] = source_manifest
+        version_key = source_manifest.version_key
+        version = metadata[version_key] if version_key else None
+
+        fw = {
+            "filename": firmware_file.name,
+            "version": version,
+            "checksum": f"sha3-256:{hashlib.sha3_256(data).hexdigest()}",
+            "size": len(data),
+            "metadata": metadata,
+            "release_notes": None,
+            "release_summary": None,
+        }
+        output["firmwares"].append(fw)
+
+        # The manifest names the source directory the changelog lives in
+        fw_type = metadata["fw_type"]
+        changelog_md = source_manifest.base_project_path / "CHANGELOG.md"
 
         if fw_type not in changelogs:
             if changelog_md.exists():
@@ -169,18 +237,16 @@ def main():
         if not changelogs[fw_type]:
             continue
 
-        entry = next(
-            (e for e in changelogs[fw_type] if e["version"] == fw["version"]), None
-        )
+        entry = next((e for e in changelogs[fw_type] if e["version"] == version), None)
 
         if entry is None:
             _LOGGER.error(
                 "Firmware %s version %s has no changelog entry in %s",
-                fw["filename"],
-                fw["version"],
+                firmware_file,
+                version,
                 changelog_md,
             )
-            missing_changelogs = True
+            inconsistent = True
             continue
 
         # These two fields are kept for backwards compatibility with older clients that
@@ -189,13 +255,18 @@ def main():
         fw["release_notes"] = entry["summary"]
         fw["release_summary"] = entry["notes"]
 
-    manifest["changelogs"] = {t: e for t, e in changelogs.items() if e}
+    for unbuilt in manifests:
+        if unbuilt.path not in matched:
+            _LOGGER.warning("Manifest %s produced no firmware", unbuilt.path)
 
-    if missing_changelogs:
+    output["changelogs"] = {t: e for t, e in changelogs.items() if e}
+
+    if inconsistent:
         sys.exit(1)
 
-    print(json.dumps(manifest, indent=2))
+    print(json.dumps(output, indent=2))
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/tools/create_manifest.py
+++ b/tools/create_manifest.py
@@ -12,7 +12,15 @@ import re
 import sys
 from datetime import UTC, datetime
 
-from pygbl import GBLError, parse_firmware_image
+from pygbl import (
+    FirmwareImage,
+    GBL3Header,
+    GBL3Image,
+    GBL3Type,
+    GBLError,
+    parse_firmware_image,
+    read_encryption_key,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +65,24 @@ def get_firmware_version(metadata: dict) -> str | None:
     return metadata[version_key]
 
 
+def maybe_decrypt_firmware(firmware: FirmwareImage, keys: list[bytes]) -> FirmwareImage:
+    """Decrypt an encrypted image to access metadata."""
+    if not isinstance(firmware, GBL3Image):
+        return firmware
+
+    if GBL3Type.ENCRYPTION_AESCCM not in firmware.get_first_tag(GBL3Header).type:
+        return firmware
+
+    # The image does not identify its key, so every key is tried until one decrypts
+    for key in keys:
+        try:
+            return firmware.decrypt(key)
+        except GBLError:
+            continue
+
+    raise ValueError("Image is encrypted, pass a matching --encryption-key")
+
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -71,8 +97,18 @@ def main():
         type=pathlib.Path,
         help="Directory containing the source tree to identify changelogs",
     )
+    parser.add_argument(
+        "--encryption-key",
+        type=pathlib.Path,
+        action="append",
+        default=[],
+        help="Path to an image encryption key token file, for encrypted GBL files. Can be passed more than once",
+    )
 
     args = parser.parse_args()
+
+    keys = [read_encryption_key(p.read_text()) for p in args.encryption_key]
+
     manifest = {
         "metadata": {
             "created_at": datetime.now(UTC).isoformat(),
@@ -90,8 +126,7 @@ def main():
             _LOGGER.warning("Ignoring invalid firmware file: %s", firmware_file)
             continue
 
-        # Encrypted images keep their metadata inside the ciphertext, so it is absent
-        raw_metadata = firmware.get_metadata()
+        raw_metadata = maybe_decrypt_firmware(firmware, keys).get_metadata()
         metadata = json.loads(raw_metadata) if raw_metadata is not None else None
 
         manifest["firmwares"].append(


### PR DESCRIPTION
GBL encryption encrypts both the firmware and the associated metadata, which means that we cannot read ZWA-2 GBL files during manifest generation without the encryption key. This is now provided as part of CI (the private key is intentionally part of this repo) and `manifest.json` will now contain a complete changelog for all known firmware types.

CC @AlCalzone 