### PR TITLE
Add KEEPALIVE_CLUSTER to zigbee_router to fix tc-keepalive plugin

### DIFF
--- a/src/zigbee_router/config/zcl/zcl_config.zap
+++ b/src/zigbee_router/config/zcl/zcl_config.zap
@@ -265,6 +265,32 @@
               "reportableChange": 0
             }
           ]
+        },
+        {
+          "name": "Keep-Alive",
+          "code": 37,
+          "mfgCode": null,
+          "define": "KEEPALIVE_CLUSTER",
+          "side": "client",
+          "enabled": 1,
+          "attributes": [
+            {
+              "name": "cluster revision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "client",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "0x0001",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
The tc-keepalive plugin included by the zigbee_router base project would frequently report keepalive timeouts and periodically disconnect, even when connecting to a ZBT-1 with Zigbee 4.0 support (v2026.08.18-beta1).

This (cluster 0x0025) wasn't advertised on join during initial interview, so zigpy would reject the keepalives. Only the client cluster is included here, as it's all that's required.

Note that this is included in the ZBT-2's zcl_config.zap since df44c39fe2, so would only affect third-party projects utilizing zigbee_router.