### PR TITLE
fix: Implement DLK negotiation callback for direct router joins

### DIFF
--- a/manifests/nabucasa/skyconnect/skyconnect_zigbee_ncp.yaml
+++ b/manifests/nabucasa/skyconnect/skyconnect_zigbee_ncp.yaml
@@ -27,6 +27,8 @@ add_components:
   package: xncp_common
 
 c_defines:
+  XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE: 1
+
   XNCP_MFG_MANUF_NAME: '"Nabu Casa"'
   XNCP_MFG_BOARD_NAME: '"Home Assistant Connect ZBT-1"'
   XNCP_BUILD_STRING: template:"{now:%Y%m%d%H%M%S}"

--- a/manifests/nabucasa/yellow/yellow_zigbee_ncp.yaml
+++ b/manifests/nabucasa/yellow/yellow_zigbee_ncp.yaml
@@ -39,6 +39,8 @@ configuration:
   SL_CLOCK_MANAGER_PCLK_DIVIDER: SL_CLOCK_MANAGER_PCLK_DIV_MIN
 
 c_defines:
+  XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE: 1
+
   # SDK bug: the PCLK divider is set to 1 for the MGM210, it is set to 2 everywhere else
   SL_CLOCK_MANAGER_PCLK_DIVIDER: SL_CLOCK_MANAGER_PCLK_DIV_MIN
 

--- a/manifests/nabucasa/zbt2/zbt2_zigbee_ncp.yaml
+++ b/manifests/nabucasa/zbt2/zbt2_zigbee_ncp.yaml
@@ -62,6 +62,8 @@ configuration:
   SL_SPIDRV_EUSART_WS2812_CS_CONTROL: spidrvCsControlApplication
 
 c_defines:
+  XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE: 1
+
   XNCP_MFG_MANUF_NAME: '"Nabu Casa"'
   XNCP_MFG_BOARD_NAME: '"Home Assistant Connect ZBT-2"'
   XNCP_BUILD_STRING: template:"{now:%Y%m%d%H%M%S}"

--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 9.1.1.1
+Fix Zigbee 4.0 routers failing to join directly through the coordinator.
+
+- Fixed Zigbee 4.0 routers without an install code failing to join when paired directly via the coordinator instead of through another router. The coordinator committed to an install code key negotiation that the joiner could not complete and never fell back to the standard network key delivery. It now only negotiates a dynamic link key when a link key has been provisioned for that specific device, and otherwise uses the standard join.
+
 # 9.1.1.0
 Built with EmberZNet 9.1 from Simplicity SDK 2026.6.1, migrating us from Gecko SDK to Simplicity SDK. Faster message sending, Zigbee 4.0 support, and a few increased buffers.
 

--- a/src/zigbee_ncp/CHANGELOG.md
+++ b/src/zigbee_ncp/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 9.1.1.1
 Fix Zigbee 4.0 routers failing to join directly through the coordinator.
 
-- Fixed Zigbee 4.0 routers without an install code failing to join when paired directly via the coordinator instead of through another router. The coordinator committed to an install code key negotiation that the joiner could not complete and never fell back to the standard network key delivery. It now only negotiates a dynamic link key when a link key has been provisioned for that specific device, and otherwise uses the standard join.
+- Fixed Zigbee 4.0 routers without an install code failing to join when paired directly via the coordinator instead of through another router. The coordinator committed to an install code key negotiation that the joiner could not complete and never fell back to the standard network key delivery. It now only negotiates a dynamic link key when a transient key has been provisioned for that specific device, and otherwise uses the standard join.
 
 # 9.1.1.0
 Built with EmberZNet 9.1 from Simplicity SDK 2026.6.1, migrating us from Gecko SDK to Simplicity SDK. Faster message sending, Zigbee 4.0 support, and a few increased buffers.

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/ncp_dlk_policy.slcc
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/ncp_dlk_policy.slcc
@@ -1,0 +1,23 @@
+id: ncp_dlk_policy
+label: NCP Dynamic Link Key Policy
+package: custom
+description: >-
+  Overrides the stack's weak `sl_zigbee_zdo_dlk_select_negotiation_parameters_callback`.
+  The default selects install-code DLK for any joiner that advertises install code
+  support (every Silabs R23 device does, unconditionally) and satisfies its own PSK
+  lookup with the wildcard `ZigBeeAlliance09` transient key that hosts add for
+  legacy joins. The joiner then has no install code to negotiate with, and the trust
+  center never falls back to sending the network key, so the join dies with
+  SL_STATUS_ZIGBEE_NO_NETWORK_KEY_RECEIVED. This policy only negotiates when a
+  transient key was provisioned for the joiner's exact EUI64 and otherwise returns
+  an error, which the stack turns into the legacy well-known-key network key transport.
+category: Zigbee|NCP
+quality: production
+source:
+  - path: src/ncp_dlk_policy.c
+provides:
+  - name: ncp_dlk_policy
+requires:
+  - name: zigbee_r23_support
+  - name: zigbee_dynamic_commissioning
+  - name: zigbee_debug_print

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/ncp_dlk_policy.slcc
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/ncp_dlk_policy.slcc
@@ -20,4 +20,3 @@ provides:
 requires:
   - name: zigbee_r23_support
   - name: zigbee_dynamic_commissioning
-  - name: zigbee_debug_print

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/ncp_dlk_policy_extension.slce
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/ncp_dlk_policy_extension.slce
@@ -1,0 +1,5 @@
+id: ncp_dlk_policy
+vendor: nabucasa
+version: "1.0.0"
+component_path:
+  - path: "./"

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
@@ -1,0 +1,53 @@
+#include PLATFORM_HEADER
+#include "sl_zigbee.h"
+#include "sl_zigbee_debug_print.h"
+#include "stack/include/sl_zigbee_zdo_dlk_negotiation.h"
+#include "stack/include/zigbee-security-manager.h"
+
+// Strong override of the weak default in `sl_zigbee_r23_app_stubs.c`.
+//
+// Returning an error here makes the trust center skip DLK and deliver the network
+// key the R21 way, encrypted with the well-known key. Returning SL_STATUS_OK commits
+// the trust center to a negotiation with no fallback: it ignores the joiner's error
+// response and never sends the network key. So we only proceed when the host has
+// provisioned a link key for this specific joiner, which is the install code flow.
+//
+// `sl_zigbee_sec_man_export_transient_key_by_eui` matches the exact EUI64 only. The
+// wildcard FF:FF:FF:FF:FF:FF:FF:FF entry that bellows and network-creator-security add
+// on permit-join does not match here, which is the whole point.
+sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
+  sl_zigbee_address_info *partner,
+  sl_zigbee_dlk_supported_negotiation_method their_supported_methods,
+  sl_zigbee_dlk_negotiation_supported_shared_secret_source their_supported_secrets,
+  sl_zigbee_dlk_negotiation_method *selected_method,
+  sl_zigbee_dlk_negotiation_shared_secret_source *selected_secret)
+{
+  sl_zigbee_sec_man_context_t context;
+  sl_zigbee_sec_man_key_t key;
+  sl_zigbee_sec_man_aps_key_metadata_t metadata;
+
+  if (!(their_supported_secrets & DLK_SECRET_MASK_PRECONFIG_INSTALL_CODE)) {
+    return SL_STATUS_NOT_SUPPORTED;
+  }
+
+  if (their_supported_methods & DLK_PROTOCOL_MASK_SPEKE_C25519_SHA256) {
+    *selected_method = DLK_PROTOCOL_ENUM_SPEKE_C25519_SHA256;
+  } else if (their_supported_methods & DLK_PROTOCOL_MASK_SPEKE_C25519_AES128) {
+    *selected_method = DLK_PROTOCOL_ENUM_SPEKE_C25519_AES128;
+  } else {
+    return SL_STATUS_NOT_SUPPORTED;
+  }
+
+  sl_status_t status = sl_zigbee_sec_man_export_transient_key_by_eui(
+    partner->device_long, &context, &key, &metadata);
+
+  if (status != SL_STATUS_OK) {
+    sl_zigbee_app_debug_print("DLK: no link key for ");
+    sl_zigbee_app_debug_print_buffer(partner->device_long, EUI64_SIZE, false);
+    sl_zigbee_app_debug_println(", using legacy join");
+    return SL_STATUS_NOT_FOUND;
+  }
+
+  *selected_secret = DLK_SECRET_ENUM_PRECONFIG_INSTALL_CODE;
+  return SL_STATUS_OK;
+}

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
@@ -17,10 +17,6 @@ sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
   sl_zigbee_dlk_negotiation_method *selected_method,
   sl_zigbee_dlk_negotiation_shared_secret_source *selected_secret)
 {
-  sl_zigbee_sec_man_context_t context;
-  sl_zigbee_sec_man_key_t key;
-  sl_zigbee_sec_man_aps_key_metadata_t metadata;
-
   if (!(their_supported_secrets & DLK_SECRET_MASK_PRECONFIG_INSTALL_CODE)) {
     return SL_STATUS_NOT_SUPPORTED;
   }
@@ -35,8 +31,12 @@ sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
     return SL_STATUS_NOT_SUPPORTED;
   }
 
-  sl_status_t status = sl_zigbee_sec_man_export_transient_key_by_eui(
-    partner->device_long, &context, &key, &metadata);
+  sl_zigbee_sec_man_context_t context;
+  sl_zigbee_sec_man_key_t key;
+  sl_zigbee_sec_man_aps_key_metadata_t metadata;
+
+  sl_status_t status = sl_zigbee_sec_man_export_transient_key_by_eui(partner->device_long, &context, &key, &metadata);
+  memset(&key, 0, sizeof(key));
 
   if (status != SL_STATUS_OK) {
     return SL_STATUS_NOT_FOUND;

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
@@ -32,13 +32,13 @@ sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
   }
 
   sl_zigbee_sec_man_context_t context;
-  sl_zigbee_sec_man_key_t key;
+  sl_zigbee_sec_man_init_context(&context);
+  context.core_key_type = SL_ZB_SEC_MAN_KEY_TYPE_TC_LINK_WITH_TIMEOUT;
+  context.flags |= ZB_SEC_MAN_FLAG_EUI_IS_VALID;
+  memmove(context.eui64, partner->device_long, EUI64_SIZE);
+
   sl_zigbee_sec_man_aps_key_metadata_t metadata;
-
-  sl_status_t status = sl_zigbee_sec_man_export_transient_key_by_eui(partner->device_long, &context, &key, &metadata);
-  memset(&key, 0, sizeof(key));
-
-  if (status != SL_STATUS_OK) {
+  if (sl_zigbee_sec_man_get_aps_key_info(&context, &metadata) != SL_STATUS_OK) {
     return SL_STATUS_NOT_FOUND;
   }
 

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
@@ -29,6 +29,8 @@ sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
     *selected_method = DLK_PROTOCOL_ENUM_SPEKE_C25519_SHA256;
   } else if (their_supported_methods & DLK_PROTOCOL_MASK_SPEKE_C25519_AES128) {
     *selected_method = DLK_PROTOCOL_ENUM_SPEKE_C25519_AES128;
+  } else if (their_supported_methods & DLK_PROTOCOL_MASK_STATIC_KEY_REQUEST) {
+    *selected_method = DLK_PROTOCOL_ENUM_STATIC_KEY;
   } else {
     return SL_STATUS_NOT_SUPPORTED;
   }

--- a/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
+++ b/src/zigbee_ncp/extension/ncp_dlk_policy_extension/src/ncp_dlk_policy.c
@@ -1,6 +1,5 @@
 #include PLATFORM_HEADER
 #include "sl_zigbee.h"
-#include "sl_zigbee_debug_print.h"
 #include "stack/include/sl_zigbee_zdo_dlk_negotiation.h"
 #include "stack/include/zigbee-security-manager.h"
 
@@ -11,10 +10,6 @@
 // the trust center to a negotiation with no fallback: it ignores the joiner's error
 // response and never sends the network key. So we only proceed when the host has
 // provisioned a link key for this specific joiner, which is the install code flow.
-//
-// `sl_zigbee_sec_man_export_transient_key_by_eui` matches the exact EUI64 only. The
-// wildcard FF:FF:FF:FF:FF:FF:FF:FF entry that bellows and network-creator-security add
-// on permit-join does not match here, which is the whole point.
 sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
   sl_zigbee_address_info *partner,
   sl_zigbee_dlk_supported_negotiation_method their_supported_methods,
@@ -42,9 +37,6 @@ sl_status_t sl_zigbee_zdo_dlk_select_negotiation_parameters_callback(
     partner->device_long, &context, &key, &metadata);
 
   if (status != SL_STATUS_OK) {
-    sl_zigbee_app_debug_print("DLK: no link key for ");
-    sl_zigbee_app_debug_print_buffer(partner->device_long, EUI64_SIZE, false);
-    sl_zigbee_app_debug_println(", using legacy join");
     return SL_STATUS_NOT_FOUND;
   }
 

--- a/src/zigbee_ncp/extension/xncp_common_extension/src/ezsp_version.c
+++ b/src/zigbee_ncp/extension/xncp_common_extension/src/ezsp_version.c
@@ -1,0 +1,26 @@
+/*
+ * ezsp_version.c
+ *
+ * Replaces the stack library's `sl_zigbee_version` so the EZSP patch number override
+ * is applied at compile time. Providing the definition here keeps the linker from
+ * pulling `sl_zigbee_version.c.obj` out of the stack archive, whose value LTO would
+ * otherwise fold into the `getValue(VERSION_INFO)` handler.
+ */
+
+#include "sl_zigbee.h"
+#include "xncp_config.h"
+
+#if XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE == 0xFF
+  #define XNCP_EZSP_SPECIAL_VERSION SL_ZIGBEE_SPECIAL_VERSION
+#else
+  #define XNCP_EZSP_SPECIAL_VERSION XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE
+#endif
+
+const sl_zigbee_version_t sl_zigbee_version = {
+  .build = SL_ZIGBEE_BUILD_NUMBER,
+  .major = SL_ZIGBEE_MAJOR_VERSION,
+  .minor = SL_ZIGBEE_MINOR_VERSION,
+  .patch = SL_ZIGBEE_PATCH_VERSION,
+  .special = XNCP_EZSP_SPECIAL_VERSION,
+  .type = SL_ZIGBEE_VERSION_TYPE,
+};

--- a/src/zigbee_ncp/extension/xncp_common_extension/xncp_common_commands.slcc
+++ b/src/zigbee_ncp/extension/xncp_common_extension/xncp_common_commands.slcc
@@ -7,6 +7,7 @@ quality: production
 source:
   - path: src/xncp_common_commands.c
   - path: src/tx_power.c
+  - path: src/ezsp_version.c
 include:
   - path: inc
     file_list:

--- a/src/zigbee_ncp/zigbee_ncp.slcp
+++ b/src/zigbee_ncp/zigbee_ncp.slcp
@@ -6,6 +6,11 @@ quality: production
 description: Zigbee NCP firmware. Derived from the `ncp-uart-hw` example Gecko SDK project.
 author: Nabu Casa
 
+sdk_extension:
+  - id: ncp_dlk_policy
+    vendor: nabucasa
+    version: 1.0.0
+
 component:
   - id: sl_main
   - id: iostream_usart
@@ -29,6 +34,9 @@ component:
   - id: zigbee_r22_support
   - id: zigbee_r23_support
   - id: zigbee_dynamic_commissioning
+  - id: ncp_dlk_policy
+    vendor: nabucasa
+    package: ncp_dlk_policy
   - id: zigbee_security_link_keys
   - id: zigbee_zll
   - id: zigbee_system_common

--- a/src/zigbee_ncp/zigbee_ncp.slcp
+++ b/src/zigbee_ncp/zigbee_ncp.slcp
@@ -59,12 +59,6 @@ define:
   - name: SL_ZIGBEE_CUSTOM_MAC_FILTER_TABLE_SIZE
     value: 2
 
-# Prevent LTO from stripping sl_zigbee_version, which is read from the ELF
-# by create_gbl.py to extract the EZSP version for firmware metadata.
-toolchain_settings:
-  - option: gcc_linker_option
-    value: "-Wl,--undefined=sl_zigbee_version"
-
 configuration:
   - name: SL_CLI_MAX_INPUT_ARGUMENTS
     value: 16

--- a/tools/create_gbl.py
+++ b/tools/create_gbl.py
@@ -5,69 +5,16 @@ from __future__ import annotations
 import ast
 import json
 import pathlib
-import struct
-from typing import Any, BinaryIO
+from typing import Any
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from elftools.elf.elffile import ELFFile
 from pygbl import (
     GBL3Compression,
     build_application_gbl3,
     build_bootloader_gbl3,
     read_encryption_key,
 )
-
-
-def _jump_to_elf_symbol(file: BinaryIO, symbol_name: str) -> tuple[ELFFile, int, int]:
-    elf = ELFFile(file)
-
-    symtab = elf.get_section_by_name(".symtab")
-    symbols = symtab.get_symbol_by_name(symbol_name)
-
-    if symbols is None or len(symbols) != 1:
-        raise ValueError(f"Expected one symbol for {symbol_name!r}, got {symbols}")
-
-    symbol = symbols[0]
-    symbol_addr = symbol["st_value"]
-    symbol_size = symbol["st_size"]
-
-    for segment in elf.iter_segments():
-        if segment["p_type"] != "PT_LOAD":
-            continue
-
-        segment_start = segment["p_vaddr"]
-        segment_end = segment_start + segment["p_filesz"]
-
-        if segment_start <= symbol_addr < segment_end:
-            return (
-                elf,
-                symbol_addr - segment_start + segment["p_offset"],
-                symbol_size,
-            )
-
-    raise ValueError("Could not find segment")
-
-
-def read_elf_symbol(file: BinaryIO, symbol_name: str) -> bytes:
-    """
-    Read an ELF symbol.
-    """
-    _elf, offset, size = _jump_to_elf_symbol(file, symbol_name)
-
-    file.seek(offset)
-    return file.read(size)
-
-
-def modify_elf_symbol(file: BinaryIO, symbol_name: str, value: bytes) -> None:
-    """
-    Modify an ELF symbol.
-    """
-    _elf, offset, size = _jump_to_elf_symbol(file, symbol_name)
-    assert len(value) == size
-
-    file.seek(offset)
-    file.write(value)
 
 
 def parse_c_header_defines(file_content: str) -> dict[str, str]:
@@ -128,48 +75,26 @@ def create_gbl(
     if "ezsp_version" in gbl_dynamic:
         gbl_dynamic.remove("ezsp_version")
 
-        with elf.open("rb") as f:
-            # Try new SDK symbol name first, fall back to old
-            try:
-                ember_version = read_elf_symbol(f, "sl_zigbee_version")
-                version_symbol = "sl_zigbee_version"
-            except ValueError:
-                f.seek(0)
-                ember_version = read_elf_symbol(f, "emberVersion")
-                version_symbol = "emberVersion"
-
-        (
-            build,
-            major,
-            minor,
-            patch,
-            special,
-            version_type,
-            padding,
-        ) = struct.unpack(">HBBBBBB", ember_version)
-
-        # Look for overrides
-        xncp_config_h = parse_c_header_defines(
-            (project_root / "config/xncp_config.h").read_text()
+        zigbee_config_h = parse_c_header_defines(
+            (gsdk_path / "zigbee/stack/config/config.h").read_text()
         )
-        if xncp_config_h["XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE"] != 0xFF:
-            special = xncp_config_h["XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE"]
+        special_version = zigbee_config_h["SL_ZIGBEE_SPECIAL_VERSION"]
 
-            # Write the override back to the ELF
-            with elf.open("r+b") as f:
-                new_ember_version = struct.pack(
-                    ">HBBBBBB",
-                    build,
-                    major,
-                    minor,
-                    patch,
-                    special,
-                    version_type,
-                    padding,
-                )
-                modify_elf_symbol(f, version_symbol, new_ember_version)
+        # `ezsp_version.c` in the NCP applies the same override at compile time
+        xncp_config_path = project_root / "config/xncp_config.h"
+        if xncp_config_path.exists():
+            xncp_config_h = parse_c_header_defines(xncp_config_path.read_text())
+            if xncp_config_h["XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE"] != 0xFF:
+                special_version = xncp_config_h["XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE"]
 
-        metadata["ezsp_version"] = f"{major}.{minor}.{patch}.{special}"
+        metadata["ezsp_version"] = ".".join(
+            [
+                str(zigbee_config_h["SL_ZIGBEE_MAJOR_VERSION"]),
+                str(zigbee_config_h["SL_ZIGBEE_MINOR_VERSION"]),
+                str(zigbee_config_h["SL_ZIGBEE_PATCH_VERSION"]),
+                str(special_version),
+            ]
+        )
 
     if "cpc_version" in gbl_dynamic:
         gbl_dynamic.remove("cpc_version")


### PR DESCRIPTION
The default DLK policy unconditionally uses install codes even when routers do not actually have their install code communicated to the coordinator, causing Zigbee 4.0 routers to be unable to join the network directly through the coordinator. This PR overrides `sl_zigbee_zdo_dlk_select_negotiation_parameters_callback` so that we opt into DLK only when an install code for the device is actually known to the coordinator, not just when it advertises support for it.

As part of this fix I bumped `XNCP_EZSP_VERSION_PATCH_NUM_OVERRIDE` but @tofurky noticed that our recent transition to full-program LTO rendered the original method for patching the version broken. I've fixed this more generally by adding a strong `sl_zigbee_version` symbol via XNCP that redefines the version, removing the need to patch the binary entirely.

Fixes #224